### PR TITLE
Configure Renovate to ignore mysql-connector-java updates.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,12 @@
   "extends": [
     "config:base"
   ],
+  "packageRules": [
+    {
+      "packageNames":[ "mysql:mysql-connector-java" ],
+      "enabled": false
+    }
+  ],
   "prConcurrentLimit": 0,
   "rebaseStalePrs": true,
   "masterIssue": true


### PR DESCRIPTION
These versions need to be pinned to the major version for each different major package. 