### PR TITLE
Update dependencies to more recent versions. 

### DIFF
--- a/connector-j-5/pom.xml
+++ b/connector-j-5/pom.xml
@@ -15,16 +15,15 @@
   <name>Cloud SQL MySQL Socket Factory (for Connector/J 5.x)</name>
   <description>
     Socket factory for the MySQL JDBC driver (version 5.x) that allows a user with the appropriate
-    permissions
-    to connect to a Cloud SQL database without having to deal with IP whitelisting or SSL
-    certificates manually
+    permissions to connect to a Cloud SQL database without having to deal with IP whitelisting or
+    SSL certificates manually.
   </description>
 
   <dependencies>
     <dependency>
       <groupId>mysql</groupId>
       <artifactId>mysql-connector-java</artifactId>
-      <version>5.1.46</version>
+      <version>5.1.47</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -33,4 +32,5 @@
       <version>1.0.13-SNAPSHOT</version>
     </dependency>
   </dependencies>
+
 </project>

--- a/connector-j-6/pom.xml
+++ b/connector-j-6/pom.xml
@@ -15,9 +15,8 @@
   <name>Cloud SQL MySQL Socket Factory (for Connector/J 6.x)</name>
   <description>
     Socket factory for the MySQL JDBC driver (version 6.x) that allows a user with the appropriate
-    permissions
-    to connect to a Cloud SQL database without having to deal with IP whitelisting or SSL
-    certificates manually
+    permissions to connect to a Cloud SQL database without having to deal with IP whitelisting or
+    SSL certificates manually.
   </description>
 
   <dependencies>

--- a/connector-j-8/pom.xml
+++ b/connector-j-8/pom.xml
@@ -16,15 +16,14 @@
   <description>
     Socket factory for the MySQL JDBC driver (version 8.x) that allows a user with the appropriate
     permissions to connect to a Cloud SQL database without having to deal with IP whitelisting or
-    SSL
-    certificates manually
+    SSL certificates manually.
   </description>
 
   <dependencies>
     <dependency>
       <groupId>mysql</groupId>
       <artifactId>mysql-connector-java</artifactId>
-      <version>8.0.13</version>
+      <version>8.0.14</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -43,7 +43,7 @@
     <dependency>
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
-      <version>0.28</version>
+      <version>0.42</version>
       <scope>test</scope>
     </dependency>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -23,30 +23,7 @@
     <dependency>
       <groupId>com.google.apis</groupId>
       <artifactId>google-api-services-sqladmin</artifactId>
-      <version>v1beta4-rev56-1.23.0</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.code.findbugs</groupId>
-          <artifactId>jsr305</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava-jdk5</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>26.0-android</version>
-    </dependency>
-
-    <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
-      <version>3.0.2</version>
-      <scope>provided</scope>
+      <version>v1beta4-rev20181031-1.28.0</version>
     </dependency>
 
     <dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -47,13 +47,6 @@
       <scope>test</scope>
     </dependency>
 
-    <dependency>
-      <groupId>joda-time</groupId>
-      <artifactId>joda-time</artifactId>
-      <version>2.9.2</version>
-      <scope>test</scope>
-    </dependency>
-
   </dependencies>
 
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>1.9.5</version>
+      <version>2.24.0</version>
       <scope>test</scope>
     </dependency>
 

--- a/postgres/pom.xml
+++ b/postgres/pom.xml
@@ -16,12 +16,18 @@
 
   <name>Cloud SQL Postgres Socket Factory</name>
   <description>
-    Socket factory for the Postgres JDBC driver that allows a user with the appropriate
-    permissions to connect to a Cloud SQL database without having to deal with IP whitelisting
-    or SSL certificates manually
+    Socket factory for the Postgres JDBC driver that allows a user with the appropriate permissions
+    to connect to a Cloud SQL database without having to deal with IP whitelisting or SSL
+    certificates manually.
   </description>
 
   <dependencies>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <version>42.2.5</version>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
       <groupId>com.google.cloud.sql</groupId>
       <artifactId>jdbc-socket-factory-core</artifactId>


### PR DESCRIPTION
Fixes #121.

Notes:
* `1.28.0` of `google-api-services-sqladmin` brings `guava` and `findbugs` up to matching versions, so I removed the substitutions. 
* `joda-time` recommends moving to `java.time` for Java8, so I replaced it accordingly. 
