### PR TITLE
fix: exclude unreachable optional dependency in r2dbc-core

### DIFF
--- a/r2dbc/core/pom.xml
+++ b/r2dbc/core/pom.xml
@@ -32,6 +32,12 @@
       <groupId>io.projectreactor.netty</groupId>
       <artifactId>reactor-netty</artifactId>
       <version>1.0.7</version>
+      <exclusions>
+        <exclusion>
+          <groupId>io.micrometer</groupId>
+          <artifactId>micrometer-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.cloud.sql</groupId>


### PR DESCRIPTION
## Change Description
Explicitly excluded the optional `io.micrometer:micrometer-core` dependency which was causing the linkage checker to fail in https://github.com/GoogleCloudPlatform/cloud-opensource-java/pull/2073

cc @suztomo
## Checklist

- [ ] Make sure to open an issue as a 
  [bug/issue](https://github.com/GoogleCloudPlatform//issues/new/choose) 
  before writing your code!  That way we can discuss the change, evaluate 
  designs, and agree on the general idea.
- [ ] Ensure the tests and linter pass
- [ ] Appropriate documentation is updated (if necessary)

## Relevant issues:

- Fixes #507 