### PR TITLE
fix: strip padding from access tokens if present

### DIFF
--- a/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstance.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstance.java
@@ -524,8 +524,7 @@ class CloudSqlInstance {
         String token = credentials.get().getAccessToken().getTokenValue();
         // TODO: remove this once issue with OAuth2 Tokens is resolved.
         // See: https://github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory/issues/565
-        String strippedToken = CharMatcher.is('.').trimTrailingFrom(token);
-        request.setAccessToken(strippedToken);
+        request.setAccessToken(CharMatcher.is('.').trimTrailingFrom(token));
       } catch (IOException ex) {
         throw addExceptionContext(
             ex,

--- a/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstance.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstance.java
@@ -522,6 +522,7 @@ class CloudSqlInstance {
       try {
         credentials.get().refresh();
         String token = credentials.get().getAccessToken().getTokenValue();
+        // TODO: remove this once issue with OAuth2 Tokens is resolved.
         String strippedToken = CharMatcher.is('.').trimTrailingFrom(token);
         request.setAccessToken(strippedToken);
       } catch (IOException ex) {

--- a/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstance.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstance.java
@@ -523,6 +523,7 @@ class CloudSqlInstance {
         credentials.get().refresh();
         String token = credentials.get().getAccessToken().getTokenValue();
         // TODO: remove this once issue with OAuth2 Tokens is resolved.
+        // See: https://github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory/issues/565
         String strippedToken = CharMatcher.is('.').trimTrailingFrom(token);
         request.setAccessToken(strippedToken);
       } catch (IOException ex) {

--- a/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstance.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstance.java
@@ -27,6 +27,7 @@ import com.google.api.services.sqladmin.model.SslCertsCreateEphemeralRequest;
 import com.google.auth.http.HttpCredentialsAdapter;
 import com.google.auth.oauth2.OAuth2Credentials;
 import com.google.cloud.sql.CredentialFactory;
+import com.google.common.base.CharMatcher;
 import com.google.common.base.Throwables;
 import com.google.common.io.BaseEncoding;
 import com.google.common.util.concurrent.FutureCallback;
@@ -521,7 +522,8 @@ class CloudSqlInstance {
       try {
         credentials.get().refresh();
         String token = credentials.get().getAccessToken().getTokenValue();
-        request.setAccessToken(token);
+        String strippedToken = CharMatcher.is('.').trimTrailingFrom(token);
+        request.setAccessToken(strippedToken);
       } catch (IOException ex) {
         throw addExceptionContext(
             ex,


### PR DESCRIPTION
## Change Description

Strips trailing `.` characters from access tokens


## Checklist

- [ ] Make sure to open an issue as a 
  [bug/issue](https://github.com/GoogleCloudPlatform//issues/new/choose) 
  before writing your code!  That way we can discuss the change, evaluate 
  designs, and agree on the general idea.
- [ ] Ensure the tests and linter pass
- [ ] Appropriate documentation is updated (if necessary)

## Relevant issues:

- Fixes #565 