### PR TITLE
feat(mysql): Deprecated the mysql-socket-factory-connector-j-6 artifact

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,8 @@ are unsure, it is recommended to use the latest version of `mysql-connector-java
 
 | JDBC Driver Version        | Cloud SQL Socket Factory Version         |
 | -------------------------- | ---------------------------------------- |
-| mysql-connector-java:8.x   | mysql-socket-factory-connector-j-8:1.0.16 |
-| mysql-connector-java:6.x   | mysql-socket-factory-connector-j-6:1.0.16 |
-| mysql-connector-java:5.1.x | mysql-socket-factory:1.0.16              |
+| mysql-connector-java:8.x   | mysql-socket-factory-connector-j-8:1.1.0 |
+| mysql-connector-java:5.1.x | mysql-socket-factory:1.1.0             |
 
 [//]: # ({x-version-update-start:cloud-sql-java-connector:released})
 

--- a/connector-j-6/pom.xml
+++ b/connector-j-6/pom.xml
@@ -12,6 +12,15 @@
   <artifactId>mysql-socket-factory-connector-j-6</artifactId>
   <packaging>jar</packaging>
 
+    <distributionManagement>
+    <relocation>
+      <groupId>com.google.cloud.sql</groupId>
+      <artifactId>mysql-socket-factory-connector-j-8</artifactId>
+      <version>1.2.0</version>
+      <message>MySQL Connector/J 6.0.x is no longer under development. Please update to 8.0.x instead.</message>
+    </relocation>
+  </distributionManagement>
+
   <name>Cloud SQL MySQL Socket Factory (for Connector/J 6.x)</name>
   <description>
     Socket factory for the MySQL JDBC driver (version 6.x) that allows a user with the appropriate


### PR DESCRIPTION
## Change Description

Deprecate the mysql-socket-factory-connector-j-6 artifact and instead point users to the j-8 artifact. The j-6 version of the connector has been abandoned for some time, and the j-8 version is presumed to be backwards compatible. 


## Checklist

- [ ] Make sure to open an issue as a 
  [bug/issue](https://github.com/GoogleCloudPlatform//issues/new/choose) 
  before writing your code!  That way we can discuss the change, evaluate 
  designs, and agree on the general idea.
- [x] Ensure the tests and linter pass
- [x] Appropriate documentation is updated (if necessary)

## Relevant issues:

- Fixes #<issue_number_goes_here>