### PR TITLE
Upgrades SQLAdmin version

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>com.google.apis</groupId>
             <artifactId>google-api-services-sqladmin</artifactId>
-            <version>v1beta4-rev25-1.22.0</version>
+            <version>v1beta4-rev56-1.23.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.code.findbugs</groupId>

--- a/examples/getting-started/pom.xml
+++ b/examples/getting-started/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>com.google.apis</groupId>
             <artifactId>google-api-services-sqladmin</artifactId>
-            <version>v1beta4-rev30-1.22.0</version>
+            <version>v1beta4-rev56-1.23.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This version uses google-api-client 1.23.0 instead of 1.22.0.
1.23.0 is already in use by other dependencies (e.g., everything at
google-cloud-java).
The fact that this dependency is pulling 1.22.0 is causing diamond
dependency issues in Spring Cloud GCP.
We had to manually set the version to be used on our side but,
ideally, this project should set the right version.
Better yet, this version should be obtained from dependencyManagement,
so we could use BOMs and not enforce any versions.