### PR TITLE
Improve handling of connections through unix domain sockets. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,9 +160,16 @@ this purpose.
  
 ### Connection via Unix Sockets
 
-The library will automatically detect when it is running on GAE Standard, and will connect via the 
- provided unix socket for reduced latency.
+To connect using a Unix domain socket (such as created by the Cloud SQL proxy), 
+you can use the `"unixSocketPath"` property to specify a path to a local file 
+instead of connecting directly over TCP.
 
-To force the library to connect to a unix socket (typically created by the Cloud SQL proxy) when 
-running outside of the GAE-Standard environment, set the environment variable 
-`CLOUD_SQL_FORCE_UNIX_SOCKET` to any value.
+Example using MySQL:
+```
+jdbc:mysql:///<DATABASE_NAME>?unixSocketPath=</PATH/TO/UNIX/SOCKET>&cloudSqlInstance=<INSTANCE_CONNECTION_NAME>&socketFactory=com.google.cloud.sql.mysql.SocketFactory&user=<MYSQL_USER_NAME>&password=<MYSQL_USER_PASSWORD>
+```
+
+Example using PostgreSQL:
+```
+jdbc:postgresql:///<DATABASE_NAME>?unixSocketPath=</PATH/TO/UNIX/SOCKET>&cloudSqlInstance=<INSTANCE_CONNECTION_NAME>&socketFactory=com.google.cloud.sql.postgres.SocketFactory&user=<POSTGRESQL_USER_NAME>&password=<POSTGRESQL_USER_PASSWORD>
+```

--- a/README.md
+++ b/README.md
@@ -160,9 +160,9 @@ this purpose.
  
 ### Connection via Unix Sockets
 
-To connect using a Unix domain socket (such as created by the Cloud SQL proxy), 
-you can use the `"unixSocketPath"` property to specify a path to a local file 
-instead of connecting directly over TCP.
+To connect using a Unix domain socket (such as the one created by the Cloud SQL 
+proxy), you can use the `unixSocketPath` property to specify a path to a local 
+file instead of connecting directly over TCP.
 
 Example using MySQL:
 ```

--- a/connector-j-5/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
+++ b/connector-j-5/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
@@ -33,7 +33,6 @@ public class SocketFactory implements com.mysql.jdbc.SocketFactory {
 
   @Override
   public Socket connect(String hostname, int portNumber, Properties props) throws IOException {
-    CoreSocketFactory.migrateForceSocketVarToProperty(props);
     socket = CoreSocketFactory.connect(props);
     return socket;
   }

--- a/connector-j-5/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
+++ b/connector-j-5/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
@@ -33,7 +33,8 @@ public class SocketFactory implements com.mysql.jdbc.SocketFactory {
 
   @Override
   public Socket connect(String hostname, int portNumber, Properties props) throws IOException {
-    socket = CoreSocketFactory.connect(props, CoreSocketFactory.MYSQL_SOCKET_FILE_FORMAT);
+    CoreSocketFactory.migrateForceSocketVarToProperty(props);
+    socket = CoreSocketFactory.connect(props);
     return socket;
   }
 

--- a/connector-j-6/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
+++ b/connector-j-6/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
@@ -34,7 +34,8 @@ public class SocketFactory implements com.mysql.cj.api.io.SocketFactory {
   @Override
   public Socket connect(String host, int portNumber, Properties props, int loginTimeout)
       throws IOException {
-    socket = CoreSocketFactory.connect(props, CoreSocketFactory.MYSQL_SOCKET_FILE_FORMAT);
+    CoreSocketFactory.migrateForceSocketVarToProperty(props);
+    socket = CoreSocketFactory.connect(props);
     return socket;
   }
 

--- a/connector-j-6/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
+++ b/connector-j-6/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
@@ -34,7 +34,6 @@ public class SocketFactory implements com.mysql.cj.api.io.SocketFactory {
   @Override
   public Socket connect(String host, int portNumber, Properties props, int loginTimeout)
       throws IOException {
-    CoreSocketFactory.migrateForceSocketVarToProperty(props);
     socket = CoreSocketFactory.connect(props);
     return socket;
   }

--- a/connector-j-8/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
+++ b/connector-j-8/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
@@ -44,7 +44,6 @@ public class SocketFactory implements com.mysql.cj.protocol.SocketFactory {
    */
   public <T extends Closeable> T connect(
       String host, int portNumber, Properties props, int loginTimeout) throws IOException {
-    CoreSocketFactory.migrateForceSocketVarToProperty(props);
     @SuppressWarnings("unchecked")
     T socket = (T) CoreSocketFactory.connect(props);
     return socket;

--- a/connector-j-8/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
+++ b/connector-j-8/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
@@ -44,8 +44,9 @@ public class SocketFactory implements com.mysql.cj.protocol.SocketFactory {
    */
   public <T extends Closeable> T connect(
       String host, int portNumber, Properties props, int loginTimeout) throws IOException {
+    CoreSocketFactory.migrateForceSocketVarToProperty(props);
     @SuppressWarnings("unchecked")
-    T socket = (T) CoreSocketFactory.connect(props, CoreSocketFactory.MYSQL_SOCKET_FILE_FORMAT);
+    T socket = (T) CoreSocketFactory.connect(props);
     return socket;
   }
 

--- a/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
@@ -116,7 +116,7 @@ public final class CoreSocketFactory {
                   + " '%s=\"/cloudsql/INSTANCE_CONNECTION_NAME\"' property in your JDBC url"
                   + " instead.",
               UNIX_SOCKET_PROPERTY));
-      if (prop.get(UNIX_SOCKET_PROPERTY) != null) {
+      if (prop.getProperty(UNIX_SOCKET_PROPERTY) != null) {
         String instanceName = prop.getProperty(CLOUD_SQL_INSTANCE_PROPERTY, "");
         prop.setProperty(UNIX_SOCKET_PROPERTY, "/cloudsql/" + instanceName);
       }

--- a/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
@@ -63,7 +63,7 @@ import jnr.unixsocket.UnixSocketChannel;
  */
 public final class CoreSocketFactory {
   public static final String CLOUD_SQL_INSTANCE_PROPERTY = "cloudSqlInstance";
-  public static final String UNIX_SOCKET_PROPERTY = "unixSocket";
+  public static final String UNIX_SOCKET_PROPERTY = "unixSocketPath";
 
   /**
    * Property used to set the application name for the underlying SQLAdmin client.

--- a/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
@@ -63,7 +63,7 @@ import jnr.unixsocket.UnixSocketChannel;
  */
 public final class CoreSocketFactory {
   public static final String CLOUD_SQL_INSTANCE_PROPERTY = "cloudSqlInstance";
-  public static final String UNIX_SOCKET_PROPERTY = "unixSocketPath";
+  private static final String UNIX_SOCKET_PROPERTY = "unixSocketPath";
 
   /**
    * Property used to set the application name for the underlying SQLAdmin client.
@@ -170,8 +170,6 @@ public final class CoreSocketFactory {
 
   /**
    * Creates a socket representing a connection to a Cloud SQL instance.
-   *
-   * @see CoreSocketFactory#connect(Properties, String)
    */
   public static Socket connect(Properties props) throws IOException {
     return connect(props, null);
@@ -183,14 +181,13 @@ public final class CoreSocketFactory {
    * <p>Depending on the given properties, it may return either a SSL Socket or a Unix Socket.
    *
    * @param props Properties used to configure the connection.
-   * @param unixPathSuffix Optional suffix to add the the Unix socket path. Unused if null.
+   * @param unixPathSuffix suffix to add the the Unix socket path. Unused if null.
    * @return the newly created Socket.
    * @throws IOException if error occurs during socket creation.
    */
   public static Socket connect(Properties props, String unixPathSuffix) throws IOException {
     // Gather parameters
     final String csqlInstanceName = props.getProperty(CLOUD_SQL_INSTANCE_PROPERTY);
-    final List<String> ipTypes = listIpTypes(props.getProperty("ipTypes", DEFAULT_IP_TYPES));
 
     // Validate parameters
     Preconditions.checkArgument(
@@ -213,6 +210,7 @@ public final class CoreSocketFactory {
       return UnixSocketChannel.open(socketAddress).socket();
     }
 
+    final List<String> ipTypes = listIpTypes(props.getProperty("ipTypes", DEFAULT_IP_TYPES));
     logger.info(
         String.format("Connecting to Cloud SQL instance [%s] via SSL socket.", csqlInstanceName));
     return getInstance().createSslSocket(csqlInstanceName, ipTypes);

--- a/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
@@ -203,26 +203,6 @@ public final class CoreSocketFactory {
     return getInstance().createSslSocket(csqlInstanceName, ipTypes);
   }
 
-  /** Returns {@code true} if running in a Google App Engine Standard runtime. */
-  private static boolean runningOnGaeStandard() {
-    // gaeEnv="standard" indicates standard instances
-    String gaeEnv = System.getenv("GAE_ENV");
-    // runEnv="Production" requires to rule out Java 8 emulated environments
-    String runEnv = System.getProperty("com.google.appengine.runtime.environment");
-    // gaeRuntime="java11" in Java 11 environments (no emulated environments)
-    String gaeRuntime = System.getenv("GAE_RUNTIME");
-
-    return "standard".equals(gaeEnv)
-        && ("Production".equals(runEnv) || "java11".equals(gaeRuntime));
-  }
-
-  /** Returns {@code true} if running in a Google Cloud Functions runtime. */
-  private static boolean runningOnGoogleCloudFunctions() {
-    // Functions automatically sets a few variables we can use to guess the env:
-    // See https://cloud.google.com/functions/docs/env-var#nodejs_10_and_subsequent_runtimes
-    return System.getenv("K_SERVICE") != null && System.getenv("K_REVISION") != null;
-  }
-
   /**
    * Creates a secure socket representing a connection to a Cloud SQL instance.
    *

--- a/postgres/src/main/java/com/google/cloud/sql/postgres/SocketFactory.java
+++ b/postgres/src/main/java/com/google/cloud/sql/postgres/SocketFactory.java
@@ -52,13 +52,7 @@ public class SocketFactory extends javax.net.SocketFactory {
               DEPRECATED_SOCKET_ARG, CoreSocketFactory.CLOUD_SQL_INSTANCE_PROPERTY));
       info.setProperty(CoreSocketFactory.CLOUD_SQL_INSTANCE_PROPERTY, oldInstanceKey);
     }
-    CoreSocketFactory.migrateForceSocketVarToProperty(info);
 
-    // If unixSocket property is set, verify it ends with the correct suffix
-    String unixSocket = info.getProperty(CoreSocketFactory.UNIX_SOCKET_PROPERTY);
-    if (unixSocket != null && !unixSocket.endsWith(POSTGRES_SUFFIX)) {
-      info.setProperty(CoreSocketFactory.UNIX_SOCKET_PROPERTY, unixSocket + POSTGRES_SUFFIX);
-    }
     this.props = info;
   }
 
@@ -76,7 +70,7 @@ public class SocketFactory extends javax.net.SocketFactory {
 
   @Override
   public Socket createSocket() throws IOException {
-    return CoreSocketFactory.connect(props);
+    return CoreSocketFactory.connect(props, POSTGRES_SUFFIX);
   }
 
   @Override

--- a/postgres/src/main/java/com/google/cloud/sql/postgres/SocketFactory.java
+++ b/postgres/src/main/java/com/google/cloud/sql/postgres/SocketFactory.java
@@ -34,6 +34,7 @@ public class SocketFactory extends javax.net.SocketFactory {
   private static final Logger logger = Logger.getLogger(SocketFactory.class.getName());
 
   private static final String DEPRECATED_SOCKET_ARG = "SocketFactoryArg";
+  private static final String POSTGRES_SUFFIX = "/.s.PGSQL.5432";
 
   private Properties props;
 
@@ -50,6 +51,13 @@ public class SocketFactory extends javax.net.SocketFactory {
                   + "the  '%s' property in your JDBC url instead.",
               DEPRECATED_SOCKET_ARG, CoreSocketFactory.CLOUD_SQL_INSTANCE_PROPERTY));
       info.setProperty(CoreSocketFactory.CLOUD_SQL_INSTANCE_PROPERTY, oldInstanceKey);
+    }
+    CoreSocketFactory.migrateForceSocketVarToProperty(info);
+
+    // If unixSocket property is set, verify it ends with the correct suffix
+    String unixSocket = info.getProperty(CoreSocketFactory.UNIX_SOCKET_PROPERTY);
+    if (unixSocket != null && !unixSocket.endsWith(POSTGRES_SUFFIX)) {
+      info.setProperty(CoreSocketFactory.UNIX_SOCKET_PROPERTY, unixSocket + POSTGRES_SUFFIX);
     }
     this.props = info;
   }
@@ -68,7 +76,7 @@ public class SocketFactory extends javax.net.SocketFactory {
 
   @Override
   public Socket createSocket() throws IOException {
-    return CoreSocketFactory.connect(props, CoreSocketFactory.POSTGRES_SOCKET_FILE_FORMAT);
+    return CoreSocketFactory.connect(props);
   }
 
   @Override


### PR DESCRIPTION
- Adds new `unixSocket` property, which which can be used to specify a path to a unix socket that will connect to an instance
- Deprecates `"CLOUD_SQL_FORCE_UNIX_SOCKET"` env var in favor of the above property
- Disables the use of the `/cloudsql` unix socket by default when on GAE or GCF

Fixes #172