### PR TITLE
feat: use regionalized instance ids to prevent global conflicts with sqladmin v1

### DIFF
--- a/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstance.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstance.java
@@ -69,7 +69,7 @@ class CloudSqlInstance {
   private final String projectId;
   private final String regionId;
   private final String instanceId;
-  private final String prefixedInstanceId;
+  private final String regionalizedInstanceId;
   private final ListenableFuture<KeyPair> keyPair;
 
   private final Object instanceDataGuard = new Object();
@@ -106,7 +106,7 @@ class CloudSqlInstance {
     this.projectId = matcher.group(1);
     this.regionId = matcher.group(3);
     this.instanceId = matcher.group(4);
-    this.prefixedInstanceId = String.format("%s~%s", this.regionId, this.instanceId);
+    this.regionalizedInstanceId = String.format("%s~%s", this.regionId, this.instanceId);
 
     this.apiClient = apiClient;
     this.executor = executor;
@@ -281,7 +281,7 @@ class CloudSqlInstance {
   private Metadata fetchMetadata() {
     try {
       DatabaseInstance instanceMetadata =
-          apiClient.instances().get(projectId, prefixedInstanceId).execute();
+          apiClient.instances().get(projectId, regionalizedInstanceId).execute();
 
       // Validate the instance will support the authenticated connection.
       if (!instanceMetadata.getRegion().equals(regionId)) {
@@ -343,7 +343,7 @@ class CloudSqlInstance {
         new SslCertsCreateEphemeralRequest().setPublicKey(generatePublicKeyCert(keyPair));
     SslCert response;
     try {
-      response = apiClient.sslCerts().createEphemeral(projectId, prefixedInstanceId, request)
+      response = apiClient.sslCerts().createEphemeral(projectId, regionalizedInstanceId, request)
           .execute();
     } catch (IOException ex) {
       throw addExceptionContext(

--- a/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstance.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstance.java
@@ -69,6 +69,7 @@ class CloudSqlInstance {
   private final String projectId;
   private final String regionId;
   private final String instanceId;
+  private final String prefixedInstanceId;
   private final ListenableFuture<KeyPair> keyPair;
 
   private final Object instanceDataGuard = new Object();
@@ -86,9 +87,9 @@ class CloudSqlInstance {
    * Initializes a new Cloud SQL instance based on the given connection name.
    *
    * @param connectionName instance connection name in the format "PROJECT_ID:REGION_ID:INSTANCE_ID"
-   * @param apiClient Cloud SQL Admin API client for interacting with the Cloud SQL instance
-   * @param executor executor used to schedule asynchronous tasks
-   * @param keyPair public/private key pair used to authenticate connections
+   * @param apiClient      Cloud SQL Admin API client for interacting with the Cloud SQL instance
+   * @param executor       executor used to schedule asynchronous tasks
+   * @param keyPair        public/private key pair used to authenticate connections
    */
   CloudSqlInstance(
       String connectionName,
@@ -105,6 +106,7 @@ class CloudSqlInstance {
     this.projectId = matcher.group(1);
     this.regionId = matcher.group(3);
     this.instanceId = matcher.group(4);
+    this.prefixedInstanceId = String.format("%s~%s", this.regionId, this.instanceId);
 
     this.apiClient = apiClient;
     this.executor = executor;
@@ -149,10 +151,10 @@ class CloudSqlInstance {
    * preferredTypes.
    *
    * @param preferredTypes Preferred instance IP types to use. Valid IP types include "Public" and
-   *     "Private".
+   *                       "Private".
    * @return returns a string representing the IP address for the instance
    * @throws IllegalArgumentException If the instance has no IP addresses matching the provided
-   *     preferences.
+   *                                  preferences.
    */
   String getPreferredIp(List<String> preferredTypes) {
     Map<String, String> ipAddrs = getInstanceData().getIpAddrs();
@@ -238,11 +240,10 @@ class CloudSqlInstance {
   }
 
   /**
-   * Creates a new SslData based on the provided parameters.
-   * It contains a SSLContext that will be used to provide new SSLSockets
-   * authorized to connect to a Cloud SQL instance.
-   * It also contains a KeyManagerFactory and a TrustManagerFactory
-   * that can be used by drivers to establish an SSL tunnel.
+   * Creates a new SslData based on the provided parameters. It contains a SSLContext that will be
+   * used to provide new SSLSockets authorized to connect to a Cloud SQL instance. It also contains
+   * a KeyManagerFactory and a TrustManagerFactory that can be used by drivers to establish an SSL
+   * tunnel.
    */
   private SslData createSslData(
       KeyPair keyPair, Metadata metadata, Certificate ephemeralCertificate) {
@@ -280,7 +281,7 @@ class CloudSqlInstance {
   private Metadata fetchMetadata() {
     try {
       DatabaseInstance instanceMetadata =
-          apiClient.instances().get(projectId, instanceId).execute();
+          apiClient.instances().get(projectId, prefixedInstanceId).execute();
 
       // Validate the instance will support the authenticated connection.
       if (!instanceMetadata.getRegion().equals(regionId)) {
@@ -342,7 +343,8 @@ class CloudSqlInstance {
         new SslCertsCreateEphemeralRequest().setPublicKey(generatePublicKeyCert(keyPair));
     SslCert response;
     try {
-      response = apiClient.sslCerts().createEphemeral(projectId, instanceId, request).execute();
+      response = apiClient.sslCerts().createEphemeral(projectId, prefixedInstanceId, request)
+          .execute();
     } catch (IOException ex) {
       throw addExceptionContext(
           ex,
@@ -448,9 +450,9 @@ class CloudSqlInstance {
    * Checks for common errors that can occur when interacting with the Cloud SQL Admin API, and adds
    * additional context to help the user troubleshoot them.
    *
-   * @param ex exception thrown by the Admin API request
+   * @param ex           exception thrown by the Admin API request
    * @param fallbackDesc generic description used as a fallback if no additional information can be
-   *     provided to the user
+   *                     provided to the user
    */
   private RuntimeException addExceptionContext(IOException ex, String fallbackDesc) {
     // Verify we are able to extract a reason from an exception, or fallback to a generic desc

--- a/core/src/test/java/com/google/cloud/sql/core/CoreSocketFactoryTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/CoreSocketFactoryTest.java
@@ -151,9 +151,15 @@ public class CoreSocketFactoryTest {
     // Stub when correct project, but generic instance
     when(adminApiInstances.get(eq("myProject"), anyString()))
         .thenThrow(fakeNotAuthorizedException());
+
     // Stub when correct instance
     when(adminApiInstances.get(eq("myProject"), eq("myInstance"))).thenReturn(adminApiInstancesGet);
     when(adminApiInstances.get(eq("example.com:myProject"), eq("myInstance"))).thenReturn(adminApiInstancesGet);
+
+    // Prefixing the region to the instance name is considered valid
+    when(adminApiInstances.get(eq("myProject"), eq("myRegion~myInstance"))).thenReturn(adminApiInstancesGet);
+    when(adminApiInstances.get(eq("myProject"), eq("notMyRegion~myInstance"))).thenReturn(adminApiInstancesGet);
+    when(adminApiInstances.get(eq("example.com:myProject"), eq("myRegion~myInstance"))).thenReturn(adminApiInstancesGet);
 
     when(adminApi.sslCerts()).thenReturn(adminApiSslCerts);
     when(adminApiSslCerts.createEphemeral(
@@ -224,10 +230,10 @@ public class CoreSocketFactoryTest {
         coreSocketFactory.createSslSocket(
             "myProject:myRegion:myInstance", Arrays.asList("PRIVATE"));
 
-    verify(adminApiInstances).get("myProject", "myInstance");
+    verify(adminApiInstances).get("myProject", "myRegion~myInstance");
     verify(adminApiSslCerts)
         .createEphemeral(
-            eq("myProject"), eq("myInstance"), isA(SslCertsCreateEphemeralRequest.class));
+            eq("myProject"), eq("myRegion~myInstance"), isA(SslCertsCreateEphemeralRequest.class));
 
     BufferedReader bufferedReader =
         new BufferedReader(new InputStreamReader(socket.getInputStream(), UTF_8));
@@ -246,10 +252,10 @@ public class CoreSocketFactoryTest {
         coreSocketFactory.createSslSocket(
             "myProject:myRegion:myInstance", Arrays.asList("PRIMARY"));
 
-    verify(adminApiInstances).get("myProject", "myInstance");
+    verify(adminApiInstances).get("myProject", "myRegion~myInstance");
     verify(adminApiSslCerts)
         .createEphemeral(
-            eq("myProject"), eq("myInstance"), isA(SslCertsCreateEphemeralRequest.class));
+            eq("myProject"), eq("myRegion~myInstance"), isA(SslCertsCreateEphemeralRequest.class));
 
     BufferedReader bufferedReader =
         new BufferedReader(new InputStreamReader(socket.getInputStream(), UTF_8));
@@ -268,10 +274,10 @@ public class CoreSocketFactoryTest {
         coreSocketFactory.createSslSocket(
             "example.com:myProject:myRegion:myInstance", Arrays.asList("PRIMARY"));
 
-    verify(adminApiInstances).get("example.com:myProject", "myInstance");
+    verify(adminApiInstances).get("example.com:myProject", "myRegion~myInstance");
     verify(adminApiSslCerts)
         .createEphemeral(
-            eq("example.com:myProject"), eq("myInstance"), isA(SslCertsCreateEphemeralRequest.class));
+            eq("example.com:myProject"), eq("myRegion~myInstance"), isA(SslCertsCreateEphemeralRequest.class));
 
     BufferedReader bufferedReader =
         new BufferedReader(new InputStreamReader(socket.getInputStream(), UTF_8));
@@ -300,10 +306,10 @@ public class CoreSocketFactoryTest {
         coreSocketFactory.createSslSocket(
             "myProject:myRegion:myInstance", Arrays.asList("PRIMARY"));
 
-    verify(adminApiInstances, times(2)).get("myProject", "myInstance");
+    verify(adminApiInstances, times(2)).get("myProject", "myRegion~myInstance");
     verify(adminApiSslCerts, times(2))
         .createEphemeral(
-            eq("myProject"), eq("myInstance"), isA(SslCertsCreateEphemeralRequest.class));
+            eq("myProject"), eq("myRegion~myInstance"), isA(SslCertsCreateEphemeralRequest.class));
 
     BufferedReader bufferedReader =
         new BufferedReader(new InputStreamReader(socket.getInputStream(), UTF_8));
@@ -320,10 +326,10 @@ public class CoreSocketFactoryTest {
         new CoreSocketFactory(clientKeyPair, adminApi, port, defaultExecutor);
     coreSocketFactory.createSslSocket("myProject:myRegion:myInstance", Arrays.asList("PRIMARY"));
 
-    verify(adminApiInstances).get("myProject", "myInstance");
+    verify(adminApiInstances).get("myProject", "myRegion~myInstance");
     verify(adminApiSslCerts)
         .createEphemeral(
-            eq("myProject"), eq("myInstance"), isA(SslCertsCreateEphemeralRequest.class));
+            eq("myProject"), eq("myRegion~myInstance"), isA(SslCertsCreateEphemeralRequest.class));
 
     coreSocketFactory.createSslSocket("myProject:myRegion:myInstance", Arrays.asList("PRIMARY"));
 


### PR DESCRIPTION
## Change Description

Update the SQLAdmin API to use an instance name with a region prefix with the format `<region>~<instance-name>` to prevent issues with conflicting instance names when sqladmin v1 is released and instance names become regionally unique instead of globally unique.

Note: these changes were tested locally using the integration tests from #301. 