### PR TITLE
Release v1.0.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ are unsure, it is recommended to use the latest version of `mysql-connector-java
 
 | JDBC Driver Version        | Cloud SQL Socket Factory Version         |
 | -------------------------- | ---------------------------------------- |
-| mysql-connector-java:8.x   | mysql-socket-factory-connector-j-8:1.0.14 |
-| mysql-connector-java:6.x   | mysql-socket-factory-connector-j-6:1.0.14 |
-| mysql-connector-java:5.1.x | mysql-socket-factory:1.0.14              |
+| mysql-connector-java:8.x   | mysql-socket-factory-connector-j-8:1.0.15 |
+| mysql-connector-java:6.x   | mysql-socket-factory-connector-j-6:1.0.15 |
+| mysql-connector-java:5.1.x | mysql-socket-factory:1.0.15              |
 
 
 ##### Maven
@@ -46,14 +46,14 @@ Include the following in the project's `pom.xml`:
 <dependency>
     <groupId>com.google.cloud.sql</groupId>
     <artifactId>mysql-socket-factory-connector-j-8</artifactId>
-    <version>1.0.14</version>
+    <version>1.0.15</version>
 </dependency>
 ```
 
 ##### Gradle
 Include the following the project's `gradle.build`
 ```gradle
-compile 'com.google.cloud.sql:mysql-socket-factory-connector-j-8:1.0.14'
+compile 'com.google.cloud.sql:mysql-socket-factory-connector-j-8:1.0.15'
 ```
 
 #### PostgreSQL
@@ -64,14 +64,14 @@ Include the following in the project's `pom.xml`:
 <dependency>
     <groupId>com.google.cloud.sql</groupId>
     <artifactId>postgres-socket-factory</artifactId>
-    <version>1.0.14</version>
+    <version>1.0.15</version>
 </dependency>
 ```
 
 #### Gradle
 Include the following the project's `gradle.build`
 ```gradle
-compile 'com.google.cloud.sql:postgres-socket-factory:1.0.14'
+compile 'com.google.cloud.sql:postgres-socket-factory:1.0.15'
 ```
 
 

--- a/connector-j-5/pom.xml
+++ b/connector-j-5/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.google.cloud.sql</groupId>
     <artifactId>jdbc-socket-factory-parent</artifactId>
-    <version>1.0.15-SNAPSHOT</version>
+    <version>1.0.15</version>
   </parent>
   <artifactId>mysql-socket-factory</artifactId>
   <packaging>jar</packaging>
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>com.google.cloud.sql</groupId>
       <artifactId>jdbc-socket-factory-core</artifactId>
-      <version>1.0.15-SNAPSHOT</version>
+      <version>1.0.15</version>
     </dependency>
   </dependencies>
 

--- a/connector-j-5/pom.xml
+++ b/connector-j-5/pom.xml
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>mysql</groupId>
       <artifactId>mysql-connector-java</artifactId>
-      <version>5.1.47</version>
+      <version>5.1.48</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/connector-j-6/pom.xml
+++ b/connector-j-6/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.google.cloud.sql</groupId>
     <artifactId>jdbc-socket-factory-parent</artifactId>
-    <version>1.0.15-SNAPSHOT</version>
+    <version>1.0.15</version>
   </parent>
   <artifactId>mysql-socket-factory-connector-j-6</artifactId>
   <packaging>jar</packaging>
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>com.google.cloud.sql</groupId>
       <artifactId>jdbc-socket-factory-core</artifactId>
-      <version>1.0.15-SNAPSHOT</version>
+      <version>1.0.15</version>
     </dependency>
   </dependencies>
 

--- a/connector-j-8/pom.xml
+++ b/connector-j-8/pom.xml
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>mysql</groupId>
       <artifactId>mysql-connector-java</artifactId>
-      <version>8.0.16</version>
+      <version>8.0.17</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/connector-j-8/pom.xml
+++ b/connector-j-8/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.google.cloud.sql</groupId>
     <artifactId>jdbc-socket-factory-parent</artifactId>
-    <version>1.0.15-SNAPSHOT</version>
+    <version>1.0.15</version>
   </parent>
   <artifactId>mysql-socket-factory-connector-j-8</artifactId>
   <packaging>jar</packaging>
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>com.google.cloud.sql</groupId>
       <artifactId>jdbc-socket-factory-core</artifactId>
-      <version>1.0.15-SNAPSHOT</version>
+      <version>1.0.15</version>
     </dependency>
   </dependencies>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -23,13 +23,13 @@
     <dependency>
       <groupId>com.google.apis</groupId>
       <artifactId>google-api-services-sqladmin</artifactId>
-      <version>v1beta4-rev20190510-1.28.0</version>
+      <version>v1beta4-rev20190607-1.30.1</version>
     </dependency>
 
     <dependency>
       <groupId>com.google.auth</groupId>
       <artifactId>google-auth-library-oauth2-http</artifactId>
-      <version>0.16.2</version>
+      <version>0.17.1</version>
     </dependency>
 
     <dependency>
@@ -42,14 +42,14 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>2.28.2</version>
+      <version>3.0.0</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
-      <version>0.45</version>
+      <version>1.0</version>
       <scope>test</scope>
     </dependency>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.google.cloud.sql</groupId>
     <artifactId>jdbc-socket-factory-parent</artifactId>
-    <version>1.0.15-SNAPSHOT</version>
+    <version>1.0.15</version>
   </parent>
   <artifactId>jdbc-socket-factory-core</artifactId>
   <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <groupId>com.google.cloud.sql</groupId>
   <artifactId>jdbc-socket-factory-parent</artifactId>
   <packaging>pom</packaging>
-  <version>1.0.15-SNAPSHOT</version>
+  <version>1.0.15</version>
 
   <name>Cloud SQL JDBC Socket Factory</name>
   <description>

--- a/postgres/pom.xml
+++ b/postgres/pom.xml
@@ -24,7 +24,7 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>42.2.5</version>
+      <version>42.2.6</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/postgres/pom.xml
+++ b/postgres/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.google.cloud.sql</groupId>
     <artifactId>jdbc-socket-factory-parent</artifactId>
-    <version>1.0.15-SNAPSHOT</version>
+    <version>1.0.15</version>
   </parent>
 
   <artifactId>postgres-socket-factory</artifactId>
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>com.google.cloud.sql</groupId>
       <artifactId>jdbc-socket-factory-core</artifactId>
-      <version>1.0.15-SNAPSHOT</version>
+      <version>1.0.15</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
## Release Notes
* Improved initial start-up time:
  * Generate the initial RSA key pair asynchronously. (#142)
  * Remove static call on instance for Postgres. (#146)
* Now uses `google-auth-library-oauth2-http` to get default credentials (#151)