### PR TITLE
Add Postgres version of Compute Engine example.

### DIFF
--- a/examples/mysql/compute-engine/README.md
+++ b/examples/mysql/compute-engine/README.md
@@ -1,0 +1,13 @@
+An example showing how to connect and perform a query against a MySQL Cloud SQL instance.
+The sample will connect to a MySQL Cloud SQL instance and list all the tables in the database.
+
+The following variables in the code need to be updated to run against your instance:
+
+| Variable               | Description   |
+| ---------------------- | ------------- |
+| instanceConnectionName | Can be found on the instance details page in Google Developers Console or by running `gcloud sql instances describe <instance> | grep connectionName`  |
+| databaseName           | Name of the MySQL database |
+| username               | MySQL username to use to connect to the instance |
+| password               | MySQL password to use to connect to the instance |
+
+The sample can be executed using `mvn compile exec:java`.

--- a/examples/mysql/compute-engine/pom.xml
+++ b/examples/mysql/compute-engine/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.google.cloud.sql.example</groupId>
+    <artifactId>mysql-socket-factory-compute-engine</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.5.1</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.5.0</version>
+                <configuration>
+                    <mainClass>com.google.cloud.sql.mysql.example.ListTables</mainClass>
+                    <cleanupDaemonThreads>false</cleanupDaemonThreads>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <name>Cloud SQL Compute Engine Example for MySQL</name>
+    <description>
+        Example for connecting from Compute Engine to a MySQL Cloud SQL instance.
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.cloud.sql</groupId>
+            <artifactId>mysql-socket-factory</artifactId>
+            <version>1.0.2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <version>5.1.39</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/examples/mysql/compute-engine/src/main/java/com/google/cloud/sql/mysql/example/ListTables.java
+++ b/examples/mysql/compute-engine/src/main/java/com/google/cloud/sql/mysql/example/ListTables.java
@@ -1,0 +1,58 @@
+package com.google.cloud.sql.mysql.example;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+/**
+ * A sample app that connects to a Cloud SQL instance and lists all available tables in a database.
+ */
+public class ListTables {
+  public static void main(String[] args) throws IOException, SQLException {
+    // TODO: fill this in
+    // The instance connection name can be obtained from the instance overview page in Cloud Console
+    // or by running "gcloud sql instances describe <instance> | grep connectionName".
+    String instanceConnectionName = "<insert_connection_name>";
+
+    // TODO: fill this in
+    // The database from which to list tables.
+    String databaseName = "mysql";
+
+    String username = "root";
+
+    // TODO: fill this in
+    // This is the password that was set via the Cloud Console or empty if never set
+    // (not recommended).
+    String password = "<insert_password>";
+
+    if (instanceConnectionName.equals("<insert_connection_name>")) {
+      System.err.println("Please update the sample to specify the instance connection name.");
+      System.exit(1);
+    }
+
+    if (password.equals("<insert_password>")) {
+      System.err.println("Please update the sample to specify the mysql password.");
+      System.exit(1);
+    }
+
+    //[START doc-example]
+    String jdbcUrl = String.format(
+        "jdbc:mysql://google/%s?cloudSqlInstance=%s&"
+            + "socketFactory=com.google.cloud.sql.mysql.SocketFactory",
+        databaseName,
+        instanceConnectionName);
+ 
+    Connection connection = DriverManager.getConnection(jdbcUrl, username, password);
+   //[END doc-example]
+
+    try (Statement statement = connection.createStatement()) {
+      ResultSet resultSet = statement.executeQuery("SHOW TABLES");
+      while (resultSet.next()) {
+        System.out.println(resultSet.getString(1));
+      }
+    }
+  }
+}

--- a/examples/postgres/compute-engine/README.md
+++ b/examples/postgres/compute-engine/README.md
@@ -1,0 +1,13 @@
+An example showing how to connect and perform a query against a Postgres Cloud SQL instance.
+The sample will connect to a Postgres Cloud SQL instance and list all the tables in the database.
+
+The following variables in the code need to be updated to run against your instance:
+
+| Variable               | Description   |
+| ---------------------- | ------------- |
+| instanceConnectionName | Can be found on the instance details page in Google Developers Console or by running `gcloud sql instances describe <instance> | grep connectionName`  |
+| databaseName           | Name of the MySQL database |
+| username               | MySQL username to use to connect to the instance |
+| password               | MySQL password to use to connect to the instance |
+
+The sample can be executed using `mvn compile exec:java`.

--- a/examples/postgres/compute-engine/pom.xml
+++ b/examples/postgres/compute-engine/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.google.cloud.sql.example</groupId>
+    <artifactId>postgres-socket-factory-compute-engine</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.5.1</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.5.0</version>
+                <configuration>
+                    <mainClass>com.google.cloud.sql.postgres.example.ListTables</mainClass>
+                    <cleanupDaemonThreads>false</cleanupDaemonThreads>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <name>Cloud SQL Compute Engine Example for Postgres</name>
+    <description>
+        Example for connecting from Compute Engine to a Postgres Cloud SQL instance.
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.cloud.sql</groupId>
+            <artifactId>postgres-socket-factory</artifactId>
+            <version>1.0.3</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>42.1.1</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/examples/postgres/compute-engine/src/main/java/com/google/cloud/postgres/example/ListTables.java
+++ b/examples/postgres/compute-engine/src/main/java/com/google/cloud/postgres/example/ListTables.java
@@ -1,0 +1,60 @@
+package com.google.cloud.sql.postgres.example;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+/**
+ * A sample app that connects to a Cloud SQL instance and lists all available tables in a database.
+ */
+public class ListTables {
+  public static void main(String[] args) throws IOException, SQLException {
+    // TODO: fill this in
+    // The instance connection name can be obtained from the instance overview page in Cloud Console
+    // or by running "gcloud sql instances describe <instance> | grep connectionName".
+    String instanceConnectionName = "<insert_connection_name>";
+
+    // TODO: fill this in
+    // The database from which to list tables.
+    String databaseName = "postgres";
+
+    String username = "postgres";
+
+    // TODO: fill this in
+    // This is the password that was set via the Cloud Console or empty if never set
+    // (not recommended).
+    String password = "<insert_password>";
+
+    if (instanceConnectionName.equals("<insert_connection_name>")) {
+      System.err.println("Please update the sample to specify the instance connection name.");
+      System.exit(1);
+    }
+
+    if (password.equals("<insert_password>")) {
+      System.err.println("Please update the sample to specify the postgres password.");
+      System.exit(1);
+    }
+
+    //[START doc-example]
+    String jdbcUrl = String.format(
+        "jdbc:postgresql://google/%s?socketFactory=com.google.cloud.sql.postgres.SocketFactory"
+            + "&socketFactoryArg=%s",
+        databaseName,
+        instanceConnectionName);
+ 
+    Connection connection = DriverManager.getConnection(jdbcUrl, username, password);
+    //[END doc-example]
+
+    try (Statement statement = connection.createStatement()) {
+      ResultSet resultSet =
+          statement.executeQuery(
+              "SELECT schemaname, tablename FROM pg_catalog.pg_tables");
+      while (resultSet.next()) {
+        System.out.println(resultSet.getString(1) + "." + resultSet.getString(2));
+      }
+    }
+  }
+}


### PR DESCRIPTION
MySQL specific example is "moved" to a mysql subdirectory.

Note: I left the original MySQL example in place as the docs still
reference it. I will remove it once the docs are updated to point to the
new location.