### PR TITLE
Added a profile to each module for building the JDBC driver JARs with…

### DIFF
--- a/connector-j-5/pom.xml
+++ b/connector-j-5/pom.xml
@@ -33,4 +33,17 @@
     </dependency>
   </dependencies>
 
+  <profiles>
+    <profile>
+      <id>jar-with-dependencies</id>
+      <dependencies>
+        <dependency>
+          <groupId>mysql</groupId>
+          <artifactId>mysql-connector-java</artifactId>
+          <version>5.1.48</version>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
+
 </project>

--- a/connector-j-6/pom.xml
+++ b/connector-j-6/pom.xml
@@ -33,4 +33,17 @@
     </dependency>
   </dependencies>
 
+  <profiles>
+    <profile>
+      <id>jar-with-dependencies</id>
+      <dependencies>
+        <dependency>
+          <groupId>mysql</groupId>
+          <artifactId>mysql-connector-java</artifactId>
+          <version>6.0.6</version>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
+
 </project>

--- a/connector-j-8/pom.xml
+++ b/connector-j-8/pom.xml
@@ -33,4 +33,17 @@
     </dependency>
   </dependencies>
 
+  <profiles>
+    <profile>
+      <id>jar-with-dependencies</id>
+      <dependencies>
+        <dependency>
+          <groupId>mysql</groupId>
+          <artifactId>mysql-connector-java</artifactId>
+          <version>8.0.17</version>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -209,6 +209,34 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>jar-with-dependencies</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-assembly-plugin</artifactId>
+            <version>2.4.1</version>
+            <configuration>
+              <!-- get all project dependencies -->
+              <descriptorRefs>
+                <descriptorRef>jar-with-dependencies</descriptorRef>
+              </descriptorRefs>
+            </configuration>
+            <executions>
+              <execution>
+                <id>make-assembly</id>
+                <!-- bind to the packaging phase -->
+                <phase>package</phase>
+                <goals>
+                  <goal>single</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 
 </project>

--- a/postgres/pom.xml
+++ b/postgres/pom.xml
@@ -9,7 +9,6 @@
     <artifactId>jdbc-socket-factory-parent</artifactId>
     <version>1.0.15</version>
   </parent>
-
   <artifactId>postgres-socket-factory</artifactId>
   <packaging>jar</packaging>
 
@@ -33,5 +32,18 @@
       <version>1.0.15</version>
     </dependency>
   </dependencies>
+
+  <profiles>
+    <profile>
+      <id>jar-with-dependencies</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.postgresql</groupId>
+          <artifactId>postgresql</artifactId>
+          <version>42.2.6</version>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
 
 </project>


### PR DESCRIPTION
… the socket factory dependencies.

In this PR you'll find the addition of a profile for building a fat JAR with the Socket Factory  dependency for each driver module.  All the drivers can be built with a single Maven command.

This modification is required to support Google Data Fusion (CDAP).  Data Fusion requires the Socket Factory dependency in the JDBC drivers in order to connect to Cloud SQL from Wrangler for ad-hoc DB access and Dataproc for executing pipelines.

For instruction on how this PR would be used with Data Fusion and CDAP refer to the following blog article: https://medium.com/cdapio/cloud-databases-cdap-a4f77f02ec95