### PR TITLE
chore: moved r2dbc driver scope to provided and updated build profiles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -357,6 +357,8 @@
               <descriptorRefs>
                 <descriptorRef>jar-with-dependencies</descriptorRef>
               </descriptorRefs>
+              <finalName>${project.artifactId}-${project.version}-jar-with-driver-and-dependencies</finalName>
+              <appendAssemblyId>false</appendAssemblyId>
             </configuration>
             <executions>
               <execution>

--- a/r2dbc-mysql/pom.xml
+++ b/r2dbc-mysql/pom.xml
@@ -28,6 +28,7 @@
       <groupId>dev.miku</groupId>
       <artifactId>r2dbc-mysql</artifactId>
       <version>0.8.2.RELEASE</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.google.cloud.sql</groupId>
@@ -47,5 +48,18 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <profiles>
+    <profile>
+      <id>jar-with-driver-and-dependencies</id>
+      <dependencies>
+        <dependency>
+        <groupId>dev.miku</groupId>
+        <artifactId>r2dbc-mysql</artifactId>
+        <version>0.8.2.RELEASE</version>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
 
 </project>

--- a/r2dbc-postgres/pom.xml
+++ b/r2dbc-postgres/pom.xml
@@ -28,6 +28,7 @@
       <groupId>io.r2dbc</groupId>
       <artifactId>r2dbc-postgresql</artifactId>
       <version>0.8.5.RELEASE</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.google.cloud.sql</groupId>
@@ -47,6 +48,19 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <profiles>
+    <profile>
+      <id>jar-with-driver-and-dependencies</id>
+      <dependencies>
+        <dependency>
+          <groupId>io.r2dbc</groupId>
+          <artifactId>r2dbc-postgresql</artifactId>
+          <version>0.8.5.RELEASE</version>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
 
   <repositories>
 	  <repository>


### PR DESCRIPTION
## Change Description

* Move scope of r2dbc driver dependencies to provided
* Add r2dbc driver dependencies to `jar-with-driver-and-dependencies` profile
* Update filename for jars build with `jar-with-driver-and-dependencies` profile
