### PR TITLE
Support new SocketFactory API in mysql-connector-java 8.0.13.

### DIFF
--- a/connector-j-8/pom.xml
+++ b/connector-j-8/pom.xml
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.11</version>
+            <version>8.0.13</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
mysql-connector-java 8.0.13 introduced a major backwards incompatible change in the `SocketFactory` API. This makes sure the cloud SocketFactory implements both old and new APIs.

```
Exception in thread "main" java.lang.AbstractMethodError: Receiver class com.google.cloud.sql.mysql.SocketFactory does not define or inherit an implementation of the resolved method abstract connect(Ljava/lang/String;ILcom/mysql/cj/conf/PropertySet;I)Ljava/io/Closeable; of interface com.mysql.cj.protocol.SocketFactory.
	at com.mysql.cj.protocol.a.NativeSocketConnection.connect(NativeSocketConnection.java:65)
	at com.mysql.cj.NativeSession.connect(NativeSession.java:152)
	at com.mysql.cj.jdbc.ConnectionImpl.connectOneTryOnly(ConnectionImpl.java:955)
	at com.mysql.cj.jdbc.ConnectionImpl.createNewIO(ConnectionImpl.java:825)
	at com.mysql.cj.jdbc.ConnectionImpl.<init>(ConnectionImpl.java:455)
	at com.mysql.cj.jdbc.ConnectionImpl.getInstance(ConnectionImpl.java:240)
	at com.mysql.cj.jdbc.NonRegisteringDriver.connect(NonRegisteringDriver.java:207)
	at com.zaxxer.hikari.util.DriverDataSource.getConnection(DriverDataSource.java:136)
	at com.zaxxer.hikari.pool.PoolBase.newConnection(PoolBase.java:369)
	at com.zaxxer.hikari.pool.PoolBase.newPoolEntry(PoolBase.java:198)
	at com.zaxxer.hikari.pool.HikariPool.createPoolEntry(HikariPool.java:467)
	at com.zaxxer.hikari.pool.HikariPool.checkFailFast(HikariPool.java:541)
	at com.zaxxer.hikari.pool.HikariPool.<init>(HikariPool.java:115)

```

I verified the change on the three GA releases, 8.0.11, 8.0.12, and 8.0.13.

I ran into a strange behavior of Java, I believe, where previously it was fine to implicitly implement a method that returns `<T extends Closeable> T` with a method that returns `Socket`, but from what I can tell it only works when compiling a class that actually implements the interface (guess Java generates bytecode for the concrete and `Closeable` version when it sees such an interface override). Now that the method stopped having an interface method it was implementing, such a helper wasn't generated and I couldn't get the new code to run on `8.0.11` until changing the signature from `Socket` to `<T extends Closeable> T`. Since this is actually closer to the definition in `8.0.11`, it is a compatible change.