### PR TITLE
chore: tell release-please to create release tags

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,1 +1,2 @@
 releaseType: java-yoshi
+handleGHRelease: true


### PR DESCRIPTION
## Change Description

Adding [this line to the config](https://github.com/googleapis/repo-automation-bots/tree/master/packages/release-please#configuration) should get the release-please bot to automatically generate releases for us.