### PR TITLE
chore: exclude sqladmin v1 in dependency updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -16,6 +16,10 @@
     {
       "packageNames": ["com.microsoft.sqlserver:mssql-jdbc"],
       "allowedVersions": "/.+jre8.?/"
+    },
+    {
+      "packageNames": ["google-api-services-sqladmin"],
+      "allowedVersions": "/v1beta4-.*/"
     }
   ],
   "prConcurrentLimit": 0,


### PR DESCRIPTION
## Change Description

For now, exclude v1 from renovatebot updates

## Checklist

- [ ] Make sure to open an issue as a 
  [bug/issue](https://github.com/GoogleCloudPlatform//issues/new/choose) 
  before writing your code!  That way we can discuss the change, evaluate 
  designs, and agree on the general idea.
- [ ] Ensure the tests and linter pass
- [ ] Appropriate documentation is updated (if necessary)
