### PR TITLE
chore(tests): use bouncycastle instead of sun.security.x509

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -53,7 +53,7 @@
       <artifactId>google-auth-library-oauth2-http</artifactId>
       <version>0.27.0</version>
     </dependency>
-    
+
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -53,8 +53,7 @@
       <artifactId>google-auth-library-oauth2-http</artifactId>
       <version>0.27.0</version>
     </dependency>
-
-
+    
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -54,6 +54,7 @@
       <version>0.27.0</version>
     </dependency>
 
+
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
@@ -72,6 +73,20 @@
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
       <version>1.1.3</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcprov-jdk15on</artifactId>
+      <version>1.69</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk15on</artifactId>
+      <version>1.69</version>
       <scope>test</scope>
     </dependency>
 

--- a/core/src/test/java/com/google/cloud/sql/core/CoreSocketFactoryTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/CoreSocketFactoryTest.java
@@ -98,10 +98,9 @@ import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.cert.X509v3CertificateBuilder;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
-import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.operator.ContentSigner;
-import org.bouncycastle.operator.DefaultSignatureAlgorithmIdentifierFinder;
+import org.bouncycastle.operator.DefaultDigestAlgorithmIdentifierFinder;
 import org.bouncycastle.operator.OperatorCreationException;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 import org.junit.Before;
@@ -475,13 +474,18 @@ public class CoreSocketFactoryTest {
         .setProvider(new BouncyCastleProvider())
         .build(signingKey);
 
-    JcaX509v3CertificateBuilder certificateBuilder = new JcaX509v3CertificateBuilder(
+    byte[] decodedPublicKey = decodeBase64StripWhitespace(TestKeys.CLIENT_PUBLIC_KEY);
+    SubjectPublicKeyInfo subjectPublicKeyInfo = new SubjectPublicKeyInfo(
+        new DefaultDigestAlgorithmIdentifierFinder().find("SHA1withRSA"),
+        decodedPublicKey);
+
+    X509v3CertificateBuilder certificateBuilder = new X509v3CertificateBuilder(
         new X500Name("C = US, O = Google\\, Inc, CN=temporary-subject"),
         BigInteger.ONE,
         Date.from(notBefore.toInstant()),
         Date.from(notAfter.toInstant()),
         new X500Name("C = US, O = Google\\, Inc, CN=Google Cloud SQL Signing CA foo:baz"),
-        Futures.getDone(clientKeyPair).getPublic()
+        subjectPublicKeyInfo
     );
 
     X509CertificateHolder certificateHolder = certificateBuilder.build(signer);

--- a/core/src/test/java/com/google/cloud/sql/core/CoreSocketFactoryTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/CoreSocketFactoryTest.java
@@ -69,10 +69,8 @@ import java.security.KeyStore;
 import java.security.KeyStore.PasswordProtection;
 import java.security.KeyStore.PrivateKeyEntry;
 import java.security.PrivateKey;
-import java.security.Provider;
 import java.security.PublicKey;
 import java.security.SecureRandom;
-import java.security.Security;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
@@ -98,7 +96,6 @@ import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.cert.X509v3CertificateBuilder;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.operator.ContentSigner;
 import org.bouncycastle.operator.DefaultDigestAlgorithmIdentifierFinder;
 import org.bouncycastle.operator.OperatorCreationException;
@@ -142,7 +139,7 @@ public class CoreSocketFactoryTest {
   @Before
   public void setup()
       throws IOException, GeneralSecurityException, ExecutionException, OperatorCreationException {
-    MockitoAnnotations.initMocks(this);
+    MockitoAnnotations.openMocks(this);
 
     KeyFactory keyFactory = KeyFactory.getInstance("RSA");
     PKCS8EncodedKeySpec privateKeySpec =
@@ -466,12 +463,7 @@ public class CoreSocketFactoryTest {
         new PKCS8EncodedKeySpec(decodeBase64StripWhitespace(TestKeys.SIGNING_CA_PRIVATE_KEY));
     PrivateKey signingKey = keyFactory.generatePrivate(keySpec);
 
-    // add Bouncy Castle provider
-    Provider provider = new BouncyCastleProvider();
-    Security.addProvider(provider);
-
     final ContentSigner signer = new JcaContentSignerBuilder("SHA1withRSA")
-        .setProvider(new BouncyCastleProvider())
         .build(signingKey);
 
     byte[] decodedPublicKey = decodeBase64StripWhitespace(TestKeys.CLIENT_PUBLIC_KEY);
@@ -524,7 +516,7 @@ public class CoreSocketFactoryTest {
 
             CertificateFactory certFactory = CertificateFactory.getInstance("X.509");
 
-            KeyStore authKeyStore = KeyStore.getInstance("BKS", "BC");
+            KeyStore authKeyStore = KeyStore.getInstance(KeyStore.getDefaultType());
             authKeyStore.load(null, null);
             KeyFactory keyFactory = KeyFactory.getInstance("RSA");
             PKCS8EncodedKeySpec keySpec =


### PR DESCRIPTION
## Change Description

Update CoreSocketFactory tests to use Bouncy Castle for cert generation instead of sun.security.x509.


## Checklist

- [ ] Make sure to open an issue as a 
  [bug/issue](https://github.com/GoogleCloudPlatform//issues/new/choose) 
  before writing your code!  That way we can discuss the change, evaluate 
  designs, and agree on the general idea.
- [ ] Ensure the tests and linter pass
- [ ] Appropriate documentation is updated (if necessary)

## Relevant issues:

- Fixes #<issue_number_goes_here>