### PR TITLE
chore: Move most configuration out of CoreSocketFactory and into CloudSqlInstance

### DIFF
--- a/core/src/main/java/com/google/cloud/sql/core/ApplicationDefaultCredentialFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/core/ApplicationDefaultCredentialFactory.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.cloud.sql.core;
 
 import com.google.api.client.http.HttpRequestInitializer;

--- a/core/src/main/java/com/google/cloud/sql/core/ApplicationDefaultCredentialFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/core/ApplicationDefaultCredentialFactory.java
@@ -1,0 +1,31 @@
+package com.google.cloud.sql.core;
+
+import com.google.api.client.http.HttpRequestInitializer;
+import com.google.api.services.sqladmin.SQLAdminScopes;
+import com.google.auth.http.HttpCredentialsAdapter;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.sql.CredentialFactory;
+import java.io.IOException;
+import java.util.Arrays;
+
+class ApplicationDefaultCredentialFactory implements CredentialFactory {
+
+  @Override
+  public HttpRequestInitializer create() {
+    GoogleCredentials credentials;
+    try {
+      credentials = GoogleCredentials.getApplicationDefault();
+    } catch (IOException err) {
+      throw new RuntimeException(
+          "Unable to obtain credentials to communicate with the Cloud SQL API", err);
+    }
+    if (credentials.createScopedRequired()) {
+      credentials =
+          credentials.createScoped(Arrays.asList(
+              SQLAdminScopes.SQLSERVICE_ADMIN,
+              SQLAdminScopes.CLOUD_PLATFORM)
+          );
+    }
+    return new HttpCredentialsAdapter(credentials);
+  }
+}

--- a/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstance.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstance.java
@@ -134,7 +134,7 @@ class CloudSqlInstance {
    *  @param key instance connection name in the format "PROJECT_ID:REGION_ID:INSTANCE_ID"
    * @param apiClientOpt      Cloud SQL Admin API client for interacting with the Cloud SQL instance
    * @param credentialFactoryOpt     Cloud SQL Admin API client credential factory
-   * @param serverProxyPort
+   * @param serverProxyPort proxy port
    * @param executor       executor used to schedule asynchronous tasks
    * @param keyPair        public/private key pair used to authenticate connections
    */
@@ -160,7 +160,7 @@ class CloudSqlInstance {
     this.regionalizedInstanceId = String.format("%s~%s", this.regionId, this.instanceId);
 
     CredentialFactory tokenSourceFactory;
-    if(credentialFactoryOpt.isPresent()) {
+    if (credentialFactoryOpt.isPresent()) {
       tokenSourceFactory = credentialFactoryOpt.get();
     } else {
       tokenSourceFactory = loadCredentialFactory();
@@ -168,7 +168,7 @@ class CloudSqlInstance {
     this.credentialFactory = tokenSourceFactory;
 
     SQLAdmin apiClient;
-    if(credentialFactoryOpt.isPresent()) {
+    if (credentialFactoryOpt.isPresent()) {
       apiClient = apiClientOpt.get();
     } else {
       apiClient = createAdminApiClient();
@@ -388,6 +388,7 @@ class CloudSqlInstance {
       throw ex;
     }
   }
+
   /**
    * Returns the first IP address for the instance, in order of the preference supplied by
    * preferredTypes.

--- a/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstanceKey.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstanceKey.java
@@ -12,11 +12,11 @@ public class CloudSqlInstanceKey {
     this.enableIamAuth = enableIamAuth;
   }
 
-  public static CloudSqlInstanceKey Create(String instanceName, boolean enableIamAuthn) {
+  public static CloudSqlInstanceKey create(String instanceName, boolean enableIamAuthn) {
     return new CloudSqlInstanceKey(instanceName, Optional.of(enableIamAuthn));
   }
 
-  public static CloudSqlInstanceKey MatchInstance(String instanceName) {
+  public static CloudSqlInstanceKey matchingInstanceName(String instanceName) {
     return new CloudSqlInstanceKey(instanceName, Optional.empty());
   }
 

--- a/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstanceKey.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstanceKey.java
@@ -1,0 +1,48 @@
+package com.google.cloud.sql.core;
+
+import java.util.Objects;
+import java.util.Optional;
+
+public class CloudSqlInstanceKey {
+  private final String instanceName;
+  private final Optional<Boolean> enableIamAuth;
+
+  private CloudSqlInstanceKey(String instanceName, Optional<Boolean> enableIamAuth) {
+    this.instanceName = instanceName;
+    this.enableIamAuth = enableIamAuth;
+  }
+
+  public static CloudSqlInstanceKey Create(String instanceName, boolean enableIamAuthn) {
+    return new CloudSqlInstanceKey(instanceName, Optional.of(enableIamAuthn));
+  }
+
+  public static CloudSqlInstanceKey MatchInstance(String instanceName) {
+    return new CloudSqlInstanceKey(instanceName, Optional.empty());
+  }
+
+  public String getInstanceName() {
+    return instanceName;
+  }
+
+  public Optional<Boolean> getEnableIamAuth() {
+    return enableIamAuth;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof CloudSqlInstanceKey)) {
+      return false;
+    }
+    CloudSqlInstanceKey that = (CloudSqlInstanceKey) o;
+    return Objects.equals(instanceName, that.instanceName) && Objects.equals(
+        enableIamAuth, that.enableIamAuth);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(instanceName, enableIamAuth);
+  }
+}

--- a/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstanceKey.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstanceKey.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.cloud.sql.core;
 
 import java.util.Objects;

--- a/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
@@ -65,7 +65,8 @@ public final class CoreSocketFactory {
   private static CoreSocketFactory coreSocketFactory;
 
   private final ListenableFuture<KeyPair> localKeyPair;
-  private final ConcurrentHashMap<CloudSqlInstanceKey, CloudSqlInstance> instances = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<CloudSqlInstanceKey, CloudSqlInstance> instances
+      = new ConcurrentHashMap<>();
   private final ListeningScheduledExecutorService executor;
 
   /* package*/ static List<String> userAgents = new ArrayList<String>();
@@ -78,11 +79,6 @@ public final class CoreSocketFactory {
 
   /**
    * Only used for mock testing.
-   * @param localKeyPair
-   * @param adminApi
-   * @param credentialFactory
-   * @param serverProxyPort
-   * @param executor
    */
   @VisibleForTesting
   CoreSocketFactory(
@@ -99,7 +95,7 @@ public final class CoreSocketFactory {
   }
 
   /**
-   * The real constructor used by getInstance()
+   * The real constructor used by getInstance().
    */
   private CoreSocketFactory(ListenableFuture<KeyPair> localKeyPair,
       ListeningScheduledExecutorService executor) {
@@ -111,9 +107,9 @@ public final class CoreSocketFactory {
   }
 
 
-      /**
-       * Returns the {@link CoreSocketFactory} singleton.
-       */
+  /**
+   * Returns the {@link CoreSocketFactory} singleton.
+   */
   public static synchronized CoreSocketFactory getInstance() {
     if (coreSocketFactory == null) {
       logger.info("First Cloud SQL connection, generating RSA key pair.");
@@ -131,11 +127,12 @@ public final class CoreSocketFactory {
   }
 
   private CloudSqlInstance getCloudSqlInstance(String instanceName) {
-    return getCloudSqlInstance(CloudSqlInstanceKey.MatchInstance(instanceName));
+    return getCloudSqlInstance(CloudSqlInstanceKey.matchingInstanceName(instanceName));
   }
 
   private CloudSqlInstance createInstance(CloudSqlInstanceKey key) {
-    return new CloudSqlInstance(key, adminApi, credentialFactory, serverProxyPort, executor, localKeyPair);
+    return new CloudSqlInstance(key, adminApi, credentialFactory, serverProxyPort, executor,
+        localKeyPair);
   }
 
   static int getDefaultServerProxyPort() {
@@ -188,7 +185,7 @@ public final class CoreSocketFactory {
    *
    * <p>Depending on the given properties, it may return either a SSL Socket or a Unix Socket.
    *
-   * @param props          Properties used to configure the connection.
+   * @param props Properties used to configure the connection.
    * @param unixPathSuffix suffix to add the the Unix socket path. Unused if null.
    * @return the newly created Socket.
    * @throws IOException if error occurs during socket creation.
@@ -228,9 +225,8 @@ public final class CoreSocketFactory {
   /**
    * Returns data that can be used to establish Cloud SQL SSL connection.
    */
-  @Deprecated
   public static SslData getSslData(String csqlInstanceName, boolean enableIamAuth) {
-    return getSslData(CloudSqlInstanceKey.Create(csqlInstanceName, enableIamAuth));
+    return getSslData(CloudSqlInstanceKey.create(csqlInstanceName, enableIamAuth));
   }
 
   public static SslData getSslData(CloudSqlInstanceKey key) {
@@ -254,7 +250,7 @@ public final class CoreSocketFactory {
    * Creates a secure socket representing a connection to a Cloud SQL instance.
    *
    * @param instanceName Name of the Cloud SQL instance.
-   * @param ipTypes      Preferred type of IP to use ("PRIVATE", "PUBLIC")
+   * @param ipTypes Preferred type of IP to use ("PRIVATE", "PUBLIC")
    * @return the newly created Socket.
    * @throws IOException if error occurs during socket creation.
    */
@@ -262,7 +258,8 @@ public final class CoreSocketFactory {
   @VisibleForTesting
   Socket createSslSocket(String instanceName, List<String> ipTypes, boolean enableIamAuth)
       throws IOException {
-    CloudSqlInstance instance = getCloudSqlInstance(CloudSqlInstanceKey.Create(instanceName, enableIamAuth));
+    CloudSqlInstance instance = getCloudSqlInstance(
+        CloudSqlInstanceKey.create(instanceName, enableIamAuth));
     return instance.createAndConfigureSocket(ipTypes);
 
   }


### PR DESCRIPTION
Makes configuration specific to a cloud sql instances instead of part of a global singleton.

This change is small in size because it:
- avoids changes to the public methods of CoreSocketFactory
- avoids breaking existing unit tests with lots of mocks in them

Further work needed:
- Ensure that v2 style socket factory config is properly respected
- Ensure that r2dbc works properly with socket factory configs
- Possibly add more config properties to CloudSqlInstanceKey
