### PR TITLE
fix: declare used maven dependencies explicitly

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -18,6 +18,33 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.google.http-client</groupId>
+      <artifactId>google-http-client</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.http-client</groupId>
+      <artifactId>google-http-client-jackson2</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.api-client</groupId>
+      <artifactId>google-api-client</artifactId>
+      <version>1.31.1</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.checkerframework</groupId>
+      <artifactId>checker-compat-qual</artifactId>
+      <version>2.5.5</version>
+    </dependency>
+
+    <dependency>
       <groupId>com.google.apis</groupId>
       <artifactId>google-api-services-sqladmin</artifactId>
       <version>v1beta4-rev20210420-1.31.0</version>

--- a/r2dbc/core/pom.xml
+++ b/r2dbc/core/pom.xml
@@ -19,6 +19,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.reactivestreams</groupId>
+      <artifactId>reactive-streams</artifactId>
+      <version>1.0.3</version>
+    </dependency>
+    <dependency>
       <groupId>io.r2dbc</groupId>
       <artifactId>r2dbc-spi</artifactId>
       <version>0.8.4.RELEASE</version>


### PR DESCRIPTION
## Change Description
Declare used dependencies in `pom.xml` explicitly instead of relying on transitive dependencies.

Maybe it is better to `dependencyManagement` everything, but that feels like a separated PR.

## Checklist

- [x] Make sure to open an issue as a 
  [bug/issue](https://github.com/GoogleCloudPlatform//issues/new/choose) 
  before writing your code!  That way we can discuss the change, evaluate 
  designs, and agree on the general idea.
- [x] Ensure the tests and linter pass
- [ ] Appropriate documentation is updated (if necessary)

## Relevant issues:

- Fixes #477