### PR TITLE
Adds usage tracking

### DIFF
--- a/core/src/main/java/com/google/cloud/sql/core/SslSocketFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/core/SslSocketFactory.java
@@ -35,6 +35,14 @@ import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.RateLimiter;
 
+import javax.annotation.Nullable;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLHandshakeException;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManagerFactory;
+import javax.xml.bind.DatatypeConverter;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.Socket;
@@ -56,15 +64,6 @@ import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Logger;
-
-import javax.annotation.Nullable;
-import javax.net.ssl.KeyManagerFactory;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLHandshakeException;
-import javax.net.ssl.SSLSocket;
-import javax.net.ssl.SSLSocketFactory;
-import javax.net.ssl.TrustManagerFactory;
-import javax.xml.bind.DatatypeConverter;
 
 /**
  * Factory responsible for obtaining an ephemeral certificate, if necessary, and establishing a
@@ -526,7 +525,7 @@ public class SslSocketFactory {
 
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
     SQLAdmin.Builder adminApiBuilder =
-        new Builder(httpTransport, jsonFactory, credential)
+        new Builder(httpTransport, jsonFactory, new UsageMetricsHttpRequestInterceptor(credential))
             .setApplicationName("Cloud SQL Java Socket Factory");
     if (rootUrl != null) {
       logTestPropertyWarning(API_ROOT_URL_PROPERTY);

--- a/core/src/main/java/com/google/cloud/sql/core/UsageMetricsHttpRequestInterceptor.java
+++ b/core/src/main/java/com/google/cloud/sql/core/UsageMetricsHttpRequestInterceptor.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.sql.core;
+
+import com.google.api.client.auth.oauth2.Credential;
+import com.google.api.client.http.HttpHeaders;
+import com.google.api.client.http.HttpRequest;
+import com.google.api.client.http.HttpRequestInitializer;
+
+import java.io.IOException;
+
+public class UsageMetricsHttpRequestInterceptor implements HttpRequestInitializer {
+
+	private Credential credential;
+
+	public UsageMetricsHttpRequestInterceptor(Credential credential) {
+		this.credential = credential;
+	}
+
+	@Override
+	public void initialize(HttpRequest request) throws IOException {
+		HttpHeaders headers = request.getHeaders();
+		String userAgent = headers.getUserAgent();
+		String springToken = "spring-cloud-gcp-sql-mysql\\0.0.1.BUILD-SNAPSHOT";
+		userAgent = userAgent != null ? springToken + userAgent : springToken;
+		headers.setUserAgent(userAgent);
+		request.setHeaders(headers);
+
+		request.setInterceptor(credential);
+		request.setUnsuccessfulResponseHandler(credential);
+	}
+}

--- a/core/src/main/java/com/google/cloud/sql/core/UsageMetricsHttpRequestInterceptor.java
+++ b/core/src/main/java/com/google/cloud/sql/core/UsageMetricsHttpRequestInterceptor.java
@@ -27,16 +27,19 @@ public class UsageMetricsHttpRequestInterceptor implements HttpRequestInitialize
 
 	private Credential credential;
 
-	public UsageMetricsHttpRequestInterceptor(Credential credential) {
+	private String userToken;
+
+	public UsageMetricsHttpRequestInterceptor(Credential credential,
+											  String userToken) {
 		this.credential = credential;
+		this.userToken = userToken;
 	}
 
 	@Override
 	public void initialize(HttpRequest request) throws IOException {
 		HttpHeaders headers = request.getHeaders();
 		String userAgent = headers.getUserAgent();
-		String springToken = "spring-cloud-gcp-sql-mysql\\0.0.1.BUILD-SNAPSHOT";
-		userAgent = userAgent != null ? springToken + userAgent : springToken;
+		userAgent = userAgent != null ? userToken + userAgent : userToken;
 		headers.setUserAgent(userAgent);
 		request.setHeaders(headers);
 

--- a/core/src/main/java/com/google/cloud/sql/core/UsageMetricsHttpRequestInterceptor.java
+++ b/core/src/main/java/com/google/cloud/sql/core/UsageMetricsHttpRequestInterceptor.java
@@ -25,8 +25,15 @@ import java.io.IOException;
 
 public class UsageMetricsHttpRequestInterceptor implements HttpRequestInitializer {
 
+	/**
+	 * Credentials to authenticate and authorize the call.
+	 */
 	private Credential credential;
 
+	/**
+	 * Token added to the beginning of the User-Agent string. For example,
+	 * {@code spring-cloud-gcp-sql-mysql/1.0.0}.
+	 */
 	private String userToken;
 
 	public UsageMetricsHttpRequestInterceptor(Credential credential,


### PR DESCRIPTION
Relies on the presence of a `USER_TOKEN_PROPERTY_NAME` property containing the user agent token.

An example of the client side usage is in https://github.com/spring-cloud/spring-cloud-gcp/commit/bc34b667a3595d2387a4057bf1a0d6f1b117e9d1