### PR TITLE
chore: fix path setting issue with Windows tests

### DIFF
--- a/.kokoro/tests/run_tests.sh
+++ b/.kokoro/tests/run_tests.sh
@@ -26,6 +26,6 @@ if [ -n "$KOKORO_GFILE_DIR" ]; then
 fi
 
 echo -e "******************** Running tests... ********************\n"
-echo "JAVA_HOME: $JAVA_HOME"
+echo "Maven version: $(mvn --version)"
 mvn -e -B clean verify -P e2e -Dcheckstyle.skip
 echo -e "******************** Tests complete.  ********************\n"

--- a/.kokoro/tests/run_tests_java11.bat
+++ b/.kokoro/tests/run_tests_java11.bat
@@ -1,3 +1,4 @@
 setx JAVA_HOME "C:\\OpenJDK\jdk-11.0.11"
 setx PATH "%JAVA_HOME%\bin;%PATH%"
+call RefreshEnv.cmd
 "C:\Program Files\Git\bin\bash.exe" github/cloud-sql-jdbc-socket-factory/.kokoro/tests/run_tests.sh

--- a/.kokoro/tests/run_tests_java11.bat
+++ b/.kokoro/tests/run_tests_java11.bat
@@ -1,2 +1,3 @@
-set JAVA_HOME="C:\OpenJDK\jdk-11.0.11"
+setx JAVA_HOME "C:\\OpenJDK\jdk-11.0.11"
+setx PATH "%JAVA_HOME%\bin;%PATH%"
 "C:\Program Files\Git\bin\bash.exe" github/cloud-sql-jdbc-socket-factory/.kokoro/tests/run_tests.sh

--- a/.kokoro/tests/run_tests_java17.bat
+++ b/.kokoro/tests/run_tests_java17.bat
@@ -1,3 +1,4 @@
 setx JAVA_HOME "C:\\OpenJDK\jdk-17"
 setx PATH "%JAVA_HOME%\bin;%PATH%"
+call RefreshEnv.cmd
 "C:\Program Files\Git\bin\bash.exe" github/cloud-sql-jdbc-socket-factory/.kokoro/tests/run_tests.sh

--- a/.kokoro/tests/run_tests_java17.bat
+++ b/.kokoro/tests/run_tests_java17.bat
@@ -1,2 +1,3 @@
-set JAVA_HOME="C:\OpenJDK\jdk-17"
+setx JAVA_HOME "C:\\OpenJDK\jdk-17"
+setx PATH "%JAVA_HOME%\bin;%PATH%"
 "C:\Program Files\Git\bin\bash.exe" github/cloud-sql-jdbc-socket-factory/.kokoro/tests/run_tests.sh


### PR DESCRIPTION
## Change Description

Fix an issue where the PATH variable wasn't being properly set, leading to the wrong Java version sometimes being used for tests.