### PR TITLE
docs: add R2DBC connector info to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Include the following the project's `gradle.build`
 ```gradle
 compile 'com.google.cloud.sql:postgres-socket-factory:1.1.0'
 ```
+*Note: Also include the JDBC Driver for MySQL, `org.postgresql:postgresql:<LATEST-VERSION>`
 
 [//]: # ({x-version-update-end})
 
@@ -149,7 +150,7 @@ Include the following the project's `build.gradle`
 compile 'com.google.cloud.sql:cloud-sql-connector-r2dbc-mysql:1.1.0'
 ```
 
-*Note: Also include the R2DBC Driver for MySQL, `dev.miku:r2dbc-mysql:LATEST-VERSION`
+*Note: Also include the R2DBC Driver for MySQL, `dev.miku:r2dbc-mysql:<LATEST-VERSION>`
 
 #### PostgreSQL
 
@@ -167,7 +168,7 @@ Include the following the project's `build.gradle`
 ```gradle
 compile 'com.google.cloud.sql:cloud-sql-connector-r2dbc-postgres:1.1.0'
 ```
-*Note: Also include the R2DBC Driver for Postgres, `io.r2dbc:r2dbc-postgresql:LATEST-VERSION`
+*Note: Also include the R2DBC Driver for Postgres, `io.r2dbc:r2dbc-postgresql:<LATEST-VERSION>`
 
 [//]: # ({x-version-update-end})
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-## Cloud SQL Socket Factory for JDBC drivers
+## Cloud SQL Connector for Java
 [![Build
 Status](https://travis-ci.org/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory.svg?branch=master)](https://travis-ci.org/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory)
 
-The Cloud SQL Socket Factory is a library for the MySQL/Postgres JDBC drivers that allows a user 
+The Cloud SQL Connector for Java is a library for the MySQL/Postgres JDBC and R2DBC drivers that allows a user 
 with the appropriate permissions to connect to a Cloud SQL database without having to deal with IP 
 whitelisting or SSL certificates manually.
 
@@ -28,7 +28,7 @@ gcloud auth application-default login
 
 ### Add library as a dependency
 
-#### MySQL
+#### MySQL JDBC
 
 **Note**: Use your JDBC driver version to figure out which SocketFactory you should use. If you 
 are unsure, it is recommended to use the latest version of `mysql-connector-java:8.x`.
@@ -39,10 +39,10 @@ are unsure, it is recommended to use the latest version of `mysql-connector-java
 | mysql-connector-java:6.x   | mysql-socket-factory-connector-j-6:1.0.16 |
 | mysql-connector-java:5.1.x | mysql-socket-factory:1.0.16              |
 
+[//]: # ({x-version-update-start:cloud-sql-java-connector:released})
 
 ##### Maven
-Include the following in the project's `pom.xml`:
-[//]: # ({x-version-update-start:cloud-sql-java-connector:released})
+Include the following in the project's `pom.xml`: 
 ```maven-pom
 <dependency>
     <groupId>com.google.cloud.sql</groupId>
@@ -56,8 +56,31 @@ Include the following the project's `build.gradle`
 ```gradle
 compile 'com.google.cloud.sql:mysql-socket-factory-connector-j-8:1.1.0'
 ```
+#### MySQL R2DBC
 
-#### PostgreSQL
+##### Maven
+Include the following in the project's `pom.xml`: 
+```maven-pom
+    <dependency>
+      <groupId>com.google.cloud.sql</groupId>
+      <artifactId>cloud-sql-connector-r2dbc-mysql</artifactId>
+      <version>1.1.0</version>
+    </dependency>
+    <dependency>
+      <groupId>dev.miku</groupId>
+      <artifactId>r2dbc-mysql</artifactId>
+      <version>0.8.2.RELEASE</version>
+    </dependency>
+```
+
+##### Gradle
+Include the following the project's `build.gradle`
+```gradle
+compile 'com.google.cloud.sql:cloud-sql-connector-r2dbc-mysql:1.1.0'
+compile 'dev.miku:r2dbc-mysql:0.8.2.RELEASE'
+```
+
+#### PostgreSQL JDBC
 
 ##### Maven
 Include the following in the project's `pom.xml`:
@@ -74,7 +97,33 @@ Include the following the project's `gradle.build`
 ```gradle
 compile 'com.google.cloud.sql:postgres-socket-factory:1.1.0'
 ```
+
+#### PostgreSQL R2DBC
+Include the following in the project's `pom.xml`: 
+```maven-pom
+    <dependency>
+    <dependency>
+      <groupId>com.google.cloud.sql</groupId>
+      <artifactId>cloud-sql-connector-r2dbc-postgres</artifactId>
+      <version>1.1.0</version>
+    </dependency>
+    <dependency>
+      <groupId>io.r2dbc</groupId>
+      <artifactId>r2dbc-postgresql</artifactId>
+      <version>0.8.5.RELEASE</version>
+    </dependency>
+```
+
+##### Gradle
+Include the following the project's `build.gradle`
+```gradle
+compile 'com.google.cloud.sql:cloud-sql-connector-r2dbc-postgres:1.1.0'
+compile 'io.r2dbc:r2dbc-postgresql:0.8.5.RELEASE'
+```
+
 [//]: # ({x-version-update-end})
+
+---
 
 #### Creating the JDBC URL
 
@@ -117,6 +166,34 @@ jdbc:postgresql:///<DATABASE_NAME>?cloudSqlInstance=<INSTANCE_CONNECTION_NAME>&s
 ```
 
 Note: The host portion of the JDBC URL is currently unused, and has no effect on the connection process. The SocketFactory will get your instances IP address base on the provided `cloudSqlInstance` arg. 
+
+---
+#### Creating the R2DBC URL
+
+##### MySQL
+R2DBC URL template: `r2dbc:gcp:mysql//<DB_USER>:<DB_PASS>@<CLOUD_SQL_CONNECTION_NAME>/<DATABASE_NAME>`
+
+Add the following parameters:
+
+| Property         | Value         |
+| ---------------- | ------------- |
+| DATABASE_NAME   | The name of the database to connect to |
+| CLOUD_SQL_CONNECTION_NAME | The instance connection name (found on the instance details page) |
+| DB_USER         | MySQL username |
+| DB_PASS         | MySQL user's password |
+
+
+##### Postgres
+R2DBC URL template: `r2dbc:gcp:postgres//<DB_USER>:<DB_PASS>@<CLOUD_SQL_CONNECTION_NAME>/<DATABASE_NAME>`
+
+Add the following parameters:
+
+| Property         | Value         |
+| ---------------- | ------------- |
+| DATABASE_NAME   | The name of the database to connect to |
+| CLOUD_SQL_CONNECTION_NAME | The instance connection name (found on the instance details page) |
+| DB_USER         | Postgres username |
+| DB_PASS         | Postgres user's password |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -141,19 +141,15 @@ Include the following in the project's `pom.xml`:
       <artifactId>cloud-sql-connector-r2dbc-mysql</artifactId>
       <version>1.1.0</version>
     </dependency>
-    <dependency>
-      <groupId>dev.miku</groupId>
-      <artifactId>r2dbc-mysql</artifactId>
-      <version>0.8.2.RELEASE</version>
-    </dependency>
 ```
 
 ##### Gradle
 Include the following the project's `build.gradle`
 ```gradle
 compile 'com.google.cloud.sql:cloud-sql-connector-r2dbc-mysql:1.1.0'
-compile 'dev.miku:r2dbc-mysql:0.8.2.RELEASE'
 ```
+
+*Note: Also include the R2DBC Driver for MySQL, `dev.miku:r2dbc-mysql:LATEST-VERSION`
 
 #### PostgreSQL
 
@@ -161,23 +157,17 @@ compile 'dev.miku:r2dbc-mysql:0.8.2.RELEASE'
 Include the following in the project's `pom.xml`: 
 ```maven-pom
     <dependency>
-    <dependency>
       <groupId>com.google.cloud.sql</groupId>
       <artifactId>cloud-sql-connector-r2dbc-postgres</artifactId>
       <version>1.1.0</version>
-    </dependency>
-    <dependency>
-      <groupId>io.r2dbc</groupId>
-      <artifactId>r2dbc-postgresql</artifactId>
-      <version>0.8.5.RELEASE</version>
     </dependency>
 ```
 ##### Gradle
 Include the following the project's `build.gradle`
 ```gradle
 compile 'com.google.cloud.sql:cloud-sql-connector-r2dbc-postgres:1.1.0'
-compile 'io.r2dbc:r2dbc-postgresql:0.8.5.RELEASE'
 ```
+*Note: Also include the R2DBC Driver for Postgres, `io.r2dbc:r2dbc-postgresql:LATEST-VERSION`
 
 [//]: # ({x-version-update-end})
 

--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@ The Cloud SQL Connector for Java is a library for the MySQL/Postgres JDBC and R2
 with the appropriate permissions to connect to a Cloud SQL database without having to deal with IP 
 whitelisting or SSL certificates manually.
 
-## Instructions
 
-### Examples
+
+## Examples
 
 For examples of this library being used in the context of an application, check out the sample 
 applications located 
 [here](https://github.com/GoogleCloudPlatform/java-docs-samples/tree/master/cloud-sql).
 
-### Authentication
+## Authentication
 
 This library uses the [Application Default Credentials](
 https://developers.google.com/identity/protocols/application-default-credentials) to authenticate
@@ -25,10 +25,13 @@ command:
 ```bash
 gcloud auth application-default login
 ```
+---
+
+## Instructions for JDBC
 
 ### Add library as a dependency
 
-#### MySQL JDBC
+#### MySQL
 
 **Note**: Use your JDBC driver version to figure out which SocketFactory you should use. If you 
 are unsure, it is recommended to use the latest version of `mysql-connector-java:8.x`.
@@ -56,31 +59,8 @@ Include the following the project's `build.gradle`
 ```gradle
 compile 'com.google.cloud.sql:mysql-socket-factory-connector-j-8:1.1.0'
 ```
-#### MySQL R2DBC
 
-##### Maven
-Include the following in the project's `pom.xml`: 
-```maven-pom
-    <dependency>
-      <groupId>com.google.cloud.sql</groupId>
-      <artifactId>cloud-sql-connector-r2dbc-mysql</artifactId>
-      <version>1.1.0</version>
-    </dependency>
-    <dependency>
-      <groupId>dev.miku</groupId>
-      <artifactId>r2dbc-mysql</artifactId>
-      <version>0.8.2.RELEASE</version>
-    </dependency>
-```
-
-##### Gradle
-Include the following the project's `build.gradle`
-```gradle
-compile 'com.google.cloud.sql:cloud-sql-connector-r2dbc-mysql:1.1.0'
-compile 'dev.miku:r2dbc-mysql:0.8.2.RELEASE'
-```
-
-#### PostgreSQL JDBC
+#### PostgreSQL
 
 ##### Maven
 Include the following in the project's `pom.xml`:
@@ -98,32 +78,8 @@ Include the following the project's `gradle.build`
 compile 'com.google.cloud.sql:postgres-socket-factory:1.1.0'
 ```
 
-#### PostgreSQL R2DBC
-Include the following in the project's `pom.xml`: 
-```maven-pom
-    <dependency>
-    <dependency>
-      <groupId>com.google.cloud.sql</groupId>
-      <artifactId>cloud-sql-connector-r2dbc-postgres</artifactId>
-      <version>1.1.0</version>
-    </dependency>
-    <dependency>
-      <groupId>io.r2dbc</groupId>
-      <artifactId>r2dbc-postgresql</artifactId>
-      <version>0.8.5.RELEASE</version>
-    </dependency>
-```
-
-##### Gradle
-Include the following the project's `build.gradle`
-```gradle
-compile 'com.google.cloud.sql:cloud-sql-connector-r2dbc-postgres:1.1.0'
-compile 'io.r2dbc:r2dbc-postgresql:0.8.5.RELEASE'
-```
-
 [//]: # ({x-version-update-end})
 
----
 
 #### Creating the JDBC URL
 
@@ -168,6 +124,63 @@ jdbc:postgresql:///<DATABASE_NAME>?cloudSqlInstance=<INSTANCE_CONNECTION_NAME>&s
 Note: The host portion of the JDBC URL is currently unused, and has no effect on the connection process. The SocketFactory will get your instances IP address base on the provided `cloudSqlInstance` arg. 
 
 ---
+
+## Instructions for R2DBC
+
+### Add library as a dependency
+
+[//]: # ({x-version-update-start:cloud-sql-java-connector:released})
+
+#### MySQL
+
+##### Maven
+Include the following in the project's `pom.xml`: 
+```maven-pom
+    <dependency>
+      <groupId>com.google.cloud.sql</groupId>
+      <artifactId>cloud-sql-connector-r2dbc-mysql</artifactId>
+      <version>1.1.0</version>
+    </dependency>
+    <dependency>
+      <groupId>dev.miku</groupId>
+      <artifactId>r2dbc-mysql</artifactId>
+      <version>0.8.2.RELEASE</version>
+    </dependency>
+```
+
+##### Gradle
+Include the following the project's `build.gradle`
+```gradle
+compile 'com.google.cloud.sql:cloud-sql-connector-r2dbc-mysql:1.1.0'
+compile 'dev.miku:r2dbc-mysql:0.8.2.RELEASE'
+```
+
+#### PostgreSQL
+
+##### Maven
+Include the following in the project's `pom.xml`: 
+```maven-pom
+    <dependency>
+    <dependency>
+      <groupId>com.google.cloud.sql</groupId>
+      <artifactId>cloud-sql-connector-r2dbc-postgres</artifactId>
+      <version>1.1.0</version>
+    </dependency>
+    <dependency>
+      <groupId>io.r2dbc</groupId>
+      <artifactId>r2dbc-postgresql</artifactId>
+      <version>0.8.5.RELEASE</version>
+    </dependency>
+```
+##### Gradle
+Include the following the project's `build.gradle`
+```gradle
+compile 'com.google.cloud.sql:cloud-sql-connector-r2dbc-postgres:1.1.0'
+compile 'io.r2dbc:r2dbc-postgresql:0.8.5.RELEASE'
+```
+
+[//]: # ({x-version-update-end})
+
 #### Creating the R2DBC URL
 
 ##### MySQL


### PR DESCRIPTION
## Change Description

Added info on adding R2DBC connectors as dependencies and forming connection URLs. For now, I just included the info in existing sections, but we might want to think about reformatting this README.

## Relevant issues:

- Fixes #289