### PR TITLE
chore: skip assembly for parent

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -34,6 +34,10 @@
     driver-specific socket factory artifacts.
   </description>
 
+  <properties>
+    <assembly.skipAssembly>false</assembly.skipAssembly>
+  </properties>
+
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/jdbc/mysql-j-5/pom.xml
+++ b/jdbc/mysql-j-5/pom.xml
@@ -37,6 +37,10 @@
     SSL certificates manually.
   </description>
 
+  <properties>
+    <assembly.skipAssembly>false</assembly.skipAssembly>
+  </properties>
+
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/jdbc/mysql-j-8/pom.xml
+++ b/jdbc/mysql-j-8/pom.xml
@@ -36,6 +36,10 @@
     SSL certificates manually.
   </description>
 
+  <properties>
+    <assembly.skipAssembly>false</assembly.skipAssembly>
+  </properties>
+
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/jdbc/postgres/pom.xml
+++ b/jdbc/postgres/pom.xml
@@ -35,6 +35,10 @@
     certificates manually.
   </description>
 
+  <properties>
+    <assembly.skipAssembly>false</assembly.skipAssembly>
+  </properties>
+
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/jdbc/sqlserver/pom.xml
+++ b/jdbc/sqlserver/pom.xml
@@ -35,6 +35,10 @@
     allowlisting or SSL certificates manually.
   </description>
 
+  <properties>
+    <assembly.skipAssembly>false</assembly.skipAssembly>
+  </properties>
+
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <javac.version>9+181-r4173-1</javac.version>
+    <assembly.skipAssembly>true</assembly.skipAssembly>
   </properties>
 
   <modules>

--- a/r2dbc/core/pom.xml
+++ b/r2dbc/core/pom.xml
@@ -33,6 +33,10 @@
     certificates manually.
   </description>
 
+  <properties>
+    <assembly.skipAssembly>false</assembly.skipAssembly>
+  </properties>
+
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/r2dbc/mysql/pom.xml
+++ b/r2dbc/mysql/pom.xml
@@ -34,6 +34,10 @@
     certificates manually.
   </description>
 
+  <properties>
+    <assembly.skipAssembly>false</assembly.skipAssembly>
+  </properties>
+
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/r2dbc/postgres/pom.xml
+++ b/r2dbc/postgres/pom.xml
@@ -35,6 +35,10 @@
     certificates manually.
   </description>
 
+  <properties>
+    <assembly.skipAssembly>false</assembly.skipAssembly>
+  </properties>
+
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/r2dbc/sqlserver/pom.xml
+++ b/r2dbc/sqlserver/pom.xml
@@ -35,6 +35,10 @@
     allowlisting or SSL certificates manually.
   </description>
 
+  <properties>
+    <assembly.skipAssembly>false</assembly.skipAssembly>
+  </properties>
+
   <dependencyManagement>
     <dependencies>
       <dependency>


### PR DESCRIPTION
Previously, attempts to run the assembly plugin would fail because the
parent was empty. Now that we've removed all dependencies from the
parent and placed them where they belong in the respective children
artifacts, the parent is empty. This commit updates the configuration of
the assembly step to skip the parent and only run for the children.