### PR TITLE
Use built in base64 to allow use on jdk9+

### DIFF
--- a/core/src/main/java/com/google/cloud/sql/core/SslSocketFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/core/SslSocketFactory.java
@@ -43,7 +43,6 @@ import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManagerFactory;
-import javax.xml.bind.DatatypeConverter;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.Socket;
@@ -59,6 +58,7 @@ import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
+import java.util.Base64;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.GregorianCalendar;
@@ -442,7 +442,7 @@ public class SslSocketFactory {
     StringBuilder publicKeyPemBuilder = new StringBuilder();
     publicKeyPemBuilder.append("-----BEGIN RSA PUBLIC KEY-----\n");
     publicKeyPemBuilder.append(
-        DatatypeConverter.printBase64Binary(localKeyPair.getPublic().getEncoded())
+        Base64.getEncoder().encodeToString(localKeyPair.getPublic().getEncoded())
             .replaceAll("(.{64})", "$1\n"));
     publicKeyPemBuilder.append("\n");
     publicKeyPemBuilder.append("-----END RSA PUBLIC KEY-----\n");

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.5.1</version>
+                <version>3.8.0</version>
                 <configuration>
                     <compilerId>javac-with-errorprone</compilerId>
                     <forceJavacCompilerUse>true</forceJavacCompilerUse>
@@ -72,14 +72,14 @@
                     <dependency>
                         <groupId>org.codehaus.plexus</groupId>
                         <artifactId>plexus-compiler-javac-errorprone</artifactId>
-                        <version>2.7</version>
+                        <version>2.8.4</version>
                     </dependency>
                     <!-- override plexus-compiler-javac-errorprone's dependency on
                          Error Prone with the latest version -->
                     <dependency>
                         <groupId>com.google.errorprone</groupId>
                         <artifactId>error_prone_core</artifactId>
-                        <version>2.0.9</version>
+                        <version>2.3.1</version>
                     </dependency>
                 </dependencies>
             </plugin>


### PR DESCRIPTION
`javax.xml.bind.DatatypeConverter` is not available out of the box on modularized JVMs, but since this project is already targeting 1.8, we can use `java.util.Base64` which was introduced then.

I also updated a few maven plugins so the build wouldn't die on current JDKs.