### PR TITLE
fix(r2dbc): fetch updated SSLData for each new connection

### DIFF
--- a/r2dbc/core/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProvider.java
+++ b/r2dbc/core/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProvider.java
@@ -27,6 +27,8 @@ import io.r2dbc.spi.ConnectionFactoryOptions;
 import io.r2dbc.spi.ConnectionFactoryProvider;
 import io.r2dbc.spi.Option;
 import java.util.function.Function;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 /**
  * {@link ConnectionFactoryProvider} for proxied access to GCP Postgres and MySQL instances.
@@ -37,10 +39,15 @@ public abstract class GcpConnectionFactoryProvider implements ConnectionFactoryP
   public static final Option<Boolean> ENABLE_IAM_AUTH = Option.valueOf("ENABLE_IAM_AUTH");
 
   private static Function<SslContextBuilder, SslContextBuilder> createSslCustomizer(
-      SslData sslData) {
+      String connectionName, boolean enableIamAuth) {
 
     Function<SslContextBuilder, SslContextBuilder> customizer =
         sslContextBuilder -> {
+          // Execute in a default scheduler to prevent it from blocking event loop
+          SslData sslData = Mono
+              .fromSupplier(() -> CoreSocketFactory.getSslData(connectionName, enableIamAuth))
+              .subscribeOn(Schedulers.boundedElastic())
+              .block();
           sslContextBuilder.keyManager(sslData.getKeyManagerFactory());
           sslContextBuilder.trustManager(sslData.getTrustManagerFactory());
           sslContextBuilder.protocols("TLSv1.2");
@@ -100,13 +107,11 @@ public abstract class GcpConnectionFactoryProvider implements ConnectionFactoryP
       enableIamAuth = false;
     }
 
-    // precompute SSL Data to avoid blocking calls during the connect phase.
-    SslData sslData = CoreSocketFactory.getSslData(connectionName, enableIamAuth);
-
     if (socket != null) {
       return socketConnectionFactory(optionBuilder, socket);
     }
-    return tcpConnectonFactory(optionBuilder, createSslCustomizer(sslData), connectionName);
+    return tcpConnectonFactory(optionBuilder, createSslCustomizer(connectionName, enableIamAuth),
+        connectionName);
   }
 
   @Override

--- a/r2dbc/core/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProvider.java
+++ b/r2dbc/core/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProvider.java
@@ -108,6 +108,10 @@ public abstract class GcpConnectionFactoryProvider implements ConnectionFactoryP
       enableIamAuth = false;
     }
 
+    // Precompute SSL Data to trigger the initial refresh to happen immediately,
+    // and ensure enableIAMAuth is set correctly.
+    CoreSocketFactory.getSslData(connectionName, enableIamAuth);
+
     if (socket != null) {
       return socketConnectionFactory(optionBuilder, socket);
     }

--- a/r2dbc/core/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProvider.java
+++ b/r2dbc/core/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProvider.java
@@ -47,6 +47,7 @@ public abstract class GcpConnectionFactoryProvider implements ConnectionFactoryP
           SslData sslData = Mono
               .fromSupplier(() -> CoreSocketFactory.getSslData(connectionName, enableIamAuth))
               .subscribeOn(Schedulers.boundedElastic())
+              .share()
               .block();
           sslContextBuilder.keyManager(sslData.getKeyManagerFactory());
           sslContextBuilder.trustManager(sslData.getTrustManagerFactory());


### PR DESCRIPTION
## Change Description

Updates the SSL Customizer used in r2dbc core to pull the most recent SSLData on each connection.

## Relevant issues:

- Fixes #472 