### PR TITLE
Using google-auth-library-oauth2-http to get default credentials

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -27,6 +27,12 @@
     </dependency>
 
     <dependency>
+      <groupId>com.google.auth</groupId>
+      <artifactId>google-auth-library-oauth2-http</artifactId>
+      <version>0.16.2</version>
+    </dependency>
+
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.12</version>

--- a/core/src/main/java/com/google/cloud/sql/CredentialFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/CredentialFactory.java
@@ -17,11 +17,12 @@
 package com.google.cloud.sql;
 
 import com.google.api.client.auth.oauth2.Credential;
+import com.google.api.client.http.HttpRequestInitializer;
 
 /** Factory for creating {@link Credential}s for interaction with Cloud SQL Admin API. */
 public interface CredentialFactory {
   /** Name of system property that can specify an alternative credential factory. */
   String CREDENTIAL_FACTORY_PROPERTY = "cloudSql.socketFactory.credentialFactory";
 
-  Credential create();
+  HttpRequestInitializer create();
 }

--- a/core/src/test/java/com/google/cloud/sql/core/CoreSocketFactoryTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/CoreSocketFactoryTest.java
@@ -176,7 +176,7 @@ public class CoreSocketFactoryTest {
   @Test
   public void create_throwsErrorForInvalidInstanceName() throws IOException {
     CoreSocketFactory coreSocketFactory =
-        new CoreSocketFactory(clientKeyPair, credential, adminApi, 3307, defaultExecutor);
+        new CoreSocketFactory(clientKeyPair, adminApi, 3307, defaultExecutor);
     try {
       coreSocketFactory.createSslSocket("myProject", Arrays.asList("PRIMARY"));
       fail();
@@ -195,7 +195,7 @@ public class CoreSocketFactoryTest {
   @Test
   public void create_throwsErrorForInvalidInstanceRegion() throws IOException {
     CoreSocketFactory coreSocketFactory =
-        new CoreSocketFactory(clientKeyPair, credential, adminApi, 3307, defaultExecutor);
+        new CoreSocketFactory(clientKeyPair, adminApi, 3307, defaultExecutor);
     try {
       coreSocketFactory.createSslSocket(
           "myProject:notMyRegion:myInstance", Arrays.asList("PRIMARY"));
@@ -218,7 +218,7 @@ public class CoreSocketFactoryTest {
     int port = sslServer.start(PRIVATE_IP);
 
     CoreSocketFactory coreSocketFactory =
-        new CoreSocketFactory(clientKeyPair, credential, adminApi, port, defaultExecutor);
+        new CoreSocketFactory(clientKeyPair, adminApi, port, defaultExecutor);
     Socket socket =
         coreSocketFactory.createSslSocket(
             "myProject:myRegion:myInstance", Arrays.asList("PRIVATE"));
@@ -240,7 +240,7 @@ public class CoreSocketFactoryTest {
     int port = sslServer.start();
 
     CoreSocketFactory coreSocketFactory =
-        new CoreSocketFactory(clientKeyPair, credential, adminApi, port, defaultExecutor);
+        new CoreSocketFactory(clientKeyPair, adminApi, port, defaultExecutor);
     Socket socket =
         coreSocketFactory.createSslSocket(
             "myProject:myRegion:myInstance", Arrays.asList("PRIMARY"));
@@ -272,7 +272,7 @@ public class CoreSocketFactoryTest {
         .thenReturn(new SslCert().setCert(createEphemeralCert(Duration.ofMinutes(65))));
 
     CoreSocketFactory coreSocketFactory =
-        new CoreSocketFactory(clientKeyPair, credential, adminApi, port, defaultExecutor);
+        new CoreSocketFactory(clientKeyPair, adminApi, port, defaultExecutor);
     Socket socket =
         coreSocketFactory.createSslSocket(
             "myProject:myRegion:myInstance", Arrays.asList("PRIMARY"));
@@ -294,7 +294,7 @@ public class CoreSocketFactoryTest {
     int port = sslServer.start();
 
     CoreSocketFactory coreSocketFactory =
-        new CoreSocketFactory(clientKeyPair, credential, adminApi, port, defaultExecutor);
+        new CoreSocketFactory(clientKeyPair, adminApi, port, defaultExecutor);
     coreSocketFactory.createSslSocket("myProject:myRegion:myInstance", Arrays.asList("PRIMARY"));
 
     verify(adminApiInstances).get("myProject", "myInstance");
@@ -311,7 +311,7 @@ public class CoreSocketFactoryTest {
   @Test
   public void create_adminApiNotEnabled() throws IOException {
     CoreSocketFactory coreSocketFactory =
-        new CoreSocketFactory(clientKeyPair, credential, adminApi, 3307, defaultExecutor);
+        new CoreSocketFactory(clientKeyPair, adminApi, 3307, defaultExecutor);
     try {
       // Use a different project to get Api Not Enabled Error.
       coreSocketFactory.createSslSocket(
@@ -331,7 +331,7 @@ public class CoreSocketFactoryTest {
   @Test
   public void create_notAuthorized() throws IOException {
     CoreSocketFactory coreSocketFactory =
-        new CoreSocketFactory(clientKeyPair, credential, adminApi, 3307, defaultExecutor);
+        new CoreSocketFactory(clientKeyPair, adminApi, 3307, defaultExecutor);
     try {
       // Use a different instance to simulate incorrect permissions.
       coreSocketFactory.createSslSocket(


### PR DESCRIPTION
This should enable use of [Workload Identities](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) on GKE, which requires [this fix](https://github.com/googleapis/google-auth-library-java/pull/283) included in google-auth-library-oauth2-http 0.16.2

The solution isn't terribly beautiful but it seemed like a simple way to do it while maintaining backwards compatibility.