### PR TITLE
Add support for specifying a list of preferred IP types

### DIFF
--- a/connector-j-5/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
+++ b/connector-j-5/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
@@ -22,6 +22,8 @@ import com.google.cloud.sql.core.SslSocketFactory;
 import java.io.File;
 import java.io.IOException;
 import java.net.Socket;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
 import java.util.logging.Logger;
 import jnr.unixsocket.UnixSocketAddress;
@@ -65,9 +67,24 @@ public class SocketFactory implements com.mysql.jdbc.SocketFactory {
       // Default to SSL Socket
       logger.info(String.format(
           "Connecting to Cloud SQL instance [%s] via ssl socket.", instanceName));
-      this.socket = SslSocketFactory.getInstance().create(instanceName);
+      List<String> ipTypes =
+          listIpTypes(props.getProperty("cloudSqlIpTypes", "PUBLIC"));
+      this.socket = SslSocketFactory.getInstance().create(instanceName, ipTypes);
     }
     return this.socket;
+  }
+
+  private List<String> listIpTypes(String cloudSqlIpTypes) {
+    String[] rawTypes = cloudSqlIpTypes.split(",");
+    ArrayList<String> result = new ArrayList<>(rawTypes.length);
+    for (int i = 0; i < rawTypes.length; i++) {
+      if (rawTypes[i].trim().equalsIgnoreCase("PUBLIC")) {
+        result.add(i, "PRIMARY");
+      } else {
+        result.add(i, rawTypes[i].trim().toUpperCase());
+      }
+    }
+    return result;
   }
 
   // Cloud SQL sockets always use TLS and the socket returned by connect above is already TLS-ready. It is fine

--- a/connector-j-5/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
+++ b/connector-j-5/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
@@ -68,7 +68,7 @@ public class SocketFactory implements com.mysql.jdbc.SocketFactory {
           "Connecting to Cloud SQL instance [%s] via ssl socket.", instanceName));
       List<String> ipTypes =
           SslSocketFactory.listIpTypes(
-              props.getProperty("cloudsqlIpTypes", SslSocketFactory.DEFAULT_IP_TYPES));
+              props.getProperty("ipTypes", SslSocketFactory.DEFAULT_IP_TYPES));
       this.socket = SslSocketFactory.getInstance().create(instanceName, ipTypes);
     }
     return this.socket;

--- a/connector-j-5/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
+++ b/connector-j-5/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
@@ -22,7 +22,6 @@ import com.google.cloud.sql.core.SslSocketFactory;
 import java.io.File;
 import java.io.IOException;
 import java.net.Socket;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 import java.util.logging.Logger;
@@ -68,23 +67,11 @@ public class SocketFactory implements com.mysql.jdbc.SocketFactory {
       logger.info(String.format(
           "Connecting to Cloud SQL instance [%s] via ssl socket.", instanceName));
       List<String> ipTypes =
-          listIpTypes(props.getProperty("cloudSqlIpTypes", "PUBLIC"));
+          SslSocketFactory.listIpTypes(
+              props.getProperty("cloudsqlIpTypes", SslSocketFactory.DEFAULT_IP_TYPES));
       this.socket = SslSocketFactory.getInstance().create(instanceName, ipTypes);
     }
     return this.socket;
-  }
-
-  private List<String> listIpTypes(String cloudSqlIpTypes) {
-    String[] rawTypes = cloudSqlIpTypes.split(",");
-    ArrayList<String> result = new ArrayList<>(rawTypes.length);
-    for (int i = 0; i < rawTypes.length; i++) {
-      if (rawTypes[i].trim().equalsIgnoreCase("PUBLIC")) {
-        result.add(i, "PRIMARY");
-      } else {
-        result.add(i, rawTypes[i].trim().toUpperCase());
-      }
-    }
-    return result;
   }
 
   // Cloud SQL sockets always use TLS and the socket returned by connect above is already TLS-ready. It is fine

--- a/connector-j-6/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
+++ b/connector-j-6/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
@@ -22,7 +22,6 @@ import com.google.cloud.sql.core.SslSocketFactory;
 import java.io.File;
 import java.io.IOException;
 import java.net.Socket;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 import java.util.logging.Logger;
@@ -65,10 +64,11 @@ public class SocketFactory implements com.mysql.cj.api.io.SocketFactory {
       this.socket = UnixSocketChannel.open(socketAddress).socket();
     } else {
       // Default to SSL Socket
-      List<String> ipTypes =
-          listIpTypes(props.getProperty("cloudSqlIpTypes", "PUBLIC"));
       logger.info(String.format(
           "Connecting to Cloud SQL instance [%s] via ssl socket.", instanceName));
+      List<String> ipTypes =
+          SslSocketFactory.listIpTypes(
+              props.getProperty("cloudsqlIpTypes", SslSocketFactory.DEFAULT_IP_TYPES));
       this.socket = SslSocketFactory.getInstance().create(instanceName, ipTypes);
     }
     return this.socket;
@@ -84,18 +84,5 @@ public class SocketFactory implements com.mysql.cj.api.io.SocketFactory {
   @Override
   public Socket afterHandshake() {
     return socket;
-  }
-
-  private List<String> listIpTypes(String cloudSqlIpTypes) {
-    String[] rawTypes = cloudSqlIpTypes.split(",");
-    ArrayList<String> result = new ArrayList<>(rawTypes.length);
-    for (int i = 0; i < rawTypes.length; i++) {
-      if (rawTypes[i].trim().equalsIgnoreCase("PUBLIC")) {
-        result.add(i, "PRIMARY");
-      } else {
-        result.add(i, rawTypes[i].trim().toUpperCase());
-      }
-    }
-    return result;
   }
 }

--- a/connector-j-6/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
+++ b/connector-j-6/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
@@ -68,7 +68,7 @@ public class SocketFactory implements com.mysql.cj.api.io.SocketFactory {
           "Connecting to Cloud SQL instance [%s] via ssl socket.", instanceName));
       List<String> ipTypes =
           SslSocketFactory.listIpTypes(
-              props.getProperty("cloudsqlIpTypes", SslSocketFactory.DEFAULT_IP_TYPES));
+              props.getProperty("ipTypes", SslSocketFactory.DEFAULT_IP_TYPES));
       this.socket = SslSocketFactory.getInstance().create(instanceName, ipTypes);
     }
     return this.socket;

--- a/connector-j-8/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
+++ b/connector-j-8/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
@@ -71,7 +71,7 @@ public class SocketFactory implements com.mysql.cj.protocol.SocketFactory {
           "Connecting to Cloud SQL instance [%s] via ssl socket.", instanceName));
       List<String> ipTypes =
           SslSocketFactory.listIpTypes(
-              props.getProperty("cloudsqlIpTypes", SslSocketFactory.DEFAULT_IP_TYPES));
+              props.getProperty("ipTypes", SslSocketFactory.DEFAULT_IP_TYPES));
       this.socket = SslSocketFactory.getInstance().create(instanceName, ipTypes);
     }
     return this.socket;

--- a/connector-j-8/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
+++ b/connector-j-8/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
@@ -25,6 +25,8 @@ import com.mysql.cj.protocol.SocketConnection;
 import java.io.File;
 import java.io.IOException;
 import java.net.Socket;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
 import java.util.logging.Logger;
 import jnr.unixsocket.UnixSocketAddress;
@@ -68,11 +70,26 @@ public class SocketFactory implements com.mysql.cj.protocol.SocketFactory {
       // Default to SSL Socket
       logger.info(String.format(
           "Connecting to Cloud SQL instance [%s] via ssl socket.", instanceName));
-      this.socket = SslSocketFactory.getInstance().create(instanceName);
+        List<String> ipTypes =
+          listIpTypes(props.getProperty("cloudSqlIpTypes", "PUBLIC"));
+        this.socket = SslSocketFactory.getInstance().create(instanceName, ipTypes);
     }
     return this.socket;
   }
 
+
+  private List<String> listIpTypes(String cloudSqlIpTypes) {
+    String[] rawTypes = cloudSqlIpTypes.split(",");
+    ArrayList<String> result = new ArrayList<>(rawTypes.length);
+    for (int i = 0; i < rawTypes.length; i++) {
+      if (rawTypes[i].trim().equalsIgnoreCase("PUBLIC")) {
+        result.add(i, "PRIMARY");
+      } else {
+        result.add(i, rawTypes[i].trim().toUpperCase());
+      }
+    }
+    return result;
+  }
 
   // Cloud SQL sockets always use TLS and the socket returned by connect above is already TLS-ready. It is fine
   // to implement these as no-ops.

--- a/connector-j-8/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
+++ b/connector-j-8/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
@@ -25,7 +25,6 @@ import com.mysql.cj.protocol.SocketConnection;
 import java.io.File;
 import java.io.IOException;
 import java.net.Socket;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 import java.util.logging.Logger;
@@ -70,26 +69,14 @@ public class SocketFactory implements com.mysql.cj.protocol.SocketFactory {
       // Default to SSL Socket
       logger.info(String.format(
           "Connecting to Cloud SQL instance [%s] via ssl socket.", instanceName));
-        List<String> ipTypes =
-          listIpTypes(props.getProperty("cloudSqlIpTypes", "PUBLIC"));
-        this.socket = SslSocketFactory.getInstance().create(instanceName, ipTypes);
+      List<String> ipTypes =
+          SslSocketFactory.listIpTypes(
+              props.getProperty("cloudsqlIpTypes", SslSocketFactory.DEFAULT_IP_TYPES));
+      this.socket = SslSocketFactory.getInstance().create(instanceName, ipTypes);
     }
     return this.socket;
   }
 
-
-  private List<String> listIpTypes(String cloudSqlIpTypes) {
-    String[] rawTypes = cloudSqlIpTypes.split(",");
-    ArrayList<String> result = new ArrayList<>(rawTypes.length);
-    for (int i = 0; i < rawTypes.length; i++) {
-      if (rawTypes[i].trim().equalsIgnoreCase("PUBLIC")) {
-        result.add(i, "PRIMARY");
-      } else {
-        result.add(i, rawTypes[i].trim().toUpperCase());
-      }
-    }
-    return result;
-  }
 
   // Cloud SQL sockets always use TLS and the socket returned by connect above is already TLS-ready. It is fine
   // to implement these as no-ops.

--- a/core/src/main/java/com/google/cloud/sql/core/SslSocketFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/core/SslSocketFactory.java
@@ -192,7 +192,7 @@ public class SslSocketFactory {
       CertificateCaching certificateCaching)
       throws IOException {
     InstanceSslInfo instanceSslInfo = getInstanceSslInfo(instanceName, certificateCaching);
-    String ipAddress = getPreferredIp(ipTypes, instanceSslInfo);
+    String ipAddress = getPreferredIp(instanceName, ipTypes, instanceSslInfo);
 
     logger.info(
         String.format(
@@ -228,7 +228,8 @@ public class SslSocketFactory {
   }
 
   @Nullable
-  private String getPreferredIp(List<String> ipTypes, InstanceSslInfo instanceSslInfo) {
+  private String getPreferredIp(
+      String instanceName, List<String> ipTypes, InstanceSslInfo instanceSslInfo) {
     String ipAddress = null;
     for (String ipType : ipTypes) {
       ipAddress = instanceSslInfo.getInstanceIpAddress(ipType);
@@ -243,7 +244,7 @@ public class SslSocketFactory {
         if (sb.length() > 0) {
           sb.append(", ");
         }
-        sb.append(type.toUpperCase());
+        sb.append(type);
       }
       throw new RuntimeException(
           String.format(
@@ -375,7 +376,7 @@ public class SslSocketFactory {
     InstanceSslInfo info = new InstanceSslInfo(ephemeralCertificate, sslContext.getSocketFactory());
 
     for (IpMapping ip : instance.getIpAddresses()) {
-      info.setInstanceIpAddress(ip.getType(), ip.getIpAddress());
+      info.putInstanceIpAddress(ip.getType(), ip.getIpAddress());
     }
 
     return info;
@@ -674,7 +675,7 @@ public class SslSocketFactory {
       this.sslSocketFactory = sslSocketFactory;
     }
 
-    public void setInstanceIpAddress(String type, String ipAddress) {
+    public void putInstanceIpAddress(String type, String ipAddress) {
       instanceIpAddresses.put(type == null ? "" : type.toUpperCase(), ipAddress);
     }
 

--- a/core/src/main/java/com/google/cloud/sql/core/SslSocketFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/core/SslSocketFactory.java
@@ -59,6 +59,7 @@ import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
+import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Calendar;
 import java.util.Collections;
@@ -80,6 +81,7 @@ import java.util.logging.Logger;
 public class SslSocketFactory {
   private static final Logger logger = Logger.getLogger(SslSocketFactory.class.getName());
 
+  public static final String DEFAULT_IP_TYPES = "PUBLIC,PRIVATE";
   public static final String USER_TOKEN_PROPERTY_NAME = "_CLOUD_SQL_USER_TOKEN";
 
   static final String ADMIN_API_NOT_ENABLED_REASON = "accessNotConfigured";
@@ -153,7 +155,7 @@ public class SslSocketFactory {
   }
 
   // TODO(berezv): separate creating socket and performing connection to make it easier to test
-    public Socket create(String instanceName, List<String> ipTypes) throws IOException {
+  public Socket create(String instanceName, List<String> ipTypes) throws IOException {
     try {
       return createAndConfigureSocket(instanceName, ipTypes, CertificateCaching.USE_CACHE);
     } catch (SSLHandshakeException e) {
@@ -220,6 +222,22 @@ public class SslSocketFactory {
 
     sslSocket.startHandshake();
     return sslSocket;
+  }
+
+  /**
+   * Converts the string property of IP types to a list by splitting by commas, and upper-casing.
+   */
+  public static List<String> listIpTypes(String cloudSqlIpTypes) {
+    String[] rawTypes = cloudSqlIpTypes.split(",");
+    ArrayList<String> result = new ArrayList<>(rawTypes.length);
+    for (int i = 0; i < rawTypes.length; i++) {
+      if (rawTypes[i].trim().equalsIgnoreCase("PUBLIC")) {
+        result.add(i, "PRIMARY");
+      } else {
+        result.add(i, rawTypes[i].trim().toUpperCase());
+      }
+    }
+    return result;
   }
 
   @Nullable

--- a/core/src/main/java/com/google/cloud/sql/core/SslSocketFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/core/SslSocketFactory.java
@@ -239,17 +239,10 @@ public class SslSocketFactory {
     }
 
     if (ipAddress == null) {
-      StringBuilder sb = new StringBuilder();
-      for (String type : ipTypes) {
-        if (sb.length() > 0) {
-          sb.append(", ");
-        }
-        sb.append(type);
-      }
       throw new RuntimeException(
           String.format(
               "Cloud SQL instance [%s] does not have any IP addresses matching preference: [ %s ]",
-              instanceName, sb));
+              instanceName, String.join(", ", ipTypes)));
     }
 
     return ipAddress;

--- a/core/src/main/java/com/google/cloud/sql/core/SslSocketFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/core/SslSocketFactory.java
@@ -193,19 +193,6 @@ public class SslSocketFactory {
       throws IOException {
     InstanceSslInfo instanceSslInfo = getInstanceSslInfo(instanceName, certificateCaching);
     String ipAddress = getPreferredIp(ipTypes, instanceSslInfo);
-    if (ipAddress == null) {
-      StringBuilder sb = new StringBuilder();
-      for (String type : ipTypes) {
-        if (sb.length() > 0) {
-          sb.append(", ");
-        }
-        sb.append(type.toUpperCase());
-      }
-      throw new RuntimeException(
-          String.format(
-              "Cloud SQL instance [%s] does not have any IP addresses matching preference: [ %s ]",
-              instanceName, sb));
-    }
 
     logger.info(
         String.format(
@@ -249,6 +236,21 @@ public class SslSocketFactory {
         break;
       }
     }
+
+    if (ipAddress == null) {
+      StringBuilder sb = new StringBuilder();
+      for (String type : ipTypes) {
+        if (sb.length() > 0) {
+          sb.append(", ");
+        }
+        sb.append(type.toUpperCase());
+      }
+      throw new RuntimeException(
+          String.format(
+              "Cloud SQL instance [%s] does not have any IP addresses matching preference: [ %s ]",
+              instanceName, sb));
+    }
+
     return ipAddress;
   }
 

--- a/core/src/test/java/com/google/cloud/sql/core/SslSocketFactoryTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/SslSocketFactoryTest.java
@@ -65,6 +65,7 @@ import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.net.InetAddress;
 import java.net.Socket;
 import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
@@ -81,6 +82,7 @@ import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -100,6 +102,8 @@ public class SslSocketFactoryTest {
   private static final String INSTANCE_NAME = "bar";
   private static final String REGION = "baz";
   private static final String INSTANCE_CONNECTION_STRING = "foo:baz:bar";
+  private static final String PUBLIC_IP = "127.0.0.1";
+  private static final String PRIVATE_IP = "127.0.1.1";
 
   @Mock private GoogleCredential credential;
   @Mock private SQLAdmin adminApi;
@@ -138,7 +142,10 @@ public class SslSocketFactoryTest {
         .thenReturn(
             new DatabaseInstance()
                 .setBackendType("SECOND_GEN")
-                .setIpAddresses(ImmutableList.of(new IpMapping().setIpAddress("127.0.0.1")))
+                .setIpAddresses(
+                    ImmutableList.of(
+                        new IpMapping().setIpAddress(PUBLIC_IP).setType("PRIMARY"),
+                        new IpMapping().setIpAddress(PRIVATE_IP).setType("PRIVATE")))
                 .setServerCaCert(new SslCert().setCert(TestKeys.SERVER_CA_CERT))
                 .setRegion(REGION));
     when(adminApiSslCertsCreateEphemeral.execute())
@@ -150,14 +157,14 @@ public class SslSocketFactoryTest {
     SslSocketFactory sslSocketFactory =
         new SslSocketFactory(new Clock(), clientKeyPair, credential, adminApi, 3307);
     try {
-      sslSocketFactory.create("foo");
+      sslSocketFactory.create("foo", Arrays.asList("PRIMARY"));
       fail();
     } catch (IllegalArgumentException e) {
       assertThat(e.getMessage()).startsWith("Invalid Cloud SQL instance");
     }
 
     try {
-      sslSocketFactory.create("foo:bar");
+      sslSocketFactory.create("foo:bar", Arrays.asList("PRIMARY"));
       fail();
     } catch (IllegalArgumentException e) {
       assertThat(e.getMessage()).startsWith("Invalid Cloud SQL instance");
@@ -170,18 +177,41 @@ public class SslSocketFactoryTest {
         .thenReturn(
             new DatabaseInstance()
                 .setBackendType("SECOND_GEN")
-                .setIpAddresses(ImmutableList.of(new IpMapping().setIpAddress("127.0.0.1")))
+                .setIpAddresses(ImmutableList.of(new IpMapping().setIpAddress(PUBLIC_IP)))
                 .setServerCaCert(new SslCert().setCert(TestKeys.SERVER_CA_CERT))
                 .setRegion("beer"));
 
     SslSocketFactory sslSocketFactory =
         new SslSocketFactory(new Clock(), clientKeyPair, credential, adminApi, 3307);
     try {
-      sslSocketFactory.create("foo:bar:baz");
+      sslSocketFactory.create("foo:bar:baz", Arrays.asList("PRIMARY"));
       fail();
     } catch (IllegalArgumentException e) {
       assertThat(e.getMessage()).startsWith("Incorrect region value");
     }
+  }
+
+  @Test
+  public void create_successfulPrivateConnection()
+      throws IOException, GeneralSecurityException, InterruptedException {
+    FakeSslServer sslServer = new FakeSslServer();
+    int port = sslServer.start(PRIVATE_IP);
+
+    SslSocketFactory sslSocketFactory =
+        new SslSocketFactory(new Clock(), clientKeyPair, credential, adminApi, port);
+    Socket socket =
+        sslSocketFactory.create(
+            INSTANCE_CONNECTION_STRING, Arrays.asList("PRIVATE"));
+
+    verify(adminApiInstances).get(PROJECT_ID, INSTANCE_NAME);
+    verify(adminApiSslCerts)
+        .createEphemeral(
+            eq(PROJECT_ID), eq(INSTANCE_NAME), isA(SslCertsCreateEphemeralRequest.class));
+
+    BufferedReader bufferedReader =
+        new BufferedReader(new InputStreamReader(socket.getInputStream(), UTF_8));
+    String line = bufferedReader.readLine();
+    assertThat(line).isEqualTo(SERVER_MESSAGE);
   }
 
   @Test
@@ -192,7 +222,9 @@ public class SslSocketFactoryTest {
 
     SslSocketFactory sslSocketFactory =
         new SslSocketFactory(new Clock(), clientKeyPair, credential, adminApi, port);
-    Socket socket = sslSocketFactory.create(INSTANCE_CONNECTION_STRING);
+    Socket socket =
+        sslSocketFactory.create(
+            INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
 
     verify(adminApiInstances).get(PROJECT_ID, INSTANCE_NAME);
     verify(adminApiSslCerts)
@@ -222,7 +254,9 @@ public class SslSocketFactoryTest {
 
     SslSocketFactory sslSocketFactory =
         new SslSocketFactory(new Clock(), clientKeyPair, credential, adminApi, port);
-    Socket socket = sslSocketFactory.create("foo:baz:bar");
+    Socket socket =
+        sslSocketFactory.create(
+            INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
 
     verify(adminApiInstances, times(2)).get(PROJECT_ID, INSTANCE_NAME);
     verify(adminApiSslCerts, times(2))
@@ -243,14 +277,16 @@ public class SslSocketFactoryTest {
 
     SslSocketFactory sslSocketFactory =
         new SslSocketFactory(new Clock(), clientKeyPair, credential, adminApi, port);
-    sslSocketFactory.create("foo:baz:bar");
+    sslSocketFactory.create(
+        INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
 
     verify(adminApiInstances).get(PROJECT_ID, INSTANCE_NAME);
     verify(adminApiSslCerts)
         .createEphemeral(
             eq(PROJECT_ID), eq(INSTANCE_NAME), isA(SslCertsCreateEphemeralRequest.class));
 
-    sslSocketFactory.create(INSTANCE_CONNECTION_STRING);
+    sslSocketFactory.create(
+        INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
 
     verifyNoMoreInteractions(adminApiInstances);
     verifyNoMoreInteractions(adminApiSslCerts);
@@ -268,10 +304,12 @@ public class SslSocketFactoryTest {
 
     SslSocketFactory sslSocketFactory =
         new SslSocketFactory(new Clock(), clientKeyPair, credential, adminApi, port);
-    sslSocketFactory.create(INSTANCE_CONNECTION_STRING);
+    sslSocketFactory.create(
+        INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
 
     // Second time, we should renew the certificate since it's about to expire.
-    sslSocketFactory.create(INSTANCE_CONNECTION_STRING);
+    sslSocketFactory.create(
+        INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
 
     verify(adminApiInstances, times(2)).get(PROJECT_ID, INSTANCE_NAME);
     verify(adminApiSslCerts, times(2))
@@ -294,7 +332,8 @@ public class SslSocketFactoryTest {
     SslSocketFactory sslSocketFactory =
         new SslSocketFactory(new Clock(), clientKeyPair, credential, adminApi, 3307);
     try {
-      sslSocketFactory.create(INSTANCE_CONNECTION_STRING);
+      sslSocketFactory.create(
+          INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
       fail("Expected RuntimeException");
     } catch (RuntimeException e) {
       // TODO(berezv): should we throw something more specific than RuntimeException?
@@ -317,7 +356,8 @@ public class SslSocketFactoryTest {
     SslSocketFactory sslSocketFactory =
         new SslSocketFactory(new Clock(), clientKeyPair, credential, adminApi, 3307);
     try {
-      sslSocketFactory.create(INSTANCE_CONNECTION_STRING);
+      sslSocketFactory.create(
+          INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
       fail("Expected RuntimeException");
     } catch (RuntimeException e) {
       // TODO(berezv): should we throw something more specific than RuntimeException?
@@ -340,7 +380,8 @@ public class SslSocketFactoryTest {
     SslSocketFactory sslSocketFactory =
         new SslSocketFactory(mockClock, clientKeyPair, credential, adminApi, 3307);
     try {
-      sslSocketFactory.create(INSTANCE_CONNECTION_STRING);
+      sslSocketFactory.create(
+          INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
       fail();
     } catch (RuntimeException e) {
       assertThat(e.getMessage()).contains("not authorized");
@@ -351,7 +392,8 @@ public class SslSocketFactoryTest {
     // Exception should be cached.
     when(mockClock.now()).thenReturn(59 * 1000L);
     try {
-      sslSocketFactory.create(INSTANCE_CONNECTION_STRING);
+      sslSocketFactory.create(
+          INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
       fail();
     } catch (RuntimeException e) {
       assertThat(e.getMessage()).contains("not authorized");
@@ -362,7 +404,8 @@ public class SslSocketFactoryTest {
     // Enough time has passed that cached exception should be ignored.
     when(mockClock.now()).thenReturn(61 * 1000L);
     try {
-      sslSocketFactory.create(INSTANCE_CONNECTION_STRING);
+      sslSocketFactory.create(
+          INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
       fail();
     } catch (RuntimeException e) {
       assertThat(e.getMessage()).contains("not authorized");
@@ -386,7 +429,8 @@ public class SslSocketFactoryTest {
     SslSocketFactory sslSocketFactory =
         new SslSocketFactory(new Clock(), clientKeyPair, credential, adminApi, 3307);
     try {
-      sslSocketFactory.create(INSTANCE_CONNECTION_STRING);
+      sslSocketFactory.create(
+          INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
       fail();
     } catch (RuntimeException e) {
       // TODO(berezv): should we throw something more specific than RuntimeException?
@@ -440,6 +484,10 @@ public class SslSocketFactoryTest {
 
   private static class FakeSslServer {
     int start() throws InterruptedException {
+      return start(PUBLIC_IP);
+    }
+
+    int start(final String ip) throws InterruptedException {
       final CountDownLatch countDownLatch = new CountDownLatch(1);
       final AtomicInteger pickedPort = new AtomicInteger();
 
@@ -459,10 +507,11 @@ public class SslSocketFactoryTest {
             PrivateKeyEntry serverCert =
                 new PrivateKeyEntry(
                     privateKey,
-                    new Certificate[]{
-                        certFactory.generateCertificate(
-                            new ByteArrayInputStream(
-                                TestKeys.SERVER_CERT.getBytes(StandardCharsets.UTF_8)))});
+                    new Certificate[] {
+                      certFactory.generateCertificate(
+                          new ByteArrayInputStream(
+                              TestKeys.SERVER_CERT.getBytes(StandardCharsets.UTF_8)))
+                    });
             authKeyStore.setEntry("serverCert", serverCert, new PasswordProtection(new char[0]));
             KeyManagerFactory keyManagerFactory =
                 KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
@@ -482,18 +531,17 @@ public class SslSocketFactoryTest {
 
             SSLContext sslContext = SSLContext.getInstance("TLSv1.2");
             sslContext.init(
-                keyManagerFactory.getKeyManagers(),
-                tmf.getTrustManagers(),
-                new SecureRandom());
+                keyManagerFactory.getKeyManagers(), tmf.getTrustManagers(), new SecureRandom());
             SSLServerSocketFactory sslServerSocketFactory = sslContext.getServerSocketFactory();
-            SSLServerSocket sslServerSocket=
-                (SSLServerSocket) sslServerSocketFactory.createServerSocket(0);
+            SSLServerSocket sslServerSocket =
+                (SSLServerSocket)
+                    sslServerSocketFactory.createServerSocket(0, 5, InetAddress.getByName(ip));
             sslServerSocket.setNeedClientAuth(true);
 
             pickedPort.set(sslServerSocket.getLocalPort());
             countDownLatch.countDown();
 
-            for (;;) {
+            for (; ; ) {
               SSLSocket socket = (SSLSocket) sslServerSocket.accept();
               try {
                 socket.startHandshake();

--- a/core/src/test/java/com/google/cloud/sql/core/SslSocketFactoryTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/SslSocketFactoryTest.java
@@ -191,6 +191,10 @@ public class SslSocketFactoryTest {
     }
   }
 
+  /**
+   * Start an SSL server on the private IP, and verifies that specifying a preference for private IP
+   * results in a connection to the private IP.
+   */
   @Test
   public void create_successfulPrivateConnection()
       throws IOException, GeneralSecurityException, InterruptedException {

--- a/postgres/src/main/java/com/google/cloud/sql/postgres/SocketFactory.java
+++ b/postgres/src/main/java/com/google/cloud/sql/postgres/SocketFactory.java
@@ -24,6 +24,8 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.Socket;
 import java.util.Properties;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.logging.Logger;
 import jnr.unixsocket.UnixSocketAddress;
 import jnr.unixsocket.UnixSocketChannel;
@@ -41,8 +43,10 @@ public class SocketFactory extends javax.net.SocketFactory {
   private static final String POSTGRES_SUFFIX = "/.s.PGSQL.5432";
 
   private static final String INSTANCE_PROPERTY_KEY = "cloudSqlInstance";
+  private static final String IP_TYPES_KEY = "cloudsqlIpTypes";
 
   private final String instanceName;
+  private final List<String> ipTypes;
 
 
   public SocketFactory(Properties info) {
@@ -51,11 +55,13 @@ public class SocketFactory extends javax.net.SocketFactory {
         this.instanceName != null,
         "cloudSqlInstance property not set. Please specify this property in the JDBC URL or "
             + "the connection Properties with value in form \"project:region:instance\"");
+
+      this.ipTypes = listIpTypes(info.getProperty(IP_TYPES_KEY, "PUBLIC"));
   }
 
   @Deprecated
   public SocketFactory(String instanceName) {
-    // Deprecated constructor for converting 'SocketFactoryArg' to ' 'CloudSqlInstance'
+    // Deprecated constructor for converting 'SocketFactoryArg' to 'CloudSqlInstance'
     this(createDefaultProperties(instanceName));
   }
 
@@ -86,7 +92,20 @@ public class SocketFactory extends javax.net.SocketFactory {
     // Default to SSL Socket
     logger.info(String.format(
         "Connecting to Cloud SQL instance [%s] via ssl socket.", instanceName));
-    return SslSocketFactory.getInstance().create(instanceName);
+    return SslSocketFactory.getInstance().create(instanceName, ipTypes);
+  }
+
+  private List<String> listIpTypes(String cloudSqlIpTypes) {
+    String[] rawTypes = cloudSqlIpTypes.split(",");
+    ArrayList<String> result = new ArrayList<>(rawTypes.length);
+    for (int i = 0; i < rawTypes.length; i++) {
+      if (rawTypes[i].trim().equalsIgnoreCase("PUBLIC")) {
+        result.add(i, "PRIMARY");
+      } else {
+        result.add(i, rawTypes[i].trim().toUpperCase());
+      }
+    }
+    return result;
   }
 
   @Override

--- a/postgres/src/main/java/com/google/cloud/sql/postgres/SocketFactory.java
+++ b/postgres/src/main/java/com/google/cloud/sql/postgres/SocketFactory.java
@@ -42,7 +42,7 @@ public class SocketFactory extends javax.net.SocketFactory {
   private static final String POSTGRES_SUFFIX = "/.s.PGSQL.5432";
 
   private static final String INSTANCE_PROPERTY_KEY = "cloudSqlInstance";
-  private static final String IP_TYPES_KEY = "cloudsqlIpTypes";
+  private static final String IP_TYPES_KEY = "ipTypes";
 
   private final String instanceName;
   private final List<String> ipTypes;

--- a/postgres/src/main/java/com/google/cloud/sql/postgres/SocketFactory.java
+++ b/postgres/src/main/java/com/google/cloud/sql/postgres/SocketFactory.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.Socket;
 import java.util.Properties;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
 import jnr.unixsocket.UnixSocketAddress;
@@ -56,7 +55,9 @@ public class SocketFactory extends javax.net.SocketFactory {
         "cloudSqlInstance property not set. Please specify this property in the JDBC URL or "
             + "the connection Properties with value in form \"project:region:instance\"");
 
-      this.ipTypes = listIpTypes(info.getProperty(IP_TYPES_KEY, "PUBLIC"));
+    this.ipTypes =
+        SslSocketFactory.listIpTypes(
+            info.getProperty(IP_TYPES_KEY, SslSocketFactory.DEFAULT_IP_TYPES));
   }
 
   @Deprecated
@@ -93,19 +94,6 @@ public class SocketFactory extends javax.net.SocketFactory {
     logger.info(String.format(
         "Connecting to Cloud SQL instance [%s] via ssl socket.", instanceName));
     return SslSocketFactory.getInstance().create(instanceName, ipTypes);
-  }
-
-  private List<String> listIpTypes(String cloudSqlIpTypes) {
-    String[] rawTypes = cloudSqlIpTypes.split(",");
-    ArrayList<String> result = new ArrayList<>(rawTypes.length);
-    for (int i = 0; i < rawTypes.length; i++) {
-      if (rawTypes[i].trim().equalsIgnoreCase("PUBLIC")) {
-        result.add(i, "PRIMARY");
-      } else {
-        result.add(i, rawTypes[i].trim().toUpperCase());
-      }
-    }
-    return result;
   }
 
   @Override


### PR DESCRIPTION
Cloud SQL instances can have more IPs than just a primary IP, this change allows users to specify what IP type they would prefer to use when connecting.