### PR TITLE
Unix Sockets for j5 and j6 connectors. 

### DIFF
--- a/connector-j-5/pom.xml
+++ b/connector-j-5/pom.xml
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>5.1.38</version>
+            <version>5.1.45</version>
         </dependency>
         <dependency>
             <groupId>com.google.cloud.sql</groupId>

--- a/connector-j-5/pom.xml
+++ b/connector-j-5/pom.xml
@@ -28,6 +28,11 @@
             <artifactId>jdbc-socket-factory-core</artifactId>
             <version>1.0.6-SNAPSHOT</version>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-unixsocket</artifactId>
+            <version>9.4.8.v20171121</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/connector-j-5/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
+++ b/connector-j-5/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
@@ -19,10 +19,13 @@ package com.google.cloud.sql.mysql;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.cloud.sql.core.SslSocketFactory;
+import java.io.File;
 import java.io.IOException;
 import java.net.Socket;
 import java.util.Properties;
 import java.util.logging.Logger;
+import jnr.unixsocket.UnixSocketAddress;
+import jnr.unixsocket.UnixSocketChannel;
 
 /**
  * A MySQL {@link SocketFactory} that establishes a secure connection to a Cloud SQL instance using
@@ -32,6 +35,7 @@ import java.util.logging.Logger;
  */
 public class SocketFactory implements com.mysql.jdbc.SocketFactory {
   private static final Logger logger = Logger.getLogger(SocketFactory.class.getName());
+  private static final String CloudSqlPrefix = "/cloudsql/";
 
   private Socket socket;
 
@@ -45,8 +49,18 @@ public class SocketFactory implements com.mysql.jdbc.SocketFactory {
 
     logger.info(String.format("Connecting to Cloud SQL instance [%s].", instanceName));
 
-    this.socket = SslSocketFactory.getInstance().create(instanceName);
-    return socket;
+    // This env will be set by GAE OR set manually if using Cloud SQL Proxy
+    String runtime = System.getenv("GAE_RUNTIME");
+
+    if (runtime == null || runtime.isEmpty()) {  // Use standard SSL (direct connection)
+      this.socket = SslSocketFactory.getInstance().create(instanceName);
+    } else { // Use Unix Socket
+      logger.info("Using GAE Unix Sockets");
+      UnixSocketAddress socketAddress = new UnixSocketAddress(
+          new File(CloudSqlPrefix + instanceName));
+      this.socket = UnixSocketChannel.open(socketAddress).socket();
+    }
+    return this.socket;
   }
 
   @Override

--- a/connector-j-6/pom.xml
+++ b/connector-j-6/pom.xml
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>6.0.4</version>
+            <version>6.0.6</version>
         </dependency>
         <dependency>
             <groupId>com.google.cloud.sql</groupId>

--- a/connector-j-6/pom.xml
+++ b/connector-j-6/pom.xml
@@ -28,6 +28,11 @@
             <artifactId>jdbc-socket-factory-core</artifactId>
             <version>1.0.6-SNAPSHOT</version>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-unixsocket</artifactId>
+            <version>9.4.8.v20171121</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/examples/postgres/appengine-standard-java8/pom.xml
+++ b/examples/postgres/appengine-standard-java8/pom.xml
@@ -68,7 +68,7 @@
 
     <dependency>
       <groupId>com.google.cloud.sql</groupId>
-      <artifactId>mysql-socket-factory-connector-j-6</artifactId>
+      <artifactId>postgres-socket-factory</artifactId>
       <version>1.0.5</version>
     </dependency>
     <!-- [END dependencies] -->

--- a/examples/postgres/appengine-standard-java8/pom.xml
+++ b/examples/postgres/appengine-standard-java8/pom.xml
@@ -68,7 +68,7 @@
 
     <dependency>
       <groupId>com.google.cloud.sql</groupId>
-      <artifactId>postgres-socket-factory</artifactId>
+      <artifactId>mysql-socket-factory-connector-j-6</artifactId>
       <version>1.0.5</version>
     </dependency>
     <!-- [END dependencies] -->


### PR DESCRIPTION
Adds an update for using unix sockets with the j5 and j6 connector factories, similar to https://github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory/pull/56/.