### PR TITLE
chore: added rule for guava dependency in renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,10 @@
     {
       "packageNames":[ "mysql:mysql-connector-java" ],
       "enabled": false
+    },
+    {
+      "packageNames": ["com.google.guava:guava"],
+      "allowedVersions": "/.+-android/"
     }
   ],
   "prConcurrentLimit": 0,


### PR DESCRIPTION
## Change Description

Only updates guava dependency when new `-android` version is released, because `-jre` is incompatible with the dependencies (see #241 )