### PR TITLE
chore: use github action to tag releases

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,2 +1,1 @@
 releaseType: java-yoshi
-handleGHRelease: true

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -1,0 +1,27 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: release-please
+on:
+  push:
+    branches:
+      - master
+jobs:
+  release-please-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: GoogleCloudPlatform/release-please-action@v2.4.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          package-name: cloud-sql-connector-java


### PR DESCRIPTION
Updating our Release Please configuration to use the bot to generate PRs and the Github action to tag releases.