### PR TITLE
Update TravisCI to openjdk.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk8
+  - openjdk10
+  - openjdk11
 


### PR DESCRIPTION
Travis CI has switch the default build environment, which means that `oraclejdk8` is no longer available. Switching to openjdk and adding a few other supported versions. 