### PR TITLE
fix: remove dependency on internal sun.security.x509 classes

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -72,6 +74,13 @@
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
       <version>1.1.3</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk15on</artifactId>
+      <version>1.69</version>
       <scope>test</scope>
     </dependency>
 

--- a/core/src/test/java/com/google/cloud/sql/core/CoreSocketFactoryTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/CoreSocketFactoryTest.java
@@ -58,6 +58,7 @@ import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.math.BigInteger;
 import java.net.InetAddress;
 import java.net.Socket;
 import java.nio.charset.StandardCharsets;
@@ -90,6 +91,13 @@ import javax.net.ssl.SSLServerSocket;
 import javax.net.ssl.SSLServerSocketFactory;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.TrustManagerFactory;
+import javax.security.auth.x500.X500Principal;
+import org.bouncycastle.cert.X509CertificateHolder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.OperatorCreationException;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -97,15 +105,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import sun.security.x509.AlgorithmId;
-import sun.security.x509.CertificateAlgorithmId;
-import sun.security.x509.CertificateSerialNumber;
-import sun.security.x509.CertificateValidity;
-import sun.security.x509.CertificateVersion;
-import sun.security.x509.CertificateX509Key;
-import sun.security.x509.X500Name;
-import sun.security.x509.X509CertImpl;
-import sun.security.x509.X509CertInfo;
 
 // TODO(berezv): add multithreaded test
 @RunWith(JUnit4.class)
@@ -136,8 +135,9 @@ public class CoreSocketFactoryTest {
   private ListenableFuture<KeyPair> clientKeyPair;
 
   @Before
-  public void setup() throws IOException, GeneralSecurityException, ExecutionException {
-    MockitoAnnotations.initMocks(this);
+  public void setup()
+      throws IOException, GeneralSecurityException, ExecutionException, OperatorCreationException {
+    MockitoAnnotations.openMocks(this);
 
     KeyFactory keyFactory = KeyFactory.getInstance("RSA");
     PKCS8EncodedKeySpec privateKeySpec =
@@ -306,7 +306,7 @@ public class CoreSocketFactoryTest {
   // TODO(berezv): figure out why the test server produces a different error on an expired
   // certificate
   public void create_expiredCertificateOnFirstConnection_certificateRenewed()
-      throws IOException, GeneralSecurityException, ExecutionException, InterruptedException {
+      throws IOException, GeneralSecurityException, ExecutionException, InterruptedException, OperatorCreationException {
     FakeSslServer sslServer = new FakeSslServer();
     int port = sslServer.start();
 
@@ -451,39 +451,42 @@ public class CoreSocketFactoryTest {
   }
 
   private String createEphemeralCert(Duration shiftIntoPast)
-      throws GeneralSecurityException, ExecutionException, IOException {
+      throws GeneralSecurityException, ExecutionException, IOException, OperatorCreationException {
     Duration validFor = Duration.ofHours(1);
     ZonedDateTime notBefore = ZonedDateTime.now().minus(shiftIntoPast);
     ZonedDateTime notAfter = notBefore.plus(validFor);
-
-    CertificateValidity interval =
-        new CertificateValidity(Date.from(notBefore.toInstant()), Date.from(notAfter.toInstant()));
-
-    X509CertInfo info = new X509CertInfo();
-    info.set(X509CertInfo.VERSION, new CertificateVersion(CertificateVersion.V3));
-    info.set(X509CertInfo.SERIAL_NUMBER, new CertificateSerialNumber(1));
-    info.set(X509CertInfo.ALGORITHM_ID, new CertificateAlgorithmId(AlgorithmId.get("SHA1withRSA")));
-    info.set(X509CertInfo.SUBJECT, new X500Name("C = US, O = Google\\, Inc, CN=temporary-subject"));
-    info.set(X509CertInfo.KEY, new CertificateX509Key(Futures.getDone(clientKeyPair).getPublic()));
-    info.set(X509CertInfo.VALIDITY, interval);
-    info.set(
-        X509CertInfo.ISSUER,
-        new X500Name("C = US, O = Google\\, Inc, CN=Google Cloud SQL Signing CA foo:baz"));
 
     KeyFactory keyFactory = KeyFactory.getInstance("RSA");
     PKCS8EncodedKeySpec keySpec =
         new PKCS8EncodedKeySpec(decodeBase64StripWhitespace(TestKeys.SIGNING_CA_PRIVATE_KEY));
     PrivateKey signingKey = keyFactory.generatePrivate(keySpec);
 
-    X509CertImpl cert = new X509CertImpl(info);
-    cert.sign(signingKey, "SHA1withRSA");
+    final ContentSigner signer = new JcaContentSignerBuilder("SHA1withRSA")
+        .build(signingKey);
+
+    X500Principal issuer = new X500Principal("C = US, O = Google\\, Inc, CN=Google Cloud SQL Signing CA foo:baz");
+    X500Principal subject = new X500Principal("C = US, O = Google\\, Inc, CN=temporary-subject");
+
+    JcaX509v3CertificateBuilder certificateBuilder = new JcaX509v3CertificateBuilder(
+        issuer,
+        BigInteger.ONE,
+        Date.from(notBefore.toInstant()),
+        Date.from(notAfter.toInstant()),
+        subject,
+        Futures.getDone(clientKeyPair).getPublic()
+    );
+
+    X509CertificateHolder certificateHolder = certificateBuilder.build(signer);
+
+    Certificate cert = new JcaX509CertificateConverter()
+        .getCertificate(certificateHolder);
 
     StringBuilder sb = new StringBuilder();
     sb.append("-----BEGIN CERTIFICATE-----\n");
-    sb.append(Base64.getEncoder().encodeToString(cert.getEncoded()).replaceAll("(.{64})", "$1\n"));
+    sb.append(Base64.getEncoder().encodeToString(cert.getEncoded())
+        .replaceAll("(.{64})", "$1\n"));
     sb.append("\n");
     sb.append("-----END CERTIFICATE-----\n");
-
     return sb.toString();
   }
 
@@ -505,6 +508,7 @@ public class CoreSocketFactoryTest {
         @Override
         public void run() {
           try {
+
             CertificateFactory certFactory = CertificateFactory.getInstance("X.509");
 
             KeyStore authKeyStore = KeyStore.getInstance(KeyStore.getDefaultType());

--- a/core/src/test/java/com/google/cloud/sql/core/CoreSocketFactoryTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/CoreSocketFactoryTest.java
@@ -509,7 +509,6 @@ public class CoreSocketFactoryTest {
         @Override
         public void run() {
           try {
-
             CertificateFactory certFactory = CertificateFactory.getInstance("X.509");
 
             KeyStore authKeyStore = KeyStore.getInstance(KeyStore.getDefaultType());

--- a/core/src/test/java/com/google/cloud/sql/core/CoreSocketFactoryTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/CoreSocketFactoryTest.java
@@ -464,7 +464,8 @@ public class CoreSocketFactoryTest {
     final ContentSigner signer = new JcaContentSignerBuilder("SHA1withRSA")
         .build(signingKey);
 
-    X500Principal issuer = new X500Principal("C = US, O = Google\\, Inc, CN=Google Cloud SQL Signing CA foo:baz");
+    X500Principal issuer = new X500Principal(
+        "C = US, O = Google\\, Inc, CN=Google Cloud SQL Signing CA foo:baz");
     X500Principal subject = new X500Principal("C = US, O = Google\\, Inc, CN=temporary-subject");
 
     JcaX509v3CertificateBuilder certificateBuilder = new JcaX509v3CertificateBuilder(


### PR DESCRIPTION
## Change Description

Use bouncycastle instead of internal sun.security APIs to generate certs for tests. I looked into using `java.security.cert` but most examples I saw either used bouncycastle or used `sun.security` or some other internal API


## Checklist

- [x] Make sure to open an issue as a 
  [bug/issue](https://github.com/GoogleCloudPlatform//issues/new/choose) 
  before writing your code!  That way we can discuss the change, evaluate 
  designs, and agree on the general idea.
- [x] Ensure the tests and linter pass
- [ ] Appropriate documentation is updated (if necessary)

## Relevant issues:

- Fixes #551 