### PR TITLE
Improve GAE Standard detection

### DIFF
--- a/connector-j-5/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
+++ b/connector-j-5/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
@@ -47,18 +47,25 @@ public class SocketFactory implements com.mysql.jdbc.SocketFactory {
         "cloudSqlInstance property not set. Please specify this property in the JDBC URL or "
             + "the connection Properties with value in form \"project:region:instance\"");
 
-    logger.info(String.format("Connecting to Cloud SQL instance [%s].", instanceName));
+    // gaeEnv="standard" indicates standard instances
+    // runEnv="Production" indicates production instances
+    String gaeEnv = System.getenv("GAE_ENV");
+    String runEnv = System.getProperty("com.google.appengine.runtime.environment");
+    // Custom env variable for forcing unix socket
+    Boolean forceUnixSocket = System.getenv("CLOUD_SQL_FORCE_UNIX_SOCKET") != null;
 
-    // This env will be set by GAE OR set manually if using Cloud SQL Proxy
-    String runtime = System.getenv("GAE_RUNTIME");
-
-    if (runtime == null || runtime.isEmpty()) {  // Use standard SSL (direct connection)
-      this.socket = SslSocketFactory.getInstance().create(instanceName);
-    } else { // Use Unix Socket
-      logger.info("Using GAE Unix Sockets");
+    // If running on GAE Standard, connect with unix socket
+    if (forceUnixSocket || "standard".equals(gaeEnv) && "Production".equals(runEnv)) {
+      logger.info(String.format(
+          "Connecting to Cloud SQL instance [%s] via unix socket.", instanceName));
       UnixSocketAddress socketAddress = new UnixSocketAddress(
           new File(CloudSqlPrefix + instanceName));
       this.socket = UnixSocketChannel.open(socketAddress).socket();
+    } else {
+      // Default to SSL Socket
+      logger.info(String.format(
+          "Connecting to Cloud SQL instance [%s] via ssl socket.", instanceName));
+      this.socket = SslSocketFactory.getInstance().create(instanceName);
     }
     return this.socket;
   }

--- a/connector-j-6/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
+++ b/connector-j-6/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
@@ -47,18 +47,25 @@ public class SocketFactory implements com.mysql.cj.api.io.SocketFactory {
             "cloudSqlInstance property not set. Please specify this property in the JDBC URL or "
                     + "the connection Properties with value in form \"project:region:instance\"");
 
-    logger.info(String.format("Connecting to Cloud SQL instance [%s].", instanceName));
+    // gaeEnv="standard" indicates standard instances
+    // runEnv="Production" indicates production instances
+    String gaeEnv = System.getenv("GAE_ENV");
+    String runEnv = System.getProperty("com.google.appengine.runtime.environment");
+    // Custom env variable for forcing unix socket
+    Boolean forceUnixSocket = System.getenv("CLOUD_SQL_FORCE_UNIX_SOCKET") != null;
 
-    // This env will be set by GAE OR set manually if using Cloud SQL Proxy
-    String runtime = System.getenv("GAE_RUNTIME");
-
-    if (runtime == null || runtime.isEmpty()) {  // Use standard SSL (direct connection)
-      this.socket = SslSocketFactory.getInstance().create(instanceName);
-    } else { // Use Unix Socket
-      logger.info("Using GAE Unix Sockets");
+    // If running on GAE Standard, connect with unix socket
+    if (forceUnixSocket || "standard".equals(gaeEnv) && "Production".equals(runEnv)) {
+      logger.info(String.format(
+          "Connecting to Cloud SQL instance [%s] via unix socket.", instanceName));
       UnixSocketAddress socketAddress = new UnixSocketAddress(
           new File(CloudSqlPrefix + instanceName));
       this.socket = UnixSocketChannel.open(socketAddress).socket();
+    } else {
+      // Default to SSL Socket
+      logger.info(String.format(
+          "Connecting to Cloud SQL instance [%s] via ssl socket.", instanceName));
+      this.socket = SslSocketFactory.getInstance().create(instanceName);
     }
     return this.socket;
   }


### PR DESCRIPTION
Fixes #77. 

After speaking with the GAE Java team, it should be safe to check two different points:
* Environment variable "GAE_ENV" should be set to `"standard"`
* System property "com.google.appengine.runtime.environment" should be set to "Production"

If these two conditions are true and not running on GAE Standard production, it should be considered a bug. 

Additionally, this adds a check for the environment variable `"CLOUD_SQL_FORCE_UNIX_SOCKET"` that, if set, will force the library to attempt to connect through a unix socket. 