### PR TITLE
fix: set IOExceptionHandler for SQLAdmin API requests

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -63,10 +63,11 @@
 
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
+      <artifactId>mockito-inline</artifactId>
       <version>3.11.2</version>
       <scope>test</scope>
     </dependency>
+
 
     <dependency>
       <groupId>com.google.truth</groupId>

--- a/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstance.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstance.java
@@ -21,7 +21,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.client.http.HttpBackOffIOExceptionHandler;
 import com.google.api.client.http.HttpRequest;
-import com.google.api.client.util.BackOff;
+import com.google.api.client.util.ExponentialBackOff;
 import com.google.api.services.sqladmin.SQLAdmin;
 import com.google.api.services.sqladmin.SQLAdmin.Instances.Get;
 import com.google.api.services.sqladmin.SQLAdmin.SslCerts.CreateEphemeral;
@@ -443,7 +443,8 @@ class CloudSqlInstance {
           apiClient.instances().get(projectId, regionalizedInstanceId);
       HttpRequest httpRequest = getInstanceMetadata.buildHttpRequest();
       // Retry request with backoff if an IOException occurs
-      httpRequest.setIOExceptionHandler(new HttpBackOffIOExceptionHandler(BackOff.ZERO_BACKOFF));
+      httpRequest
+          .setIOExceptionHandler(new HttpBackOffIOExceptionHandler(new ExponentialBackOff()));
 
       DatabaseInstance instanceMetadata = httpRequest.execute()
           .parseAs(getInstanceMetadata.getResponseClass());
@@ -524,7 +525,7 @@ class CloudSqlInstance {
           .createEphemeral(projectId, regionalizedInstanceId, request);
       // Retry request with backoff if an IOException occurs
       HttpRequest httpRequest = createEphemeral.buildHttpRequest();
-      httpRequest.setIOExceptionHandler(new HttpBackOffIOExceptionHandler(BackOff.ZERO_BACKOFF));
+      httpRequest.setIOExceptionHandler(new HttpBackOffIOExceptionHandler(new ExponentialBackOff());
 
       response = httpRequest.execute().parseAs(createEphemeral.getResponseClass());
 

--- a/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstance.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstance.java
@@ -19,7 +19,12 @@ package com.google.cloud.sql.core;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import com.google.api.client.http.HttpBackOffIOExceptionHandler;
+import com.google.api.client.http.HttpRequest;
+import com.google.api.client.util.BackOff;
 import com.google.api.services.sqladmin.SQLAdmin;
+import com.google.api.services.sqladmin.SQLAdmin.Instances.Get;
+import com.google.api.services.sqladmin.SQLAdmin.SslCerts.CreateEphemeral;
 import com.google.api.services.sqladmin.model.DatabaseInstance;
 import com.google.api.services.sqladmin.model.IpMapping;
 import com.google.api.services.sqladmin.model.SslCert;
@@ -434,8 +439,14 @@ class CloudSqlInstance {
    */
   private Metadata fetchMetadata() {
     try {
-      DatabaseInstance instanceMetadata =
-          apiClient.instances().get(projectId, regionalizedInstanceId).execute();
+      Get getInstanceMetadata =
+          apiClient.instances().get(projectId, regionalizedInstanceId);
+      HttpRequest httpRequest = getInstanceMetadata.buildHttpRequest();
+      // Retry request with backoff if an IOException occurs
+      httpRequest.setIOExceptionHandler(new HttpBackOffIOExceptionHandler(BackOff.ZERO_BACKOFF));
+
+      DatabaseInstance instanceMetadata = httpRequest.execute()
+          .parseAs(getInstanceMetadata.getResponseClass());
 
       // Validate the instance will support the authenticated connection.
       if (!instanceMetadata.getRegion().equals(regionId)) {
@@ -509,8 +520,14 @@ class CloudSqlInstance {
     }
     SslCert response;
     try {
-      response = apiClient.sslCerts().createEphemeral(projectId, regionalizedInstanceId, request)
-          .execute();
+      CreateEphemeral createEphemeral = apiClient.sslCerts()
+          .createEphemeral(projectId, regionalizedInstanceId, request);
+      // Retry request with backoff if an IOException occurs
+      HttpRequest httpRequest = createEphemeral.buildHttpRequest();
+      httpRequest.setIOExceptionHandler(new HttpBackOffIOExceptionHandler(BackOff.ZERO_BACKOFF));
+
+      response = httpRequest.execute().parseAs(createEphemeral.getResponseClass());
+
     } catch (IOException ex) {
       throw addExceptionContext(
           ex,

--- a/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstance.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstance.java
@@ -525,7 +525,8 @@ class CloudSqlInstance {
           .createEphemeral(projectId, regionalizedInstanceId, request);
       // Retry request with backoff if an IOException occurs
       HttpRequest httpRequest = createEphemeral.buildHttpRequest();
-      httpRequest.setIOExceptionHandler(new HttpBackOffIOExceptionHandler(new ExponentialBackOff());
+      httpRequest
+          .setIOExceptionHandler(new HttpBackOffIOExceptionHandler(new ExponentialBackOff()));
 
       response = httpRequest.execute().parseAs(createEphemeral.getResponseClass());
 

--- a/core/src/test/java/com/google/cloud/sql/core/CoreSocketFactoryTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/CoreSocketFactoryTest.java
@@ -31,6 +31,7 @@ import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 import com.google.api.client.googleapis.json.GoogleJsonError;
 import com.google.api.client.googleapis.json.GoogleJsonError.ErrorInfo;
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import com.google.api.client.http.HttpBackOffIOExceptionHandler;
 import com.google.api.client.http.HttpRequest;
 import com.google.api.client.http.HttpResponse;
 import com.google.api.client.http.HttpStatusCodes;
@@ -44,6 +45,7 @@ import com.google.api.client.testing.http.HttpTesting;
 import com.google.api.client.testing.http.MockHttpTransport;
 import com.google.api.client.testing.http.MockLowLevelHttpRequest;
 import com.google.api.client.testing.http.MockLowLevelHttpResponse;
+import com.google.api.client.util.ExponentialBackOff;
 import com.google.api.services.sqladmin.SQLAdmin;
 import com.google.api.services.sqladmin.model.DatabaseInstance;
 import com.google.api.services.sqladmin.model.IpMapping;
@@ -123,6 +125,10 @@ public class CoreSocketFactoryTest {
   @Mock
   private GoogleCredential credential;
   @Mock
+  private HttpRequest httpRequest;
+  @Mock
+  private HttpResponse httpResponse;
+  @Mock
   private SQLAdmin adminApi;
   @Mock
   private SQLAdmin.Instances adminApiInstances;
@@ -134,6 +140,70 @@ public class CoreSocketFactoryTest {
   private SQLAdmin.SslCerts.CreateEphemeral adminApiSslCertsCreateEphemeral;
 
   private ListenableFuture<KeyPair> clientKeyPair;
+
+  // Creates a fake "accessNotConfigured" exception that can be used for testing.
+  private static GoogleJsonResponseException fakeNotConfiguredException() throws IOException {
+    return fakeGoogleJsonResponseException(
+        HttpStatusCodes.STATUS_CODE_FORBIDDEN,
+        "accessNotConfigured",
+        "Cloud SQL Admin API has not been used in project 12345 before or it is disabled. Enable"
+            + " it by visiting "
+            + " https://console.developers.google.com/apis/api/sqladmin.googleapis.com/overview?project=12345"
+            + " then retry. If you enabled this API recently, wait a few minutes for the action to"
+            + " propagate to our systems and retry.");
+  }
+
+  // Creates a fake "notAuthorized" exception that can be used for testing.
+  private static GoogleJsonResponseException fakeNotAuthorizedException() throws IOException {
+    return fakeGoogleJsonResponseException(
+        HttpStatusCodes.STATUS_CODE_FORBIDDEN,
+        "notAuthorized",
+        "The client is not authorized to make this request");
+  }
+
+  // Builds a fake GoogleJsonResponseException for testing API error handling.
+  private static GoogleJsonResponseException fakeGoogleJsonResponseException(
+      int httpStatus, String reason, String message) throws IOException {
+    ErrorInfo errorInfo = new ErrorInfo();
+    errorInfo.setReason(reason);
+    errorInfo.setMessage(message);
+    return fakeGoogleJsonResponseException(httpStatus, errorInfo, message);
+  }
+
+  private static GoogleJsonResponseException fakeGoogleJsonResponseException(
+      int status, ErrorInfo errorInfo, String message) throws IOException {
+    final JsonFactory jsonFactory = new JacksonFactory();
+    HttpTransport transport =
+        new MockHttpTransport() {
+          @Override
+          public LowLevelHttpRequest buildRequest(String method, String url) throws IOException {
+            errorInfo.setFactory(jsonFactory);
+            GoogleJsonError jsonError = new GoogleJsonError();
+            jsonError.setCode(status);
+            jsonError.setErrors(Collections.singletonList(errorInfo));
+            jsonError.setMessage(message);
+            jsonError.setFactory(jsonFactory);
+            GenericJson errorResponse = new GenericJson();
+            errorResponse.set("error", jsonError);
+            errorResponse.setFactory(jsonFactory);
+            return new MockLowLevelHttpRequest()
+                .setResponse(
+                    new MockLowLevelHttpResponse()
+                        .setContent(errorResponse.toPrettyString())
+                        .setContentType(Json.MEDIA_TYPE)
+                        .setStatusCode(status));
+          }
+        };
+    HttpRequest request =
+        transport.createRequestFactory().buildGetRequest(HttpTesting.SIMPLE_GENERIC_URL);
+    request.setThrowExceptionOnExecuteError(false);
+    HttpResponse response = request.execute();
+    return GoogleJsonResponseException.from(jsonFactory, response);
+  }
+
+  private static byte[] decodeBase64StripWhitespace(String b64) {
+    return Base64.getDecoder().decode(b64.replaceAll("\\s", ""));
+  }
 
   @Before
   public void setup() throws IOException, GeneralSecurityException, ExecutionException {
@@ -174,12 +244,24 @@ public class CoreSocketFactoryTest {
     when(adminApiInstances.get(eq("example.com:myProject"), eq("myRegion~myInstance")))
         .thenReturn(adminApiInstancesGet);
 
+    when(adminApiInstancesGet.buildHttpRequest()).thenReturn(httpRequest);
+    when(httpRequest
+        .setIOExceptionHandler(new HttpBackOffIOExceptionHandler(new ExponentialBackOff())))
+        .thenReturn(httpRequest);
+
     when(adminApi.sslCerts()).thenReturn(adminApiSslCerts);
     when(adminApiSslCerts.createEphemeral(
         anyString(), anyString(), isA(SslCertsCreateEphemeralRequest.class)))
         .thenReturn(adminApiSslCertsCreateEphemeral);
 
-    when(adminApiInstancesGet.execute())
+    when(adminApiInstancesGet.buildHttpRequest()).thenReturn(httpRequest);
+    when(adminApiSslCertsCreateEphemeral.buildHttpRequest()).thenReturn(httpRequest);
+    when(httpRequest
+        .setIOExceptionHandler(new HttpBackOffIOExceptionHandler(new ExponentialBackOff())))
+        .thenReturn(httpRequest);
+
+    when(httpRequest.execute()).thenReturn(httpResponse);
+    when(httpResponse.parseAs(adminApiInstancesGet.getResponseClass()))
         .thenReturn(
             new DatabaseInstance()
                 .setBackendType("SECOND_GEN")
@@ -189,7 +271,7 @@ public class CoreSocketFactoryTest {
                         new IpMapping().setIpAddress(PRIVATE_IP).setType("PRIVATE")))
                 .setServerCaCert(new SslCert().setCert(TestKeys.SERVER_CA_CERT))
                 .setRegion("myRegion"));
-    when(adminApiSslCertsCreateEphemeral.execute())
+    when(httpResponse.parseAs(adminApiSslCertsCreateEphemeral.getResponseClass()))
         .thenReturn(new SslCert().setCert(createEphemeralCert(Duration.ofSeconds(0))));
   }
 
@@ -390,66 +472,6 @@ public class CoreSocketFactoryTest {
     }
   }
 
-  // Creates a fake "accessNotConfigured" exception that can be used for testing.
-  private static GoogleJsonResponseException fakeNotConfiguredException() throws IOException {
-    return fakeGoogleJsonResponseException(
-        HttpStatusCodes.STATUS_CODE_FORBIDDEN,
-        "accessNotConfigured",
-        "Cloud SQL Admin API has not been used in project 12345 before or it is disabled. Enable"
-            + " it by visiting "
-            + " https://console.developers.google.com/apis/api/sqladmin.googleapis.com/overview?project=12345"
-            + " then retry. If you enabled this API recently, wait a few minutes for the action to"
-            + " propagate to our systems and retry.");
-  }
-
-  // Creates a fake "notAuthorized" exception that can be used for testing.
-  private static GoogleJsonResponseException fakeNotAuthorizedException() throws IOException {
-    return fakeGoogleJsonResponseException(
-        HttpStatusCodes.STATUS_CODE_FORBIDDEN,
-        "notAuthorized",
-        "The client is not authorized to make this request");
-  }
-
-  // Builds a fake GoogleJsonResponseException for testing API error handling.
-  private static GoogleJsonResponseException fakeGoogleJsonResponseException(
-      int httpStatus, String reason, String message) throws IOException {
-    ErrorInfo errorInfo = new ErrorInfo();
-    errorInfo.setReason(reason);
-    errorInfo.setMessage(message);
-    return fakeGoogleJsonResponseException(httpStatus, errorInfo, message);
-  }
-
-  private static GoogleJsonResponseException fakeGoogleJsonResponseException(
-      int status, ErrorInfo errorInfo, String message) throws IOException {
-    final JsonFactory jsonFactory = new JacksonFactory();
-    HttpTransport transport =
-        new MockHttpTransport() {
-          @Override
-          public LowLevelHttpRequest buildRequest(String method, String url) throws IOException {
-            errorInfo.setFactory(jsonFactory);
-            GoogleJsonError jsonError = new GoogleJsonError();
-            jsonError.setCode(status);
-            jsonError.setErrors(Collections.singletonList(errorInfo));
-            jsonError.setMessage(message);
-            jsonError.setFactory(jsonFactory);
-            GenericJson errorResponse = new GenericJson();
-            errorResponse.set("error", jsonError);
-            errorResponse.setFactory(jsonFactory);
-            return new MockLowLevelHttpRequest()
-                .setResponse(
-                    new MockLowLevelHttpResponse()
-                        .setContent(errorResponse.toPrettyString())
-                        .setContentType(Json.MEDIA_TYPE)
-                        .setStatusCode(status));
-          }
-        };
-    HttpRequest request =
-        transport.createRequestFactory().buildGetRequest(HttpTesting.SIMPLE_GENERIC_URL);
-    request.setThrowExceptionOnExecuteError(false);
-    HttpResponse response = request.execute();
-    return GoogleJsonResponseException.from(jsonFactory, response);
-  }
-
   private String createEphemeralCert(Duration shiftIntoPast)
       throws GeneralSecurityException, ExecutionException, IOException {
     Duration validFor = Duration.ofHours(1);
@@ -485,10 +507,6 @@ public class CoreSocketFactoryTest {
     sb.append("-----END CERTIFICATE-----\n");
 
     return sb.toString();
-  }
-
-  private static byte[] decodeBase64StripWhitespace(String b64) {
-    return Base64.getDecoder().decode(b64.replaceAll("\\s", ""));
   }
 
   private static class FakeSslServer {

--- a/core/src/test/java/com/google/cloud/sql/core/CoreSocketFactoryTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/CoreSocketFactoryTest.java
@@ -259,7 +259,8 @@ public class CoreSocketFactoryTest {
     when(httpRequest
         .setIOExceptionHandler(new HttpBackOffIOExceptionHandler(new ExponentialBackOff())))
         .thenReturn(httpRequest);
-
+    when(adminApiInstancesGet.getResponseClass()).thenReturn(DatabaseInstance.class);
+    when(adminApiSslCertsCreateEphemeral.getResponseClass()).thenReturn(SslCert.class);
     when(httpRequest.execute()).thenReturn(httpResponse);
     when(httpResponse.parseAs(adminApiInstancesGet.getResponseClass()))
         .thenReturn(

--- a/core/src/test/java/com/google/cloud/sql/core/CoreSocketFactoryTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/CoreSocketFactoryTest.java
@@ -207,7 +207,7 @@ public class CoreSocketFactoryTest {
 
   @Before
   public void setup() throws IOException, GeneralSecurityException, ExecutionException {
-    MockitoAnnotations.initMocks(this);
+    MockitoAnnotations.openMocks(this);
 
     KeyFactory keyFactory = KeyFactory.getInstance("RSA");
     PKCS8EncodedKeySpec privateKeySpec =


### PR DESCRIPTION
## Change Description

Sets an IOException Handler for the SQLAdmin API requests in fetchMetadata and fetchEphemeralCert, allowing the client to retry requests if network errors occur

## Checklist

- [ ] Make sure to open an issue as a 
  [bug/issue](https://github.com/GoogleCloudPlatform//issues/new/choose) 
  before writing your code!  That way we can discuss the change, evaluate 
  designs, and agree on the general idea.
- [ ] Ensure the tests and linter pass
- [ ] Appropriate documentation is updated (if necessary)

## Relevant issues:

- Fixes #528 