### PR TITLE
Add SocketFactory constructor with Properties argument for Postgres. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ When specifying the JDBC connection URL, add the additional parameters:
 | Property         | Value         |
 | ---------------- | ------------- |
 | socketFactory    | com.google.cloud.sql.mysql.SocketFactory |
-| cloudSqlInstance | The instance connection name (found on the instance details) |
+| cloudSqlInstance | The instance connection name (found on the instance details page) |
 | useSSL           | False |
 | user             | MySQL username |
 | password         | MySQL user's password |
@@ -103,13 +103,13 @@ When specifying the JDBC connection URL, add the additional parameters:
 | Property         | Value         |
 | ---------------- | ------------- |
 | socketFactory    | com.google.cloud.sql.postgres.SocketFactory |
-| socketFactoryArg | The instance connection name (which is found on the instance details page in Google Developers Console)  |
+| cloudSqlInstance | The instance connection name (found on the instance details page) |
 | user             | Postgres username |
 | password         | Postgres user's password |
 
 The full JDBC url should look like this:
 ```
-jdbc:postgresql://google/<DATABASE_NAME>?useSSL=false&socketFactoryArg=<INSTANCE_CONNECTION_NAME>&socketFactory=com.google.cloud.sql.postgres.SocketFactory&user=<POSTGRESQL_USER_NAME>&password=<POSTGRESQL_USER_PASSWORD>
+jdbc:postgresql://google/<DATABASE_NAME>?cloudSqlInstance=<INSTANCE_CONNECTION_NAME>&socketFactory=com.google.cloud.sql.postgres.SocketFactory&user=<POSTGRESQL_USER_NAME>&password=<POSTGRESQL_USER_PASSWORD>
 ```
 
 ## Additional Information

--- a/postgres/src/main/java/com/google/cloud/sql/postgres/SocketFactory.java
+++ b/postgres/src/main/java/com/google/cloud/sql/postgres/SocketFactory.java
@@ -23,8 +23,8 @@ import java.io.File;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.Socket;
+import java.util.Properties;
 import java.util.logging.Logger;
-import jnr.unixsocket.UnixSocket;
 import jnr.unixsocket.UnixSocketAddress;
 import jnr.unixsocket.UnixSocketChannel;
 
@@ -36,18 +36,34 @@ import jnr.unixsocket.UnixSocketChannel;
  */
 public class SocketFactory extends javax.net.SocketFactory {
   private static final Logger logger = Logger.getLogger(SocketFactory.class.getName());
-  private static final String CloudSqlPrefix = "/cloudsql/";
-  private static final String PostgreSqlSufix = "/.s.PGSQL.5432";
+  
+  private static final String CLOUD_SQL_PREFIX = "/cloudsql/";
+  private static final String POSTGRES_SUFIX = "/.s.PGSQL.5432";
+
+  private static final String INSTANCE_PROPERTY_KEY = "cloudSqlInstance";
 
   private final String instanceName;
 
-  public SocketFactory(String instanceName) {
+
+  public SocketFactory(Properties info){
+    this.instanceName = info.getProperty(INSTANCE_PROPERTY_KEY);
     checkArgument(
-        instanceName != null,
-        "socketFactoryArg property not set. Please specify this property in the JDBC "
-            + "URL or the connection Properties with the instance connection name in "
-            + "form \"project:region:instance\"");
-    this.instanceName = instanceName;
+        this.instanceName != null,
+        "cloudSqlInstance property not set. Please specify this property in the JDBC URL or "
+            + "the connection Properties with value in form \"project:region:instance\"");
+  }
+
+  @Deprecated
+  public SocketFactory(String instanceName) {
+    // Deprecated constructor for converting 'SocketFactoryArg' to ' 'CloudSqlInstance'
+    this(createDefaultProperties(instanceName));
+  }
+
+
+  private static Properties createDefaultProperties(String instanceName){
+    Properties info = new Properties();
+    info.setProperty(INSTANCE_PROPERTY_KEY, instanceName);
+    return info;
   }
 
   @Override
@@ -64,7 +80,7 @@ public class SocketFactory extends javax.net.SocketFactory {
       logger.info(String.format(
           "Connecting to Cloud SQL instance [%s] via unix socket.", instanceName));
       UnixSocketAddress socketAddress = new UnixSocketAddress(
-          new File(CloudSqlPrefix + instanceName + PostgreSqlSufix));
+          new File(CLOUD_SQL_PREFIX + instanceName + POSTGRES_SUFIX));
       return UnixSocketChannel.open(socketAddress).socket();
     }
     // Default to SSL Socket

--- a/postgres/src/main/java/com/google/cloud/sql/postgres/SocketFactory.java
+++ b/postgres/src/main/java/com/google/cloud/sql/postgres/SocketFactory.java
@@ -36,7 +36,7 @@ import jnr.unixsocket.UnixSocketChannel;
  */
 public class SocketFactory extends javax.net.SocketFactory {
   private static final Logger logger = Logger.getLogger(SocketFactory.class.getName());
-  
+
   private static final String CLOUD_SQL_PREFIX = "/cloudsql/";
   private static final String POSTGRES_SUFIX = "/.s.PGSQL.5432";
 


### PR DESCRIPTION
As of [v42.2.5](https://jdbc.postgresql.org/documentation/changelog.html#version_42.2.5), the Postgres JDBC driver has deprecated the [SocketFactoryArg](https://jdbc.postgresql.org/documentation/changelog.html#version_42.2.5) in favor of a constructor taking a Properties argument. This PR is an update to incorporate this change while remaining backwards compatible with earlier version of the driver. 

@hfwang - FYI