### PR TITLE
fix: add back missing dependencies to JAR files

### DIFF
--- a/jdbc/mysql-j-5/pom.xml
+++ b/jdbc/mysql-j-5/pom.xml
@@ -133,7 +133,6 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -145,7 +144,7 @@
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
       <version>1.1.3</version>
-      <scope>compile</scope>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.zaxxer</groupId>

--- a/jdbc/mysql-j-5/pom.xml
+++ b/jdbc/mysql-j-5/pom.xml
@@ -133,7 +133,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <scope>test</scope>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -145,7 +145,7 @@
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
       <version>1.1.3</version>
-      <scope>test</scope>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.zaxxer</groupId>

--- a/jdbc/mysql-j-8/pom.xml
+++ b/jdbc/mysql-j-8/pom.xml
@@ -132,7 +132,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <scope>test</scope>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/jdbc/mysql-j-8/pom.xml
+++ b/jdbc/mysql-j-8/pom.xml
@@ -132,7 +132,6 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/jdbc/postgres/pom.xml
+++ b/jdbc/postgres/pom.xml
@@ -131,7 +131,6 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/jdbc/postgres/pom.xml
+++ b/jdbc/postgres/pom.xml
@@ -131,7 +131,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <scope>test</scope>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/jdbc/sqlserver/pom.xml
+++ b/jdbc/sqlserver/pom.xml
@@ -141,7 +141,6 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/jdbc/sqlserver/pom.xml
+++ b/jdbc/sqlserver/pom.xml
@@ -141,7 +141,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <scope>test</scope>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -255,10 +255,13 @@
 
                 Necessary for SQL Server support
 
+                Necessary to allow guava into the assembly jars
+                com.google.guava:guava
+
                 Global test dependencies unused in r2dbc core (no tests currently):
                 junit:junit,com.google.truth:truth
                 -->
-                org.ow2.asm:asm-util,com.github.jnr:jnr-unixsocket,org.postgresql:postgresql,junit:junit,com.google.truth:truth,com.microsoft.sqlserver:mssql-jdbc
+                org.ow2.asm:asm-util,com.github.jnr:jnr-unixsocket,org.postgresql:postgresql,junit:junit,com.google.truth:truth,com.microsoft.sqlserver:mssql-jdbc,com.google.guava:guava
               </ignoredDependencies>
             </configuration>
             <executions>

--- a/r2dbc/mysql/pom.xml
+++ b/r2dbc/mysql/pom.xml
@@ -227,7 +227,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <scope>test</scope>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.r2dbc</groupId>

--- a/r2dbc/mysql/pom.xml
+++ b/r2dbc/mysql/pom.xml
@@ -227,7 +227,6 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.r2dbc</groupId>

--- a/r2dbc/postgres/pom.xml
+++ b/r2dbc/postgres/pom.xml
@@ -233,7 +233,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <scope>test</scope>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.r2dbc</groupId>

--- a/r2dbc/postgres/pom.xml
+++ b/r2dbc/postgres/pom.xml
@@ -233,7 +233,6 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.r2dbc</groupId>

--- a/r2dbc/sqlserver/pom.xml
+++ b/r2dbc/sqlserver/pom.xml
@@ -227,7 +227,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <scope>test</scope>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.r2dbc</groupId>

--- a/r2dbc/sqlserver/pom.xml
+++ b/r2dbc/sqlserver/pom.xml
@@ -227,7 +227,6 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.r2dbc</groupId>


### PR DESCRIPTION
All of the classes show up in the JAR after building once these were introduced. @hessjcg was able to track down the root cause to be this change:  
https://github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory/commit/64cfee110ec54272c45fe4b0d150182c65c8c828
The `test` scope was added to fix a failing lint check:
https://github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory/runs/6236244256?check_suite_focus=true

Fixes #881 