### PR TITLE
Consolidate "connect" logic from individual factories into core SocketFactory.

### DIFF
--- a/connector-j-5/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
+++ b/connector-j-5/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
@@ -66,7 +66,7 @@ public class SocketFactory implements com.mysql.jdbc.SocketFactory {
       List<String> ipTypes =
           CoreSocketFactory.listIpTypes(
               props.getProperty("ipTypes", CoreSocketFactory.DEFAULT_IP_TYPES));
-      this.socket = CoreSocketFactory.getInstance().create(instanceName, ipTypes);
+      this.socket = CoreSocketFactory.getInstance().createSslSocket(instanceName, ipTypes);
     }
     return this.socket;
   }

--- a/connector-j-5/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
+++ b/connector-j-5/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
@@ -33,7 +33,8 @@ public class SocketFactory implements com.mysql.jdbc.SocketFactory {
 
   @Override
   public Socket connect(String hostname, int portNumber, Properties props) throws IOException {
-    socket = CoreSocketFactory.getInstance().connect(props);
+    socket =
+        CoreSocketFactory.getInstance().connect(props, CoreSocketFactory.MYSQL_SOCKET_FILE_FORMAT);
     return socket;
   }
 

--- a/connector-j-5/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
+++ b/connector-j-5/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
@@ -18,7 +18,7 @@ package com.google.cloud.sql.mysql;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import com.google.cloud.sql.core.SslSocketFactory;
+import com.google.cloud.sql.core.CoreSocketFactory;
 import java.io.File;
 import java.io.IOException;
 import java.net.Socket;
@@ -32,7 +32,7 @@ import jnr.unixsocket.UnixSocketChannel;
  * A MySQL {@link SocketFactory} that establishes a secure connection to a Cloud SQL instance using
  * ephemeral certificates.
  *
- * <p>The heavy lifting is done by the singleton {@link SslSocketFactory} class.
+ * <p>The heavy lifting is done by the singleton {@link CoreSocketFactory} class.
  */
 public class SocketFactory implements com.mysql.jdbc.SocketFactory {
 
@@ -64,9 +64,9 @@ public class SocketFactory implements com.mysql.jdbc.SocketFactory {
       logger.info(
           String.format("Connecting to Cloud SQL instance [%s] via ssl socket.", instanceName));
       List<String> ipTypes =
-          SslSocketFactory.listIpTypes(
-              props.getProperty("ipTypes", SslSocketFactory.DEFAULT_IP_TYPES));
-      this.socket = SslSocketFactory.getInstance().create(instanceName, ipTypes);
+          CoreSocketFactory.listIpTypes(
+              props.getProperty("ipTypes", CoreSocketFactory.DEFAULT_IP_TYPES));
+      this.socket = CoreSocketFactory.getInstance().create(instanceName, ipTypes);
     }
     return this.socket;
   }

--- a/connector-j-5/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
+++ b/connector-j-5/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
@@ -16,17 +16,10 @@
 
 package com.google.cloud.sql.mysql;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 import com.google.cloud.sql.core.CoreSocketFactory;
-import java.io.File;
 import java.io.IOException;
 import java.net.Socket;
-import java.util.List;
 import java.util.Properties;
-import java.util.logging.Logger;
-import jnr.unixsocket.UnixSocketAddress;
-import jnr.unixsocket.UnixSocketChannel;
 
 /**
  * A MySQL {@link SocketFactory} that establishes a secure connection to a Cloud SQL instance using
@@ -36,44 +29,16 @@ import jnr.unixsocket.UnixSocketChannel;
  */
 public class SocketFactory implements com.mysql.jdbc.SocketFactory {
 
-  private static final Logger logger = Logger.getLogger(SocketFactory.class.getName());
-  private static final String CloudSqlPrefix = "/cloudsql/";
-
   private Socket socket;
 
   @Override
   public Socket connect(String hostname, int portNumber, Properties props) throws IOException {
-    String instanceName = props.getProperty("cloudSqlInstance");
-    checkArgument(
-        instanceName != null,
-        "cloudSqlInstance property not set. Please specify this property in the JDBC URL or "
-            + "the connection Properties with value in form \"project:region:instance\"");
-
-    // Custom env variable for forcing unix socket
-    Boolean forceUnixSocket = System.getenv("CLOUD_SQL_FORCE_UNIX_SOCKET") != null;
-
-    // If running on GAE Standard, connect with unix socket
-    if (forceUnixSocket || runningOnGaeStandard()) {
-      logger.info(
-          String.format("Connecting to Cloud SQL instance [%s] via unix socket.", instanceName));
-      UnixSocketAddress socketAddress =
-          new UnixSocketAddress(new File(CloudSqlPrefix + instanceName));
-      this.socket = UnixSocketChannel.open(socketAddress).socket();
-    } else {
-      // Default to SSL Socket
-      logger.info(
-          String.format("Connecting to Cloud SQL instance [%s] via ssl socket.", instanceName));
-      List<String> ipTypes =
-          CoreSocketFactory.listIpTypes(
-              props.getProperty("ipTypes", CoreSocketFactory.DEFAULT_IP_TYPES));
-      this.socket = CoreSocketFactory.getInstance().createSslSocket(instanceName, ipTypes);
-    }
-    return this.socket;
+    socket = CoreSocketFactory.getInstance().connect(props);
+    return socket;
   }
 
   // Cloud SQL sockets always use TLS and the socket returned by connect above is already TLS-ready.
-  // It is fine
-  // to implement these as no-ops.
+  // It is fine to implement these as no-ops.
   @Override
   public Socket beforeHandshake() {
     return socket;
@@ -82,19 +47,5 @@ public class SocketFactory implements com.mysql.jdbc.SocketFactory {
   @Override
   public Socket afterHandshake() {
     return socket;
-  }
-
-  /** Returns {@code true} if running in a Google App Engine Standard runtime. */
-  // TODO(kurtisvg) move this check into a shared class
-  private boolean runningOnGaeStandard() {
-    // gaeEnv="standard" indicates standard instances
-    String gaeEnv = System.getenv("GAE_ENV");
-    // runEnv="Production" requires to rule out Java 8 emulated environments
-    String runEnv = System.getProperty("com.google.appengine.runtime.environment");
-    // gaeRuntime="java11" in Java 11 environments (no emulated environments)
-    String gaeRuntime = System.getenv("GAE_RUNTIME");
-
-    return "standard".equals(gaeEnv)
-        && ("Production".equals(runEnv) || "java11".equals(gaeRuntime));
   }
 }

--- a/connector-j-6/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
+++ b/connector-j-6/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
@@ -34,7 +34,8 @@ public class SocketFactory implements com.mysql.cj.api.io.SocketFactory {
   @Override
   public Socket connect(String host, int portNumber, Properties props, int loginTimeout)
       throws IOException {
-    socket = CoreSocketFactory.getInstance().connect(props);
+    socket =
+        CoreSocketFactory.getInstance().connect(props, CoreSocketFactory.MYSQL_SOCKET_FILE_FORMAT);
     return socket;
   }
 

--- a/connector-j-6/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
+++ b/connector-j-6/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
@@ -67,7 +67,7 @@ public class SocketFactory implements com.mysql.cj.api.io.SocketFactory {
       List<String> ipTypes =
           CoreSocketFactory.listIpTypes(
               props.getProperty("ipTypes", CoreSocketFactory.DEFAULT_IP_TYPES));
-      this.socket = CoreSocketFactory.getInstance().create(instanceName, ipTypes);
+      this.socket = CoreSocketFactory.getInstance().createSslSocket(instanceName, ipTypes);
     }
     return this.socket;
   }

--- a/connector-j-6/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
+++ b/connector-j-6/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
@@ -18,7 +18,7 @@ package com.google.cloud.sql.mysql;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import com.google.cloud.sql.core.SslSocketFactory;
+import com.google.cloud.sql.core.CoreSocketFactory;
 import java.io.File;
 import java.io.IOException;
 import java.net.Socket;
@@ -32,7 +32,7 @@ import jnr.unixsocket.UnixSocketChannel;
  * A MySQL {@link SocketFactory} that establishes a secure connection to a Cloud SQL instance using
  * ephemeral certificates.
  *
- * <p>The heavy lifting is done by the singleton {@link SslSocketFactory} class.
+ * <p>The heavy lifting is done by the singleton {@link CoreSocketFactory} class.
  */
 public class SocketFactory implements com.mysql.cj.api.io.SocketFactory {
 
@@ -65,9 +65,9 @@ public class SocketFactory implements com.mysql.cj.api.io.SocketFactory {
       logger.info(
           String.format("Connecting to Cloud SQL instance [%s] via ssl socket.", instanceName));
       List<String> ipTypes =
-          SslSocketFactory.listIpTypes(
-              props.getProperty("ipTypes", SslSocketFactory.DEFAULT_IP_TYPES));
-      this.socket = SslSocketFactory.getInstance().create(instanceName, ipTypes);
+          CoreSocketFactory.listIpTypes(
+              props.getProperty("ipTypes", CoreSocketFactory.DEFAULT_IP_TYPES));
+      this.socket = CoreSocketFactory.getInstance().create(instanceName, ipTypes);
     }
     return this.socket;
   }

--- a/connector-j-6/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
+++ b/connector-j-6/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
@@ -16,17 +16,10 @@
 
 package com.google.cloud.sql.mysql;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 import com.google.cloud.sql.core.CoreSocketFactory;
-import java.io.File;
 import java.io.IOException;
 import java.net.Socket;
-import java.util.List;
 import java.util.Properties;
-import java.util.logging.Logger;
-import jnr.unixsocket.UnixSocketAddress;
-import jnr.unixsocket.UnixSocketChannel;
 
 /**
  * A MySQL {@link SocketFactory} that establishes a secure connection to a Cloud SQL instance using
@@ -36,45 +29,17 @@ import jnr.unixsocket.UnixSocketChannel;
  */
 public class SocketFactory implements com.mysql.cj.api.io.SocketFactory {
 
-  private static final Logger logger = Logger.getLogger(SocketFactory.class.getName());
-  private static final String CloudSqlPrefix = "/cloudsql/";
-
   private Socket socket;
 
   @Override
   public Socket connect(String host, int portNumber, Properties props, int loginTimeout)
       throws IOException {
-    String instanceName = props.getProperty("cloudSqlInstance");
-    checkArgument(
-        instanceName != null,
-        "cloudSqlInstance property not set. Please specify this property in the JDBC URL or "
-            + "the connection Properties with value in form \"project:region:instance\"");
-
-    // Custom env variable for forcing unix socket
-    boolean forceUnixSocket = System.getenv("CLOUD_SQL_FORCE_UNIX_SOCKET") != null;
-
-    // If running on GAE Standard, connect with unix socket
-    if (forceUnixSocket || runningOnGaeStandard()) {
-      logger.info(
-          String.format("Connecting to Cloud SQL instance [%s] via unix socket.", instanceName));
-      UnixSocketAddress socketAddress =
-          new UnixSocketAddress(new File(CloudSqlPrefix + instanceName));
-      this.socket = UnixSocketChannel.open(socketAddress).socket();
-    } else {
-      // Default to SSL Socket
-      logger.info(
-          String.format("Connecting to Cloud SQL instance [%s] via ssl socket.", instanceName));
-      List<String> ipTypes =
-          CoreSocketFactory.listIpTypes(
-              props.getProperty("ipTypes", CoreSocketFactory.DEFAULT_IP_TYPES));
-      this.socket = CoreSocketFactory.getInstance().createSslSocket(instanceName, ipTypes);
-    }
-    return this.socket;
+    socket = CoreSocketFactory.getInstance().connect(props);
+    return socket;
   }
 
   // Cloud SQL sockets always use TLS and the socket returned by connect above is already TLS-ready.
-  // It is fine
-  // to implement these as no-ops.
+  // It is fine to implement these as no-ops.
   @Override
   public Socket beforeHandshake() {
     return socket;
@@ -83,19 +48,5 @@ public class SocketFactory implements com.mysql.cj.api.io.SocketFactory {
   @Override
   public Socket afterHandshake() {
     return socket;
-  }
-
-  /** Returns {@code true} if running in a Google App Engine Standard runtime. */
-  // TODO(kurtisvg) move this check into a shared class
-  private boolean runningOnGaeStandard() {
-    // gaeEnv="standard" indicates standard instances
-    String gaeEnv = System.getenv("GAE_ENV");
-    // runEnv="Production" requires to rule out Java 8 emulated environments
-    String runEnv = System.getProperty("com.google.appengine.runtime.environment");
-    // gaeRuntime="java11" in Java 11 environments (no emulated environments)
-    String gaeRuntime = System.getenv("GAE_RUNTIME");
-
-    return "standard".equals(gaeEnv)
-        && ("Production".equals(runEnv) || "java11".equals(gaeRuntime));
   }
 }

--- a/connector-j-8/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
+++ b/connector-j-8/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
@@ -18,7 +18,7 @@ package com.google.cloud.sql.mysql;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import com.google.cloud.sql.core.SslSocketFactory;
+import com.google.cloud.sql.core.CoreSocketFactory;
 import com.mysql.cj.conf.PropertySet;
 import com.mysql.cj.protocol.ServerSession;
 import com.mysql.cj.protocol.SocketConnection;
@@ -36,7 +36,7 @@ import jnr.unixsocket.UnixSocketChannel;
  * A MySQL {@link SocketFactory} that establishes a secure connection to a Cloud SQL instance using
  * ephemeral certificates.
  *
- * <p>The heavy lifting is done by the singleton {@link SslSocketFactory} class.
+ * <p>The heavy lifting is done by the singleton {@link CoreSocketFactory} class.
  */
 public class SocketFactory implements com.mysql.cj.protocol.SocketFactory {
 
@@ -76,9 +76,9 @@ public class SocketFactory implements com.mysql.cj.protocol.SocketFactory {
       logger.info(
           String.format("Connecting to Cloud SQL instance [%s] via ssl socket.", instanceName));
       List<String> ipTypes =
-          SslSocketFactory.listIpTypes(
-              props.getProperty("ipTypes", SslSocketFactory.DEFAULT_IP_TYPES));
-      this.socket = SslSocketFactory.getInstance().create(instanceName, ipTypes);
+          CoreSocketFactory.listIpTypes(
+              props.getProperty("ipTypes", CoreSocketFactory.DEFAULT_IP_TYPES));
+      this.socket = CoreSocketFactory.getInstance().create(instanceName, ipTypes);
     }
     @SuppressWarnings("unchecked")
     T castSocket = (T) this.socket;

--- a/connector-j-8/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
+++ b/connector-j-8/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
@@ -45,7 +45,10 @@ public class SocketFactory implements com.mysql.cj.protocol.SocketFactory {
   public <T extends Closeable> T connect(
       String host, int portNumber, Properties props, int loginTimeout) throws IOException {
     @SuppressWarnings("unchecked")
-    T socket = (T) CoreSocketFactory.getInstance().connect(props);
+    T socket =
+        (T)
+            CoreSocketFactory.getInstance()
+                .connect(props, CoreSocketFactory.MYSQL_SOCKET_FILE_FORMAT);
     return socket;
   }
 

--- a/connector-j-8/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
+++ b/connector-j-8/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
@@ -78,7 +78,7 @@ public class SocketFactory implements com.mysql.cj.protocol.SocketFactory {
       List<String> ipTypes =
           CoreSocketFactory.listIpTypes(
               props.getProperty("ipTypes", CoreSocketFactory.DEFAULT_IP_TYPES));
-      this.socket = CoreSocketFactory.getInstance().create(instanceName, ipTypes);
+      this.socket = CoreSocketFactory.getInstance().createSslSocket(instanceName, ipTypes);
     }
     @SuppressWarnings("unchecked")
     T castSocket = (T) this.socket;

--- a/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
@@ -134,9 +134,7 @@ public final class CoreSocketFactory {
     this.serverProxyPort = serverProxyPort;
   }
 
-  /**
-   * Returns the {@link CoreSocketFactory} singleton.
-   */
+  /** Returns the {@link CoreSocketFactory} singleton. */
   public static synchronized CoreSocketFactory getInstance() {
     if (coreSocketFactory == null) {
       logger.info("First Cloud SQL connection, generating RSA key pair.");
@@ -223,7 +221,8 @@ public final class CoreSocketFactory {
    * @throws IOException if error occurs during socket creation.
    */
   // TODO(berezv): separate creating socket and performing connection to make it easier to test
-  protected Socket createSslSocket(String instanceName, List<String> ipTypes) throws IOException {
+  @VisibleForTesting
+  Socket createSslSocket(String instanceName, List<String> ipTypes) throws IOException {
     try {
       return createAndConfigureSocket(instanceName, ipTypes, CertificateCaching.USE_CACHE);
     } catch (SSLHandshakeException err) {

--- a/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
@@ -135,7 +135,7 @@ public class CoreSocketFactory {
   }
 
   /**
-   * Returns the CoreSocketFactory singleton, which can be used to createSslSocket SslSockets to
+   * Returns the {@link CoreSocketFactory} singleton.
    * Cloud SQL.
    *
    * @return the CoreSocketFactory singleton.
@@ -201,7 +201,7 @@ public class CoreSocketFactory {
 
     logger.info(
         String.format("Connecting to Cloud SQL instance [%s] via SSL socket.", csqlInstanceName));
-    return CoreSocketFactory.getInstance().createSslSocket(csqlInstanceName, ipTypes);
+    return getInstance().createSslSocket(csqlInstanceName, ipTypes);
   }
 
   /** Returns {@code true} if running in a Google App Engine Standard runtime. */

--- a/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
@@ -83,11 +83,14 @@ import jnr.unixsocket.UnixSocketChannel;
  * <p>The API of this class is subject to change without notice.
  */
 public class CoreSocketFactory {
+  public static final String CLOUD_SQL_INSTANCE_PROPERTY = "cloudSqlInstance";
+  public static final String MYSQL_SOCKET_FILE_FORMAT = "/cloudsql/%s";
+  public static final String POSTGRES_SOCKET_FILE_FORMAT = "/cloudsql/%s/.s.PGSQL.5432";
+
   private static final Logger logger = Logger.getLogger(CoreSocketFactory.class.getName());
 
-  public static final String DEFAULT_IP_TYPES = "PUBLIC,PRIVATE";
-  public static final String USER_TOKEN_PROPERTY_NAME = "_CLOUD_SQL_USER_TOKEN";
-  private static final String unixSocketFilePrefix = "/cloudsql/";
+  private static final String DEFAULT_IP_TYPES = "PUBLIC,PRIVATE";
+  private static final String USER_TOKEN_PROPERTY_NAME = "_CLOUD_SQL_USER_TOKEN";
 
   static final String ADMIN_API_NOT_ENABLED_REASON = "accessNotConfigured";
   static final String INSTANCE_NOT_AUTHORIZED_REASON = "notAuthorized";
@@ -174,9 +177,9 @@ public class CoreSocketFactory {
    * @return the newly created Socket.
    * @throws IOException if error occurs during socket creation.
    */
-  public Socket connect(Properties props) throws IOException {
+  public Socket connect(Properties props, String socketPathFormat) throws IOException {
     // Gather parameters
-    final String csqlInstanceName = props.getProperty("cloudSqlInstance");
+    final String csqlInstanceName = props.getProperty(CLOUD_SQL_INSTANCE_PROPERTY);
     final List<String> ipTypes = listIpTypes(props.getProperty("ipTypes", DEFAULT_IP_TYPES));
     final boolean forceUnixSocket = System.getenv("CLOUD_SQL_FORCE_UNIX_SOCKET") != null;
 
@@ -192,7 +195,7 @@ public class CoreSocketFactory {
           String.format(
               "Connecting to Cloud SQL instance [%s] via unix socket.", csqlInstanceName));
       UnixSocketAddress socketAddress =
-          new UnixSocketAddress(new File(unixSocketFilePrefix + csqlInstanceName));
+          new UnixSocketAddress(new File(String.format(socketPathFormat, csqlInstanceName)));
       return UnixSocketChannel.open(socketAddress).socket();
     }
 

--- a/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
@@ -126,7 +126,8 @@ public class CoreSocketFactory {
   }
 
   /**
-   * Returns the CoreSocketFactory singleton, which can be used to create SslSockets to Cloud SQL.
+   * Returns the CoreSocketFactory singleton, which can be used to createSslSocket SslSockets to
+   * Cloud SQL.
    *
    * @return the CoreSocketFactory singleton.
    */
@@ -167,7 +168,7 @@ public class CoreSocketFactory {
    * @throws IOException if error occurs during socket creation.
    */
   // TODO(berezv): separate creating socket and performing connection to make it easier to test
-  public Socket create(String instanceName, List<String> ipTypes) throws IOException {
+  public Socket createSslSocket(String instanceName, List<String> ipTypes) throws IOException {
     try {
       return createAndConfigureSocket(instanceName, ipTypes, CertificateCaching.USE_CACHE);
     } catch (SSLHandshakeException err) {

--- a/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
@@ -77,8 +77,8 @@ import javax.net.ssl.TrustManagerFactory;
  *
  * <p>The API of this class is subject to change without notice.
  */
-public class SslSocketFactory {
-  private static final Logger logger = Logger.getLogger(SslSocketFactory.class.getName());
+public class CoreSocketFactory {
+  private static final Logger logger = Logger.getLogger(CoreSocketFactory.class.getName());
 
   public static final String DEFAULT_IP_TYPES = "PUBLIC,PRIVATE";
   public static final String USER_TOKEN_PROPERTY_NAME = "_CLOUD_SQL_USER_TOKEN";
@@ -93,7 +93,7 @@ public class SslSocketFactory {
   private static final int DEFAULT_SERVER_PROXY_PORT = 3307;
   private static final int RSA_KEY_SIZE = 2048;
 
-  private static SslSocketFactory sslSocketFactory;
+  private static CoreSocketFactory sslSocketFactory;
 
   private final CertificateFactory certificateFactory;
   private final Clock clock;
@@ -107,7 +107,7 @@ public class SslSocketFactory {
   private final RateLimiter forcedRenewRateLimiter = RateLimiter.create(1.0 / 60.0);
 
   @VisibleForTesting
-  SslSocketFactory(
+  CoreSocketFactory(
       Clock clock,
       KeyPair localKeyPair,
       Credential credential,
@@ -126,11 +126,11 @@ public class SslSocketFactory {
   }
 
   /**
-   * Returns the SslSocketFactory singleton, which can be used to create SslSockets to Cloud SQL.
+   * Returns the CoreSocketFactory singleton, which can be used to create SslSockets to Cloud SQL.
    *
-   * @return the SslSocketFactory singleton.
+   * @return the CoreSocketFactory singleton.
    */
-  public static synchronized SslSocketFactory getInstance() {
+  public static synchronized CoreSocketFactory getInstance() {
     if (sslSocketFactory == null) {
       logger.info("First Cloud SQL connection, generating RSA key pair.");
       KeyPair keyPair = generateRsaKeyPair();
@@ -152,7 +152,7 @@ public class SslSocketFactory {
 
       SQLAdmin adminApi = createAdminApiClient(credential);
       sslSocketFactory =
-          new SslSocketFactory(
+          new CoreSocketFactory(
               new Clock(), keyPair, credential, adminApi, DEFAULT_SERVER_PROXY_PORT);
     }
     return sslSocketFactory;

--- a/core/src/test/java/com/google/cloud/sql/core/CoreSocketFactoryTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/CoreSocketFactoryTest.java
@@ -38,7 +38,7 @@ import com.google.api.services.sqladmin.model.DatabaseInstance;
 import com.google.api.services.sqladmin.model.IpMapping;
 import com.google.api.services.sqladmin.model.SslCert;
 import com.google.api.services.sqladmin.model.SslCertsCreateEphemeralRequest;
-import com.google.cloud.sql.core.SslSocketFactory.Clock;
+import com.google.cloud.sql.core.CoreSocketFactory.Clock;
 import com.google.common.collect.ImmutableList;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
@@ -93,7 +93,7 @@ import sun.security.x509.X509CertInfo;
 
 // TODO(berezv): add multithreaded test
 @RunWith(JUnit4.class)
-public class SslSocketFactoryTest {
+public class CoreSocketFactoryTest {
   private static final String SERVER_MESSAGE = "HELLO";
   private static final String PROJECT_ID = "foo";
   private static final String INSTANCE_NAME = "bar";
@@ -151,8 +151,8 @@ public class SslSocketFactoryTest {
 
   @Test
   public void create_throwsErrorForInvalidInstanceName() throws IOException {
-    SslSocketFactory sslSocketFactory =
-        new SslSocketFactory(new Clock(), clientKeyPair, credential, adminApi, 3307);
+    CoreSocketFactory sslSocketFactory =
+        new CoreSocketFactory(new Clock(), clientKeyPair, credential, adminApi, 3307);
     try {
       sslSocketFactory.create("foo", Arrays.asList("PRIMARY"));
       fail();
@@ -178,8 +178,8 @@ public class SslSocketFactoryTest {
                 .setServerCaCert(new SslCert().setCert(TestKeys.SERVER_CA_CERT))
                 .setRegion("beer"));
 
-    SslSocketFactory sslSocketFactory =
-        new SslSocketFactory(new Clock(), clientKeyPair, credential, adminApi, 3307);
+    CoreSocketFactory sslSocketFactory =
+        new CoreSocketFactory(new Clock(), clientKeyPair, credential, adminApi, 3307);
     try {
       sslSocketFactory.create("foo:bar:baz", Arrays.asList("PRIMARY"));
       fail();
@@ -198,8 +198,8 @@ public class SslSocketFactoryTest {
     FakeSslServer sslServer = new FakeSslServer();
     int port = sslServer.start(PRIVATE_IP);
 
-    SslSocketFactory sslSocketFactory =
-        new SslSocketFactory(new Clock(), clientKeyPair, credential, adminApi, port);
+    CoreSocketFactory sslSocketFactory =
+        new CoreSocketFactory(new Clock(), clientKeyPair, credential, adminApi, port);
     Socket socket = sslSocketFactory.create(INSTANCE_CONNECTION_STRING, Arrays.asList("PRIVATE"));
 
     verify(adminApiInstances).get(PROJECT_ID, INSTANCE_NAME);
@@ -219,8 +219,8 @@ public class SslSocketFactoryTest {
     FakeSslServer sslServer = new FakeSslServer();
     int port = sslServer.start();
 
-    SslSocketFactory sslSocketFactory =
-        new SslSocketFactory(new Clock(), clientKeyPair, credential, adminApi, port);
+    CoreSocketFactory sslSocketFactory =
+        new CoreSocketFactory(new Clock(), clientKeyPair, credential, adminApi, port);
     Socket socket = sslSocketFactory.create(INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
 
     verify(adminApiInstances).get(PROJECT_ID, INSTANCE_NAME);
@@ -249,8 +249,8 @@ public class SslSocketFactoryTest {
     when(adminApiSslCertsCreateEphemeral.execute())
         .thenReturn(new SslCert().setCert(createEphemeralCert(Duration.ofMinutes(65))));
 
-    SslSocketFactory sslSocketFactory =
-        new SslSocketFactory(new Clock(), clientKeyPair, credential, adminApi, port);
+    CoreSocketFactory sslSocketFactory =
+        new CoreSocketFactory(new Clock(), clientKeyPair, credential, adminApi, port);
     Socket socket = sslSocketFactory.create(INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
 
     verify(adminApiInstances, times(2)).get(PROJECT_ID, INSTANCE_NAME);
@@ -270,8 +270,8 @@ public class SslSocketFactoryTest {
     FakeSslServer sslServer = new FakeSslServer();
     int port = sslServer.start();
 
-    SslSocketFactory sslSocketFactory =
-        new SslSocketFactory(new Clock(), clientKeyPair, credential, adminApi, port);
+    CoreSocketFactory sslSocketFactory =
+        new CoreSocketFactory(new Clock(), clientKeyPair, credential, adminApi, port);
     sslSocketFactory.create(INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
 
     verify(adminApiInstances).get(PROJECT_ID, INSTANCE_NAME);
@@ -295,8 +295,8 @@ public class SslSocketFactoryTest {
     when(adminApiSslCertsCreateEphemeral.execute())
         .thenReturn(new SslCert().setCert(createEphemeralCert(Duration.ofMinutes(56))));
 
-    SslSocketFactory sslSocketFactory =
-        new SslSocketFactory(new Clock(), clientKeyPair, credential, adminApi, port);
+    CoreSocketFactory sslSocketFactory =
+        new CoreSocketFactory(new Clock(), clientKeyPair, credential, adminApi, port);
     sslSocketFactory.create(INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
 
     // Second time, we should renew the certificate since it's about to expire.
@@ -311,7 +311,7 @@ public class SslSocketFactoryTest {
   @Test
   public void create_adminApiNotEnabled() throws IOException {
     ErrorInfo error = new ErrorInfo();
-    error.setReason(SslSocketFactory.ADMIN_API_NOT_ENABLED_REASON);
+    error.setReason(CoreSocketFactory.ADMIN_API_NOT_ENABLED_REASON);
     GoogleJsonError details = new GoogleJsonError();
     details.setErrors(ImmutableList.of(error));
     when(adminApiInstancesGet.execute())
@@ -319,8 +319,8 @@ public class SslSocketFactoryTest {
             new GoogleJsonResponseException(
                 new HttpResponseException.Builder(403, "Forbidden", new HttpHeaders()), details));
 
-    SslSocketFactory sslSocketFactory =
-        new SslSocketFactory(new Clock(), clientKeyPair, credential, adminApi, 3307);
+    CoreSocketFactory sslSocketFactory =
+        new CoreSocketFactory(new Clock(), clientKeyPair, credential, adminApi, 3307);
     try {
       sslSocketFactory.create(INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
       fail("Expected RuntimeException");
@@ -333,7 +333,7 @@ public class SslSocketFactoryTest {
   @Test
   public void create_notAuthorizedToGetInstance() throws IOException {
     ErrorInfo error = new ErrorInfo();
-    error.setReason(SslSocketFactory.INSTANCE_NOT_AUTHORIZED_REASON);
+    error.setReason(CoreSocketFactory.INSTANCE_NOT_AUTHORIZED_REASON);
     GoogleJsonError details = new GoogleJsonError();
     details.setErrors(ImmutableList.of(error));
     when(adminApiInstancesGet.execute())
@@ -341,8 +341,8 @@ public class SslSocketFactoryTest {
             new GoogleJsonResponseException(
                 new HttpResponseException.Builder(403, "Forbidden", new HttpHeaders()), details));
 
-    SslSocketFactory sslSocketFactory =
-        new SslSocketFactory(new Clock(), clientKeyPair, credential, adminApi, 3307);
+    CoreSocketFactory sslSocketFactory =
+        new CoreSocketFactory(new Clock(), clientKeyPair, credential, adminApi, 3307);
     try {
       sslSocketFactory.create(INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
       fail("Expected RuntimeException");
@@ -355,7 +355,7 @@ public class SslSocketFactoryTest {
   @Test
   public void create_instanceNotFoundErrorCached() throws IOException {
     ErrorInfo error = new ErrorInfo();
-    error.setReason(SslSocketFactory.INSTANCE_NOT_AUTHORIZED_REASON);
+    error.setReason(CoreSocketFactory.INSTANCE_NOT_AUTHORIZED_REASON);
     GoogleJsonError details = new GoogleJsonError();
     details.setErrors(ImmutableList.of(error));
     when(adminApiInstancesGet.execute())
@@ -363,8 +363,8 @@ public class SslSocketFactoryTest {
             new GoogleJsonResponseException(
                 new HttpResponseException.Builder(403, "Forbidden", new HttpHeaders()), details));
 
-    SslSocketFactory sslSocketFactory =
-        new SslSocketFactory(mockClock, clientKeyPair, credential, adminApi, 3307);
+    CoreSocketFactory sslSocketFactory =
+        new CoreSocketFactory(mockClock, clientKeyPair, credential, adminApi, 3307);
     try {
       sslSocketFactory.create(INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
       fail();
@@ -400,7 +400,7 @@ public class SslSocketFactoryTest {
   @Test
   public void create_notAuthorizedToCreateEphemeralCertificate() throws IOException {
     ErrorInfo error = new ErrorInfo();
-    error.setReason(SslSocketFactory.INSTANCE_NOT_AUTHORIZED_REASON);
+    error.setReason(CoreSocketFactory.INSTANCE_NOT_AUTHORIZED_REASON);
     GoogleJsonError details = new GoogleJsonError();
     details.setErrors(ImmutableList.of(error));
     when(adminApiSslCertsCreateEphemeral.execute())
@@ -408,8 +408,8 @@ public class SslSocketFactoryTest {
             new GoogleJsonResponseException(
                 new HttpResponseException.Builder(403, "Forbidden", new HttpHeaders()), details));
 
-    SslSocketFactory sslSocketFactory =
-        new SslSocketFactory(new Clock(), clientKeyPair, credential, adminApi, 3307);
+    CoreSocketFactory sslSocketFactory =
+        new CoreSocketFactory(new Clock(), clientKeyPair, credential, adminApi, 3307);
     try {
       sslSocketFactory.create(INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
       fail();

--- a/core/src/test/java/com/google/cloud/sql/core/CoreSocketFactoryTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/CoreSocketFactoryTest.java
@@ -154,14 +154,14 @@ public class CoreSocketFactoryTest {
     CoreSocketFactory sslSocketFactory =
         new CoreSocketFactory(new Clock(), clientKeyPair, credential, adminApi, 3307);
     try {
-      sslSocketFactory.create("foo", Arrays.asList("PRIMARY"));
+      sslSocketFactory.createSslSocket("foo", Arrays.asList("PRIMARY"));
       fail();
     } catch (IllegalArgumentException e) {
       assertThat(e.getMessage()).startsWith("Invalid Cloud SQL instance");
     }
 
     try {
-      sslSocketFactory.create("foo:bar", Arrays.asList("PRIMARY"));
+      sslSocketFactory.createSslSocket("foo:bar", Arrays.asList("PRIMARY"));
       fail();
     } catch (IllegalArgumentException e) {
       assertThat(e.getMessage()).startsWith("Invalid Cloud SQL instance");
@@ -181,7 +181,7 @@ public class CoreSocketFactoryTest {
     CoreSocketFactory sslSocketFactory =
         new CoreSocketFactory(new Clock(), clientKeyPair, credential, adminApi, 3307);
     try {
-      sslSocketFactory.create("foo:bar:baz", Arrays.asList("PRIMARY"));
+      sslSocketFactory.createSslSocket("foo:bar:baz", Arrays.asList("PRIMARY"));
       fail();
     } catch (IllegalArgumentException e) {
       assertThat(e.getMessage()).startsWith("Incorrect region value");
@@ -200,7 +200,8 @@ public class CoreSocketFactoryTest {
 
     CoreSocketFactory sslSocketFactory =
         new CoreSocketFactory(new Clock(), clientKeyPair, credential, adminApi, port);
-    Socket socket = sslSocketFactory.create(INSTANCE_CONNECTION_STRING, Arrays.asList("PRIVATE"));
+    Socket socket =
+        sslSocketFactory.createSslSocket(INSTANCE_CONNECTION_STRING, Arrays.asList("PRIVATE"));
 
     verify(adminApiInstances).get(PROJECT_ID, INSTANCE_NAME);
     verify(adminApiSslCerts)
@@ -221,7 +222,8 @@ public class CoreSocketFactoryTest {
 
     CoreSocketFactory sslSocketFactory =
         new CoreSocketFactory(new Clock(), clientKeyPair, credential, adminApi, port);
-    Socket socket = sslSocketFactory.create(INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
+    Socket socket =
+        sslSocketFactory.createSslSocket(INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
 
     verify(adminApiInstances).get(PROJECT_ID, INSTANCE_NAME);
     verify(adminApiSslCerts)
@@ -251,7 +253,8 @@ public class CoreSocketFactoryTest {
 
     CoreSocketFactory sslSocketFactory =
         new CoreSocketFactory(new Clock(), clientKeyPair, credential, adminApi, port);
-    Socket socket = sslSocketFactory.create(INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
+    Socket socket =
+        sslSocketFactory.createSslSocket(INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
 
     verify(adminApiInstances, times(2)).get(PROJECT_ID, INSTANCE_NAME);
     verify(adminApiSslCerts, times(2))
@@ -272,14 +275,14 @@ public class CoreSocketFactoryTest {
 
     CoreSocketFactory sslSocketFactory =
         new CoreSocketFactory(new Clock(), clientKeyPair, credential, adminApi, port);
-    sslSocketFactory.create(INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
+    sslSocketFactory.createSslSocket(INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
 
     verify(adminApiInstances).get(PROJECT_ID, INSTANCE_NAME);
     verify(adminApiSslCerts)
         .createEphemeral(
             eq(PROJECT_ID), eq(INSTANCE_NAME), isA(SslCertsCreateEphemeralRequest.class));
 
-    sslSocketFactory.create(INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
+    sslSocketFactory.createSslSocket(INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
 
     verifyNoMoreInteractions(adminApiInstances);
     verifyNoMoreInteractions(adminApiSslCerts);
@@ -297,10 +300,10 @@ public class CoreSocketFactoryTest {
 
     CoreSocketFactory sslSocketFactory =
         new CoreSocketFactory(new Clock(), clientKeyPair, credential, adminApi, port);
-    sslSocketFactory.create(INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
+    sslSocketFactory.createSslSocket(INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
 
     // Second time, we should renew the certificate since it's about to expire.
-    sslSocketFactory.create(INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
+    sslSocketFactory.createSslSocket(INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
 
     verify(adminApiInstances, times(2)).get(PROJECT_ID, INSTANCE_NAME);
     verify(adminApiSslCerts, times(2))
@@ -322,7 +325,7 @@ public class CoreSocketFactoryTest {
     CoreSocketFactory sslSocketFactory =
         new CoreSocketFactory(new Clock(), clientKeyPair, credential, adminApi, 3307);
     try {
-      sslSocketFactory.create(INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
+      sslSocketFactory.createSslSocket(INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
       fail("Expected RuntimeException");
     } catch (RuntimeException e) {
       // TODO(berezv): should we throw something more specific than RuntimeException?
@@ -344,7 +347,7 @@ public class CoreSocketFactoryTest {
     CoreSocketFactory sslSocketFactory =
         new CoreSocketFactory(new Clock(), clientKeyPair, credential, adminApi, 3307);
     try {
-      sslSocketFactory.create(INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
+      sslSocketFactory.createSslSocket(INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
       fail("Expected RuntimeException");
     } catch (RuntimeException e) {
       // TODO(berezv): should we throw something more specific than RuntimeException?
@@ -366,7 +369,7 @@ public class CoreSocketFactoryTest {
     CoreSocketFactory sslSocketFactory =
         new CoreSocketFactory(mockClock, clientKeyPair, credential, adminApi, 3307);
     try {
-      sslSocketFactory.create(INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
+      sslSocketFactory.createSslSocket(INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
       fail();
     } catch (RuntimeException e) {
       assertThat(e.getMessage()).contains("not authorized");
@@ -377,7 +380,7 @@ public class CoreSocketFactoryTest {
     // Exception should be cached.
     when(mockClock.now()).thenReturn(59 * 1000L);
     try {
-      sslSocketFactory.create(INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
+      sslSocketFactory.createSslSocket(INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
       fail();
     } catch (RuntimeException e) {
       assertThat(e.getMessage()).contains("not authorized");
@@ -388,7 +391,7 @@ public class CoreSocketFactoryTest {
     // Enough time has passed that cached exception should be ignored.
     when(mockClock.now()).thenReturn(61 * 1000L);
     try {
-      sslSocketFactory.create(INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
+      sslSocketFactory.createSslSocket(INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
       fail();
     } catch (RuntimeException e) {
       assertThat(e.getMessage()).contains("not authorized");
@@ -411,7 +414,7 @@ public class CoreSocketFactoryTest {
     CoreSocketFactory sslSocketFactory =
         new CoreSocketFactory(new Clock(), clientKeyPair, credential, adminApi, 3307);
     try {
-      sslSocketFactory.create(INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
+      sslSocketFactory.createSslSocket(INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
       fail();
     } catch (RuntimeException e) {
       // TODO(berezv): should we throw something more specific than RuntimeException?

--- a/core/src/test/java/com/google/cloud/sql/core/CoreSocketFactoryTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/CoreSocketFactoryTest.java
@@ -151,17 +151,17 @@ public class CoreSocketFactoryTest {
 
   @Test
   public void create_throwsErrorForInvalidInstanceName() throws IOException {
-    CoreSocketFactory sslSocketFactory =
+    CoreSocketFactory coreSocketFactory =
         new CoreSocketFactory(new Clock(), clientKeyPair, credential, adminApi, 3307);
     try {
-      sslSocketFactory.createSslSocket("foo", Arrays.asList("PRIMARY"));
+      coreSocketFactory.createSslSocket("foo", Arrays.asList("PRIMARY"));
       fail();
     } catch (IllegalArgumentException e) {
       assertThat(e.getMessage()).startsWith("Invalid Cloud SQL instance");
     }
 
     try {
-      sslSocketFactory.createSslSocket("foo:bar", Arrays.asList("PRIMARY"));
+      coreSocketFactory.createSslSocket("foo:bar", Arrays.asList("PRIMARY"));
       fail();
     } catch (IllegalArgumentException e) {
       assertThat(e.getMessage()).startsWith("Invalid Cloud SQL instance");
@@ -178,10 +178,10 @@ public class CoreSocketFactoryTest {
                 .setServerCaCert(new SslCert().setCert(TestKeys.SERVER_CA_CERT))
                 .setRegion("beer"));
 
-    CoreSocketFactory sslSocketFactory =
+    CoreSocketFactory coreSocketFactory =
         new CoreSocketFactory(new Clock(), clientKeyPair, credential, adminApi, 3307);
     try {
-      sslSocketFactory.createSslSocket("foo:bar:baz", Arrays.asList("PRIMARY"));
+      coreSocketFactory.createSslSocket("foo:bar:baz", Arrays.asList("PRIMARY"));
       fail();
     } catch (IllegalArgumentException e) {
       assertThat(e.getMessage()).startsWith("Incorrect region value");
@@ -198,10 +198,10 @@ public class CoreSocketFactoryTest {
     FakeSslServer sslServer = new FakeSslServer();
     int port = sslServer.start(PRIVATE_IP);
 
-    CoreSocketFactory sslSocketFactory =
+    CoreSocketFactory coreSocketFactory =
         new CoreSocketFactory(new Clock(), clientKeyPair, credential, adminApi, port);
     Socket socket =
-        sslSocketFactory.createSslSocket(INSTANCE_CONNECTION_STRING, Arrays.asList("PRIVATE"));
+        coreSocketFactory.createSslSocket(INSTANCE_CONNECTION_STRING, Arrays.asList("PRIVATE"));
 
     verify(adminApiInstances).get(PROJECT_ID, INSTANCE_NAME);
     verify(adminApiSslCerts)
@@ -220,10 +220,10 @@ public class CoreSocketFactoryTest {
     FakeSslServer sslServer = new FakeSslServer();
     int port = sslServer.start();
 
-    CoreSocketFactory sslSocketFactory =
+    CoreSocketFactory coreSocketFactory =
         new CoreSocketFactory(new Clock(), clientKeyPair, credential, adminApi, port);
     Socket socket =
-        sslSocketFactory.createSslSocket(INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
+        coreSocketFactory.createSslSocket(INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
 
     verify(adminApiInstances).get(PROJECT_ID, INSTANCE_NAME);
     verify(adminApiSslCerts)
@@ -251,10 +251,10 @@ public class CoreSocketFactoryTest {
     when(adminApiSslCertsCreateEphemeral.execute())
         .thenReturn(new SslCert().setCert(createEphemeralCert(Duration.ofMinutes(65))));
 
-    CoreSocketFactory sslSocketFactory =
+    CoreSocketFactory coreSocketFactory =
         new CoreSocketFactory(new Clock(), clientKeyPair, credential, adminApi, port);
     Socket socket =
-        sslSocketFactory.createSslSocket(INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
+        coreSocketFactory.createSslSocket(INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
 
     verify(adminApiInstances, times(2)).get(PROJECT_ID, INSTANCE_NAME);
     verify(adminApiSslCerts, times(2))
@@ -273,16 +273,16 @@ public class CoreSocketFactoryTest {
     FakeSslServer sslServer = new FakeSslServer();
     int port = sslServer.start();
 
-    CoreSocketFactory sslSocketFactory =
+    CoreSocketFactory coreSocketFactory =
         new CoreSocketFactory(new Clock(), clientKeyPair, credential, adminApi, port);
-    sslSocketFactory.createSslSocket(INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
+    coreSocketFactory.createSslSocket(INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
 
     verify(adminApiInstances).get(PROJECT_ID, INSTANCE_NAME);
     verify(adminApiSslCerts)
         .createEphemeral(
             eq(PROJECT_ID), eq(INSTANCE_NAME), isA(SslCertsCreateEphemeralRequest.class));
 
-    sslSocketFactory.createSslSocket(INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
+    coreSocketFactory.createSslSocket(INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
 
     verifyNoMoreInteractions(adminApiInstances);
     verifyNoMoreInteractions(adminApiSslCerts);
@@ -298,12 +298,12 @@ public class CoreSocketFactoryTest {
     when(adminApiSslCertsCreateEphemeral.execute())
         .thenReturn(new SslCert().setCert(createEphemeralCert(Duration.ofMinutes(56))));
 
-    CoreSocketFactory sslSocketFactory =
+    CoreSocketFactory coreSocketFactory =
         new CoreSocketFactory(new Clock(), clientKeyPair, credential, adminApi, port);
-    sslSocketFactory.createSslSocket(INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
+    coreSocketFactory.createSslSocket(INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
 
     // Second time, we should renew the certificate since it's about to expire.
-    sslSocketFactory.createSslSocket(INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
+    coreSocketFactory.createSslSocket(INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
 
     verify(adminApiInstances, times(2)).get(PROJECT_ID, INSTANCE_NAME);
     verify(adminApiSslCerts, times(2))
@@ -322,10 +322,10 @@ public class CoreSocketFactoryTest {
             new GoogleJsonResponseException(
                 new HttpResponseException.Builder(403, "Forbidden", new HttpHeaders()), details));
 
-    CoreSocketFactory sslSocketFactory =
+    CoreSocketFactory coreSocketFactory =
         new CoreSocketFactory(new Clock(), clientKeyPair, credential, adminApi, 3307);
     try {
-      sslSocketFactory.createSslSocket(INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
+      coreSocketFactory.createSslSocket(INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
       fail("Expected RuntimeException");
     } catch (RuntimeException e) {
       // TODO(berezv): should we throw something more specific than RuntimeException?
@@ -344,10 +344,10 @@ public class CoreSocketFactoryTest {
             new GoogleJsonResponseException(
                 new HttpResponseException.Builder(403, "Forbidden", new HttpHeaders()), details));
 
-    CoreSocketFactory sslSocketFactory =
+    CoreSocketFactory coreSocketFactory =
         new CoreSocketFactory(new Clock(), clientKeyPair, credential, adminApi, 3307);
     try {
-      sslSocketFactory.createSslSocket(INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
+      coreSocketFactory.createSslSocket(INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
       fail("Expected RuntimeException");
     } catch (RuntimeException e) {
       // TODO(berezv): should we throw something more specific than RuntimeException?
@@ -366,10 +366,10 @@ public class CoreSocketFactoryTest {
             new GoogleJsonResponseException(
                 new HttpResponseException.Builder(403, "Forbidden", new HttpHeaders()), details));
 
-    CoreSocketFactory sslSocketFactory =
+    CoreSocketFactory coreSocketFactory =
         new CoreSocketFactory(mockClock, clientKeyPair, credential, adminApi, 3307);
     try {
-      sslSocketFactory.createSslSocket(INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
+      coreSocketFactory.createSslSocket(INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
       fail();
     } catch (RuntimeException e) {
       assertThat(e.getMessage()).contains("not authorized");
@@ -380,7 +380,7 @@ public class CoreSocketFactoryTest {
     // Exception should be cached.
     when(mockClock.now()).thenReturn(59 * 1000L);
     try {
-      sslSocketFactory.createSslSocket(INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
+      coreSocketFactory.createSslSocket(INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
       fail();
     } catch (RuntimeException e) {
       assertThat(e.getMessage()).contains("not authorized");
@@ -391,7 +391,7 @@ public class CoreSocketFactoryTest {
     // Enough time has passed that cached exception should be ignored.
     when(mockClock.now()).thenReturn(61 * 1000L);
     try {
-      sslSocketFactory.createSslSocket(INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
+      coreSocketFactory.createSslSocket(INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
       fail();
     } catch (RuntimeException e) {
       assertThat(e.getMessage()).contains("not authorized");
@@ -411,10 +411,10 @@ public class CoreSocketFactoryTest {
             new GoogleJsonResponseException(
                 new HttpResponseException.Builder(403, "Forbidden", new HttpHeaders()), details));
 
-    CoreSocketFactory sslSocketFactory =
+    CoreSocketFactory coreSocketFactory =
         new CoreSocketFactory(new Clock(), clientKeyPair, credential, adminApi, 3307);
     try {
-      sslSocketFactory.createSslSocket(INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
+      coreSocketFactory.createSslSocket(INSTANCE_CONNECTION_STRING, Arrays.asList("PRIMARY"));
       fail();
     } catch (RuntimeException e) {
       // TODO(berezv): should we throw something more specific than RuntimeException?

--- a/postgres/src/main/java/com/google/cloud/sql/postgres/SocketFactory.java
+++ b/postgres/src/main/java/com/google/cloud/sql/postgres/SocketFactory.java
@@ -18,7 +18,7 @@ package com.google.cloud.sql.postgres;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import com.google.cloud.sql.core.SslSocketFactory;
+import com.google.cloud.sql.core.CoreSocketFactory;
 import java.io.File;
 import java.io.IOException;
 import java.net.InetAddress;
@@ -33,7 +33,7 @@ import jnr.unixsocket.UnixSocketChannel;
  * A Postgres {@link SocketFactory} that establishes a secure connection to a Cloud SQL instance
  * using ephemeral certificates.
  *
- * <p>The heavy lifting is done by the singleton {@link SslSocketFactory} class.
+ * <p>The heavy lifting is done by the singleton {@link CoreSocketFactory} class.
  */
 public class SocketFactory extends javax.net.SocketFactory {
 
@@ -58,8 +58,8 @@ public class SocketFactory extends javax.net.SocketFactory {
             + "the connection Properties with value in form \"project:region:instance\"");
 
     this.ipTypes =
-        SslSocketFactory.listIpTypes(
-            info.getProperty(IP_TYPES_KEY, SslSocketFactory.DEFAULT_IP_TYPES));
+        CoreSocketFactory.listIpTypes(
+            info.getProperty(IP_TYPES_KEY, CoreSocketFactory.DEFAULT_IP_TYPES));
   }
 
   @Deprecated
@@ -90,7 +90,7 @@ public class SocketFactory extends javax.net.SocketFactory {
     // Default to SSL Socket
     logger.info(
         String.format("Connecting to Cloud SQL instance [%s] via ssl socket.", instanceName));
-    return SslSocketFactory.getInstance().create(instanceName, ipTypes);
+    return CoreSocketFactory.getInstance().create(instanceName, ipTypes);
   }
 
   @Override

--- a/postgres/src/main/java/com/google/cloud/sql/postgres/SocketFactory.java
+++ b/postgres/src/main/java/com/google/cloud/sql/postgres/SocketFactory.java
@@ -16,18 +16,12 @@
 
 package com.google.cloud.sql.postgres;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 import com.google.cloud.sql.core.CoreSocketFactory;
-import java.io.File;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.Socket;
-import java.util.List;
 import java.util.Properties;
 import java.util.logging.Logger;
-import jnr.unixsocket.UnixSocketAddress;
-import jnr.unixsocket.UnixSocketChannel;
 
 /**
  * A Postgres {@link SocketFactory} that establishes a secure connection to a Cloud SQL instance
@@ -39,27 +33,25 @@ public class SocketFactory extends javax.net.SocketFactory {
 
   private static final Logger logger = Logger.getLogger(SocketFactory.class.getName());
 
-  private static final String CLOUD_SQL_PREFIX = "/cloudsql/";
-  private static final String POSTGRES_SUFFIX = "/.s.PGSQL.5432";
+  private static final String DEPRECATED_SOCKET_ARG = "SocketFactoryArg";
 
-  private static final String INSTANCE_PROPERTY_KEY = "cloudSqlInstance";
-  private static final String IP_TYPES_KEY = "ipTypes";
+  private Properties props;
 
-  private final String instanceName;
-  private final List<String> ipTypes;
-
-  // TODO(kurtisvg): add more details to this javadoc.
-  /** Implements the SocketFactory constructor for the postgres connector. */
+  /**
+   * Implements the {@link SocketFactory} constructor, which can be used to create authenticated
+   * connections to a Cloud SQL instance.
+   */
   public SocketFactory(Properties info) {
-    this.instanceName = info.getProperty(INSTANCE_PROPERTY_KEY);
-    checkArgument(
-        this.instanceName != null,
-        "cloudSqlInstance property not set. Please specify this property in the JDBC URL or "
-            + "the connection Properties with value in form \"project:region:instance\"");
-
-    this.ipTypes =
-        CoreSocketFactory.listIpTypes(
-            info.getProperty(IP_TYPES_KEY, CoreSocketFactory.DEFAULT_IP_TYPES));
+    String oldInstanceKey = info.getProperty(DEPRECATED_SOCKET_ARG);
+    if (oldInstanceKey != null) {
+      logger.warning(
+          String.format(
+              "The '%s' property has been deprecated. Please update your postgres driver and use"
+                  + "the  '%s' property in your JDBC url instead.",
+              DEPRECATED_SOCKET_ARG, CoreSocketFactory.CLOUD_SQL_INSTANCE_PROPERTY));
+      info.setProperty(CoreSocketFactory.CLOUD_SQL_INSTANCE_PROPERTY, oldInstanceKey);
+    }
+    this.props = info;
   }
 
   @Deprecated
@@ -70,27 +62,14 @@ public class SocketFactory extends javax.net.SocketFactory {
 
   private static Properties createDefaultProperties(String instanceName) {
     Properties info = new Properties();
-    info.setProperty(INSTANCE_PROPERTY_KEY, instanceName);
+    info.setProperty(DEPRECATED_SOCKET_ARG, instanceName);
     return info;
   }
 
   @Override
   public Socket createSocket() throws IOException {
-    // Custom env variable for forcing unix socket
-    boolean forceUnixSocket = System.getenv("CLOUD_SQL_FORCE_UNIX_SOCKET") != null;
-
-    // If running on GAE Standard, connect with unix socket
-    if (forceUnixSocket || runningOnGaeStandard()) {
-      logger.info(
-          String.format("Connecting to Cloud SQL instance [%s] via unix socket.", instanceName));
-      UnixSocketAddress socketAddress =
-          new UnixSocketAddress(new File(CLOUD_SQL_PREFIX + instanceName + POSTGRES_SUFFIX));
-      return UnixSocketChannel.open(socketAddress).socket();
-    }
-    // Default to SSL Socket
-    logger.info(
-        String.format("Connecting to Cloud SQL instance [%s] via ssl socket.", instanceName));
-    return CoreSocketFactory.getInstance().createSslSocket(instanceName, ipTypes);
+    return CoreSocketFactory.getInstance()
+        .connect(props, CoreSocketFactory.POSTGRES_SOCKET_FILE_FORMAT);
   }
 
   @Override
@@ -113,19 +92,5 @@ public class SocketFactory extends javax.net.SocketFactory {
   public Socket createSocket(InetAddress address, int port, InetAddress localAddress, int localPort)
       throws IOException {
     throw new UnsupportedOperationException();
-  }
-
-  /** Returns {@code true} if running in a Google App Engine Standard runtime. */
-  // TODO(kurtisvg) move this check into a shared class
-  private boolean runningOnGaeStandard() {
-    // gaeEnv="standard" indicates standard instances
-    String gaeEnv = System.getenv("GAE_ENV");
-    // runEnv="Production" requires to rule out Java 8 emulated environments
-    String runEnv = System.getProperty("com.google.appengine.runtime.environment");
-    // gaeRuntime="java11" in Java 11 environments (no emulated environments)
-    String gaeRuntime = System.getenv("GAE_RUNTIME");
-
-    return "standard".equals(gaeEnv)
-        && ("Production".equals(runEnv) || "java11".equals(gaeRuntime));
   }
 }

--- a/postgres/src/main/java/com/google/cloud/sql/postgres/SocketFactory.java
+++ b/postgres/src/main/java/com/google/cloud/sql/postgres/SocketFactory.java
@@ -90,7 +90,7 @@ public class SocketFactory extends javax.net.SocketFactory {
     // Default to SSL Socket
     logger.info(
         String.format("Connecting to Cloud SQL instance [%s] via ssl socket.", instanceName));
-    return CoreSocketFactory.getInstance().create(instanceName, ipTypes);
+    return CoreSocketFactory.getInstance().createSslSocket(instanceName, ipTypes);
   }
 
   @Override


### PR DESCRIPTION
Consolidates the "connect" function logic from being implemented in each Factory into the core Socket Factory. 

Notable changes:
* Renamed core "SslSocketFactory" to "CoreSocketFactory" to better reflect it now returns multiple types of sockets
* Renamed the "create" function to "createSslSocketFactory"
* Implemented a new "create" function containing the ssl/unix socket determination and implemented in each factory 
* As a side effect, cleaned up the way "SocketFactoryArg" deprecation was handled that fixes #113