### PR TITLE
Release v1.0.16.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ are unsure, it is recommended to use the latest version of `mysql-connector-java
 
 | JDBC Driver Version        | Cloud SQL Socket Factory Version         |
 | -------------------------- | ---------------------------------------- |
-| mysql-connector-java:8.x   | mysql-socket-factory-connector-j-8:1.0.15 |
-| mysql-connector-java:6.x   | mysql-socket-factory-connector-j-6:1.0.15 |
-| mysql-connector-java:5.1.x | mysql-socket-factory:1.0.15              |
+| mysql-connector-java:8.x   | mysql-socket-factory-connector-j-8:1.0.16 |
+| mysql-connector-java:6.x   | mysql-socket-factory-connector-j-6:1.0.16 |
+| mysql-connector-java:5.1.x | mysql-socket-factory:1.0.16              |
 
 
 ##### Maven
@@ -46,14 +46,14 @@ Include the following in the project's `pom.xml`:
 <dependency>
     <groupId>com.google.cloud.sql</groupId>
     <artifactId>mysql-socket-factory-connector-j-8</artifactId>
-    <version>1.0.15</version>
+    <version>1.0.16</version>
 </dependency>
 ```
 
 ##### Gradle
 Include the following the project's `build.gradle`
 ```gradle
-compile 'com.google.cloud.sql:mysql-socket-factory-connector-j-8:1.0.15'
+compile 'com.google.cloud.sql:mysql-socket-factory-connector-j-8:1.0.16'
 ```
 
 #### PostgreSQL
@@ -64,14 +64,14 @@ Include the following in the project's `pom.xml`:
 <dependency>
     <groupId>com.google.cloud.sql</groupId>
     <artifactId>postgres-socket-factory</artifactId>
-    <version>1.0.15</version>
+    <version>1.0.16</version>
 </dependency>
 ```
 
 #### Gradle
 Include the following the project's `gradle.build`
 ```gradle
-compile 'com.google.cloud.sql:postgres-socket-factory:1.0.15'
+compile 'com.google.cloud.sql:postgres-socket-factory:1.0.16'
 ```
 
 
@@ -128,8 +128,8 @@ This will create a *target* sub-folder within each of the module directories. Wi
 
 Example:
 ```
-mysql-socket-factory-connector-j-8–1.0.15-jar-with-dependencies.jar
-postgres-socket-factory-1.0.15-jar-with-dependencies.jar
+mysql-socket-factory-connector-j-8–1.0.16-jar-with-dependencies.jar
+postgres-socket-factory-1.0.16-jar-with-dependencies.jar
 ```
 
 ---

--- a/connector-j-5/pom.xml
+++ b/connector-j-5/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.google.cloud.sql</groupId>
     <artifactId>jdbc-socket-factory-parent</artifactId>
-    <version>1.0.15</version>
+    <version>1.0.16</version>
   </parent>
   <artifactId>mysql-socket-factory</artifactId>
   <packaging>jar</packaging>
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>com.google.cloud.sql</groupId>
       <artifactId>jdbc-socket-factory-core</artifactId>
-      <version>1.0.15</version>
+      <version>1.0.16</version>
     </dependency>
   </dependencies>
 

--- a/connector-j-6/pom.xml
+++ b/connector-j-6/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.google.cloud.sql</groupId>
     <artifactId>jdbc-socket-factory-parent</artifactId>
-    <version>1.0.15</version>
+    <version>1.0.16</version>
   </parent>
   <artifactId>mysql-socket-factory-connector-j-6</artifactId>
   <packaging>jar</packaging>
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>com.google.cloud.sql</groupId>
       <artifactId>jdbc-socket-factory-core</artifactId>
-      <version>1.0.15</version>
+      <version>1.0.16</version>
     </dependency>
   </dependencies>
 

--- a/connector-j-8/pom.xml
+++ b/connector-j-8/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.google.cloud.sql</groupId>
     <artifactId>jdbc-socket-factory-parent</artifactId>
-    <version>1.0.15</version>
+    <version>1.0.16</version>
   </parent>
   <artifactId>mysql-socket-factory-connector-j-8</artifactId>
   <packaging>jar</packaging>
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>com.google.cloud.sql</groupId>
       <artifactId>jdbc-socket-factory-core</artifactId>
-      <version>1.0.15</version>
+      <version>1.0.16</version>
     </dependency>
   </dependencies>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.google.cloud.sql</groupId>
     <artifactId>jdbc-socket-factory-parent</artifactId>
-    <version>1.0.15</version>
+    <version>1.0.16</version>
   </parent>
   <artifactId>jdbc-socket-factory-core</artifactId>
   <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <groupId>com.google.cloud.sql</groupId>
   <artifactId>jdbc-socket-factory-parent</artifactId>
   <packaging>pom</packaging>
-  <version>1.0.15</version>
+  <version>1.0.16</version>
 
   <name>Cloud SQL JDBC Socket Factory</name>
   <description>

--- a/postgres/pom.xml
+++ b/postgres/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.google.cloud.sql</groupId>
     <artifactId>jdbc-socket-factory-parent</artifactId>
-    <version>1.0.15</version>
+    <version>1.0.16</version>
   </parent>
   <artifactId>postgres-socket-factory</artifactId>
   <packaging>jar</packaging>
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>com.google.cloud.sql</groupId>
       <artifactId>jdbc-socket-factory-core</artifactId>
-      <version>1.0.15</version>
+      <version>1.0.16</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
## Release notes

- Several improvements to unix socket handling (#210):
  - Added support for new `unixSocket` property, which can be used to specify a path to a unix socket instead of connecting over TCP
  - Configuring with the `CLOUD_SQL_FORCE_UNIX_SOCKET` env var has been deprecated. Please set the `unixSocket` property to `/cloudsql/INSTANCE_CONNECTION_NAME` in your config instead. 
  - Automatic enabling of use of the `/cloudsql/` Unix domain socket when running in Google App Engine and Google Cloud Function environments has been disabled. The recommended way to connect is to continue to use TCP connections, but the behavior can be replicated using the `unixSocket` property listed above. 
- Added support for project ids that are using the legacy "domain-scoped" format (#209)