### PR TITLE
fix: exclude the unreachable dependencies that have xerces-impl

### DIFF
--- a/jdbc/sqlserver/pom.xml
+++ b/jdbc/sqlserver/pom.xml
@@ -23,6 +23,16 @@
       <groupId>com.microsoft.sqlserver</groupId>
       <artifactId>mssql-jdbc</artifactId>
       <version>9.3.1.jre8-preview</version>
+      <exclusions>
+        <exclusion>
+          <groupId>io.micrometer</groupId>
+          <artifactId>micrometer-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.azure</groupId>
+          <artifactId>azure-identity</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.cloud.sql</groupId>

--- a/r2dbc/mysql/pom.xml
+++ b/r2dbc/mysql/pom.xml
@@ -28,6 +28,12 @@
       <artifactId>r2dbc-mysql</artifactId>
       <version>0.8.2.RELEASE</version>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>io.micrometer</groupId>
+          <artifactId>micrometer-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.cloud.sql</groupId>

--- a/r2dbc/postgres/pom.xml
+++ b/r2dbc/postgres/pom.xml
@@ -28,6 +28,12 @@
       <artifactId>r2dbc-postgresql</artifactId>
       <version>0.8.8.RELEASE</version>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>io.micrometer</groupId>
+          <artifactId>micrometer-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.cloud.sql</groupId>

--- a/r2dbc/sqlserver/pom.xml
+++ b/r2dbc/sqlserver/pom.xml
@@ -24,6 +24,12 @@
       <artifactId>r2dbc-mssql</artifactId>
       <version>0.8.6.RELEASE</version>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>io.micrometer</groupId>
+          <artifactId>micrometer-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.cloud.sql</groupId>


### PR DESCRIPTION
## Change Description

Excluding more artifacts that cause failures in https://github.com/GoogleCloudPlatform/cloud-opensource-java/pull/2073.

Note that even after these exclusions, the MaximumLinkageErrorsTest in the PR above fails due to new linkage errors.

## Checklist

- [ ] Make sure to open an issue as a 
  [bug/issue](https://github.com/GoogleCloudPlatform//issues/new/choose) 
  before writing your code!  That way we can discuss the change, evaluate 
  designs, and agree on the general idea.
- [ ] Ensure the tests and linter pass
- [ ] Appropriate documentation is updated (if necessary)

## Relevant issues:

- Fixes https://github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory/issues/507