### PR TITLE
feat:  enable setting ipType connection option for r2dbc drivers

### DIFF
--- a/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
@@ -275,16 +275,14 @@ public final class CoreSocketFactory {
   /**
    * Returns default ip address that can be used to establish Cloud SQL connection.
    */
-  public static String getHostIp(String csqlInstanceName)
-      throws IOException {
+  public static String getHostIp(String csqlInstanceName) throws IOException {
     return getInstance().getHostIp(csqlInstanceName, listIpTypes(DEFAULT_IP_TYPES));
   }
 
   /**
    * Returns preferred ip address that can be used to establish Cloud SQL connection.
    */
-  public static String getHostIp(String csqlInstanceName, String ipTypes)
-      throws IOException {
+  public static String getHostIp(String csqlInstanceName, String ipTypes) throws IOException {
     return getInstance().getHostIp(csqlInstanceName, listIpTypes(ipTypes));
   }
 

--- a/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
@@ -78,7 +78,7 @@ public final class CoreSocketFactory {
 
   private static final Logger logger = Logger.getLogger(CoreSocketFactory.class.getName());
 
-  private static final String DEFAULT_IP_TYPES = "PUBLIC,PRIVATE";
+  public static final String DEFAULT_IP_TYPES = "PUBLIC,PRIVATE";
 
   // Test properties, not for end-user use. May be changed or removed without notice.
   private static final String API_ROOT_URL_PROPERTY = "_CLOUD_SQL_API_ROOT_URL";
@@ -158,19 +158,6 @@ public final class CoreSocketFactory {
         k -> {
           try {
             return new CloudSqlInstance(k, adminApi, enableIamAuth, credentialFactory, executor,
-                localKeyPair);
-          } catch (IOException e) {
-            throw new RuntimeException(e);
-          }
-        });
-  }
-
-  private CloudSqlInstance getCloudSqlInstance(String instanceName) {
-    return instances.computeIfAbsent(
-        instanceName,
-        k -> {
-          try {
-            return new CloudSqlInstance(k, adminApi, false, credentialFactory, executor,
                 localKeyPair);
           } catch (IOException e) {
             throw new RuntimeException(e);
@@ -273,19 +260,24 @@ public final class CoreSocketFactory {
     return getInstance().getCloudSqlInstance(csqlInstanceName, enableIamAuth).getSslData();
   }
 
-  public static SslData getSslData(String csqlInstanceName) throws IOException {
-    return getSslData(csqlInstanceName, false);
+  /**
+   * Returns default ip address that can be used to establish Cloud SQL connection.
+   */
+  public static String getHostIp(String csqlInstanceName, boolean enableIamAuth) 
+      throws IOException {
+    return getInstance().getHostIp(csqlInstanceName, enableIamAuth, listIpTypes(DEFAULT_IP_TYPES));
   }
 
   /**
-   * Returns preferred ip address that can be used to establish Cloud SQL connection.
+   * Returns default ip address that can be used to establish Cloud SQL connection.
    */
-  public static String getHostIp(String csqlInstanceName) throws IOException {
-    return getInstance().getHostIp(csqlInstanceName, listIpTypes(DEFAULT_IP_TYPES));
+  public static String getHostIp(String csqlInstanceName, boolean enableIamAuth, String ipTypes)
+      throws IOException {
+    return getInstance().getHostIp(csqlInstanceName, enableIamAuth, listIpTypes(ipTypes));
   }
 
-  private String getHostIp(String instanceName, List<String> ipTypes) {
-    CloudSqlInstance instance = getCloudSqlInstance(instanceName);
+  private String getHostIp(String instanceName, boolean enableIamAuth, List<String> ipTypes) {
+    CloudSqlInstance instance = getCloudSqlInstance(instanceName, enableIamAuth);
     return instance.getPreferredIp(ipTypes);
   }
 

--- a/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
@@ -152,6 +152,10 @@ public final class CoreSocketFactory {
     return coreSocketFactory;
   }
 
+  private CloudSqlInstance getCloudSqlInstance(String instanceName) {
+    return getCloudSqlInstance(instanceName, false);
+  }
+
   private CloudSqlInstance getCloudSqlInstance(String instanceName, boolean enableIamAuth) {
     return instances.computeIfAbsent(
         instanceName,
@@ -261,23 +265,30 @@ public final class CoreSocketFactory {
   }
 
   /**
+   * Returns data that can be used to establish Cloud SQL SSL connection.
+   */
+  public static SslData getSslData(String csqlInstanceName) throws IOException {
+    return getSslData(csqlInstanceName, false);
+  }
+
+  /**
    * Returns default ip address that can be used to establish Cloud SQL connection.
    */
-  public static String getHostIp(String csqlInstanceName, boolean enableIamAuth) 
+  public static String getHostIp(String csqlInstanceName)
       throws IOException {
-    return getInstance().getHostIp(csqlInstanceName, enableIamAuth, listIpTypes(DEFAULT_IP_TYPES));
+    return getInstance().getHostIp(csqlInstanceName, listIpTypes(DEFAULT_IP_TYPES));
   }
 
   /**
    * Returns preferred ip address that can be used to establish Cloud SQL connection.
    */
-  public static String getHostIp(String csqlInstanceName, boolean enableIamAuth, String ipTypes)
+  public static String getHostIp(String csqlInstanceName, String ipTypes)
       throws IOException {
-    return getInstance().getHostIp(csqlInstanceName, enableIamAuth, listIpTypes(ipTypes));
+    return getInstance().getHostIp(csqlInstanceName, listIpTypes(ipTypes));
   }
 
-  private String getHostIp(String instanceName, boolean enableIamAuth, List<String> ipTypes) {
-    CloudSqlInstance instance = getCloudSqlInstance(instanceName, enableIamAuth);
+  private String getHostIp(String instanceName,  List<String> ipTypes) {
+    CloudSqlInstance instance = getCloudSqlInstance(instanceName);
     return instance.getPreferredIp(ipTypes);
   }
 

--- a/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
@@ -152,7 +152,8 @@ public final class CoreSocketFactory {
     return coreSocketFactory;
   }
 
-  private CloudSqlInstance getCloudSqlInstance(String instanceName) {
+  @VisibleForTesting
+  CloudSqlInstance getCloudSqlInstance(String instanceName) {
     return getCloudSqlInstance(instanceName, false);
   }
 

--- a/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
@@ -269,7 +269,7 @@ public final class CoreSocketFactory {
   }
 
   /**
-   * Returns default ip address that can be used to establish Cloud SQL connection.
+   * Returns preferred ip address that can be used to establish Cloud SQL connection.
    */
   public static String getHostIp(String csqlInstanceName, boolean enableIamAuth, String ipTypes)
       throws IOException {

--- a/pom.xml
+++ b/pom.xml
@@ -272,8 +272,8 @@
                 Necessary to allow guava into the assembly jars
                 com.google.guava:guava
 
-                Global test dependencies unused in r2dbc core (no tests currently):
-                junit:junit,com.google.truth:truth, org.bouncycastle:bcpkix-jdk15on
+                Global test dependencies unused in r2dbc core:
+                junit:junit,com.google.truth:truth,org.bouncycastle:bcpkix-jdk15on
                 -->
                 org.ow2.asm:asm-util,com.github.jnr:jnr-unixsocket,org.postgresql:postgresql,junit:junit,com.google.truth:truth,com.microsoft.sqlserver:mssql-jdbc,com.google.guava:guava,org.bouncycastle:bcpkix-jdk15on
               </ignoredDependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -273,9 +273,9 @@
                 com.google.guava:guava
 
                 Global test dependencies unused in r2dbc core (no tests currently):
-                junit:junit,com.google.truth:truth
+                junit:junit,com.google.truth:truth, org.bouncycastle:bcpkix-jdk15on
                 -->
-                org.ow2.asm:asm-util,com.github.jnr:jnr-unixsocket,org.postgresql:postgresql,junit:junit,com.google.truth:truth,com.microsoft.sqlserver:mssql-jdbc,com.google.guava:guava
+                org.ow2.asm:asm-util,com.github.jnr:jnr-unixsocket,org.postgresql:postgresql,junit:junit,com.google.truth:truth,com.microsoft.sqlserver:mssql-jdbc,com.google.guava:guava,org.bouncycastle:bcpkix-jdk15on
               </ignoredDependencies>
             </configuration>
             <executions>

--- a/r2dbc/core/pom.xml
+++ b/r2dbc/core/pom.xml
@@ -135,7 +135,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.1</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/r2dbc/core/pom.xml
+++ b/r2dbc/core/pom.xml
@@ -150,6 +150,12 @@
       <version>1.70</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.apis</groupId>
+      <artifactId>google-api-services-sqladmin</artifactId>
+      <version>v1beta4-rev20230111-2.0.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
  <build>
    <plugins>

--- a/r2dbc/core/pom.xml
+++ b/r2dbc/core/pom.xml
@@ -132,7 +132,42 @@
       <artifactId>netty-handler</artifactId>
       <version>4.1.84.Final</version>
     </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>4.11.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk15on</artifactId>
+      <version>1.70</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
+ <build>
+   <plugins>
+     <plugin>
+       <groupId>org.apache.maven.plugins</groupId>
+       <artifactId>maven-jar-plugin</artifactId>
+       <version>3.3.0</version>
+       <executions>
+         <execution>
+           <goals>
+             <goal>test-jar</goal>
+           </goals>
+         </execution>
+       </executions>
+     </plugin>
+   </plugins>
+
+ </build>
 
   <repositories>
     <repository>

--- a/r2dbc/core/src/main/java/com/google/cloud/sql/core/CloudSqlConnectionFactory.java
+++ b/r2dbc/core/src/main/java/com/google/cloud/sql/core/CloudSqlConnectionFactory.java
@@ -36,7 +36,6 @@ public class CloudSqlConnectionFactory implements ConnectionFactory {
   private Function<ConnectionFactoryOptions, ConnectionFactory> connectionFactoryFactory;
   private ConnectionFactoryOptions.Builder builder;
   private String csqlHostName;
-  private boolean enableIamAuth;
   private String ipTypes;
 
   /**
@@ -44,12 +43,10 @@ public class CloudSqlConnectionFactory implements ConnectionFactory {
    */
   public CloudSqlConnectionFactory(
       Function<ConnectionFactoryOptions, ConnectionFactory> connectionFactoryFactory,
-      boolean enableIamAuth,
       String ipTypes,
       Builder builder,
       String csqlHostName) {
     this.connectionFactoryFactory = connectionFactoryFactory;
-    this.enableIamAuth = enableIamAuth;
     this.ipTypes = ipTypes;
     this.builder = builder;
     this.csqlHostName = csqlHostName;
@@ -74,7 +71,7 @@ public class CloudSqlConnectionFactory implements ConnectionFactory {
   }
 
   private ConnectionFactory getConnectionFactory() throws IOException {
-    String hostIp = CoreSocketFactory.getHostIp(csqlHostName, enableIamAuth, ipTypes);
+    String hostIp = CoreSocketFactory.getHostIp(csqlHostName, ipTypes);
     builder.option(HOST, hostIp).option(PORT, CoreSocketFactory.getDefaultServerProxyPort());
     return connectionFactoryFactory.apply(builder.build());
   }

--- a/r2dbc/core/src/main/java/com/google/cloud/sql/core/CloudSqlConnectionFactory.java
+++ b/r2dbc/core/src/main/java/com/google/cloud/sql/core/CloudSqlConnectionFactory.java
@@ -36,15 +36,21 @@ public class CloudSqlConnectionFactory implements ConnectionFactory {
   private Function<ConnectionFactoryOptions, ConnectionFactory> connectionFactoryFactory;
   private ConnectionFactoryOptions.Builder builder;
   private String csqlHostName;
+  private boolean enableIamAuth;
+  private String ipTypes;
 
   /**
    * Creates an instance of ConnectionFactory that pulls and sets host ip before delegating.
    */
   public CloudSqlConnectionFactory(
       Function<ConnectionFactoryOptions, ConnectionFactory> connectionFactoryFactory,
+      boolean enableIamAuth,
+      String ipTypes,
       Builder builder,
       String csqlHostName) {
     this.connectionFactoryFactory = connectionFactoryFactory;
+    this.enableIamAuth = enableIamAuth;
+    this.ipTypes = ipTypes;
     this.builder = builder;
     this.csqlHostName = csqlHostName;
   }
@@ -68,7 +74,7 @@ public class CloudSqlConnectionFactory implements ConnectionFactory {
   }
 
   private ConnectionFactory getConnectionFactory() throws IOException {
-    String hostIp = CoreSocketFactory.getHostIp(csqlHostName);
+    String hostIp = CoreSocketFactory.getHostIp(csqlHostName, enableIamAuth, ipTypes);
     builder.option(HOST, hostIp).option(PORT, CoreSocketFactory.getDefaultServerProxyPort());
     return connectionFactoryFactory.apply(builder.build());
   }

--- a/r2dbc/core/src/main/java/com/google/cloud/sql/core/CloudSqlConnectionFactory.java
+++ b/r2dbc/core/src/main/java/com/google/cloud/sql/core/CloudSqlConnectionFactory.java
@@ -19,6 +19,7 @@ package com.google.cloud.sql.core;
 import static io.r2dbc.spi.ConnectionFactoryOptions.HOST;
 import static io.r2dbc.spi.ConnectionFactoryOptions.PORT;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.r2dbc.spi.Connection;
 import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.ConnectionFactoryMetadata;
@@ -70,9 +71,20 @@ public class CloudSqlConnectionFactory implements ConnectionFactory {
     }
   }
 
-  private ConnectionFactory getConnectionFactory() throws IOException {
+  @VisibleForTesting
+  void setBuilderHostAndPort() throws IOException {
     String hostIp = CoreSocketFactory.getHostIp(csqlHostName, ipTypes);
     builder.option(HOST, hostIp).option(PORT, CoreSocketFactory.getDefaultServerProxyPort());
+  }
+
+  @VisibleForTesting
+  ConnectionFactoryOptions.Builder getBuilder() throws IOException {
+    return builder;
+  }
+
+
+  private ConnectionFactory getConnectionFactory() throws IOException {
+    setBuilderHostAndPort();
     return connectionFactoryFactory.apply(builder.build());
   }
 }

--- a/r2dbc/core/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProvider.java
+++ b/r2dbc/core/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProvider.java
@@ -131,7 +131,6 @@ public abstract class GcpConnectionFactoryProvider implements ConnectionFactoryP
 
     Builder optionBuilder = createBuilder(connectionFactoryOptions);
 
-
     // Precompute SSL Data to trigger the initial refresh to happen immediately,
     // and ensure enableIAMAuth is set correctly.
     CoreSocketFactory.getSslData(connectionName, enableIamAuth);
@@ -139,7 +138,9 @@ public abstract class GcpConnectionFactoryProvider implements ConnectionFactoryP
     if (socket != null) {
       return socketConnectionFactory(optionBuilder, socket);
     }
-    return tcpConnectionFactory(optionBuilder, enableIamAuth, ipTypes, createSslCustomizer(connectionName, enableIamAuth),
+
+    return tcpConnectionFactory(optionBuilder, enableIamAuth, ipTypes,
+        createSslCustomizer(connectionName, enableIamAuth),
         connectionName);
   }
 

--- a/r2dbc/core/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProvider.java
+++ b/r2dbc/core/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProvider.java
@@ -73,7 +73,6 @@ public abstract class GcpConnectionFactoryProvider implements ConnectionFactoryP
    */
   abstract ConnectionFactory tcpConnectionFactory(
       Builder optionBuilder,
-      boolean enableIamAuth,
       String ipTypes,
       Function<SslContextBuilder, SslContextBuilder> customizer,
       String csqlHostName);
@@ -139,7 +138,7 @@ public abstract class GcpConnectionFactoryProvider implements ConnectionFactoryP
       return socketConnectionFactory(optionBuilder, socket);
     }
 
-    return tcpConnectionFactory(optionBuilder, enableIamAuth, ipTypes,
+    return tcpConnectionFactory(optionBuilder, ipTypes,
         createSslCustomizer(connectionName, enableIamAuth),
         connectionName);
   }

--- a/r2dbc/core/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProvider.java
+++ b/r2dbc/core/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProvider.java
@@ -113,7 +113,6 @@ public abstract class GcpConnectionFactoryProvider implements ConnectionFactoryP
   private ConnectionFactory createFactory(
       ConnectionFactoryOptions connectionFactoryOptions) throws IOException {
     String connectionName = (String) connectionFactoryOptions.getRequiredValue(HOST);
-    String socket = (String) connectionFactoryOptions.getValue(UNIX_SOCKET);
 
     String ipTypes = CoreSocketFactory.DEFAULT_IP_TYPES;
     Object ipTypesObj = connectionFactoryOptions.getValue(IP_TYPES);
@@ -135,6 +134,7 @@ public abstract class GcpConnectionFactoryProvider implements ConnectionFactoryP
     // and ensure enableIAMAuth is set correctly.
     CoreSocketFactory.getSslData(connectionName, enableIamAuth);
 
+    String socket = (String) connectionFactoryOptions.getValue(UNIX_SOCKET);
     if (socket != null) {
       return socketConnectionFactory(optionBuilder, socket);
     }

--- a/r2dbc/core/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProvider.java
+++ b/r2dbc/core/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProvider.java
@@ -37,6 +37,7 @@ import reactor.core.scheduler.Schedulers;
 public abstract class GcpConnectionFactoryProvider implements ConnectionFactoryProvider {
 
   public static final Option<String> UNIX_SOCKET = Option.valueOf("UNIX_SOCKET");
+  public static final Option<String> IP_TYPES = Option.valueOf("IP_TYPES");
   public static final Option<Boolean> ENABLE_IAM_AUTH = Option.valueOf("ENABLE_IAM_AUTH");
 
   private static Function<SslContextBuilder, SslContextBuilder> createSslCustomizer(
@@ -72,6 +73,8 @@ public abstract class GcpConnectionFactoryProvider implements ConnectionFactoryP
    */
   abstract ConnectionFactory tcpConnectionFactory(
       Builder optionBuilder,
+      boolean enableIamAuth,
+      String ipTypes,
       Function<SslContextBuilder, SslContextBuilder> customizer,
       String csqlHostName);
 
@@ -112,6 +115,12 @@ public abstract class GcpConnectionFactoryProvider implements ConnectionFactoryP
     String connectionName = (String) connectionFactoryOptions.getRequiredValue(HOST);
     String socket = (String) connectionFactoryOptions.getValue(UNIX_SOCKET);
 
+    String ipTypes = CoreSocketFactory.DEFAULT_IP_TYPES;
+    Object ipTypesObj = connectionFactoryOptions.getValue(IP_TYPES);
+    if (ipTypesObj != null) {
+      ipTypes = (String) ipTypesObj;
+    }
+
     Object iamAuthObj = connectionFactoryOptions.getValue(ENABLE_IAM_AUTH);
     Boolean enableIamAuth = false;
     if (iamAuthObj instanceof Boolean) {
@@ -130,7 +139,7 @@ public abstract class GcpConnectionFactoryProvider implements ConnectionFactoryP
     if (socket != null) {
       return socketConnectionFactory(optionBuilder, socket);
     }
-    return tcpConnectionFactory(optionBuilder, createSslCustomizer(connectionName, enableIamAuth),
+    return tcpConnectionFactory(optionBuilder, enableIamAuth, ipTypes, createSslCustomizer(connectionName, enableIamAuth),
         connectionName);
   }
 

--- a/r2dbc/core/src/test/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderTest.java
+++ b/r2dbc/core/src/test/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google Inc. All Rights Reserved.
+ * Copyright 2023 Google LLC. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/r2dbc/core/src/test/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderTest.java
+++ b/r2dbc/core/src/test/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2023 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.sql.core;
+
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.when;
+
+import com.google.api.services.sqladmin.SQLAdmin;
+import com.google.api.services.sqladmin.model.ConnectSettings;
+import com.google.api.services.sqladmin.model.GenerateEphemeralCertRequest;
+import com.google.api.services.sqladmin.model.GenerateEphemeralCertResponse;
+import com.google.api.services.sqladmin.model.IpMapping;
+import com.google.api.services.sqladmin.model.SslCert;
+import com.google.cloud.sql.CredentialFactory;
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningScheduledExecutorService;
+import java.io.IOException;
+import java.math.BigInteger;
+import java.security.GeneralSecurityException;
+import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.cert.Certificate;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.util.Base64;
+import java.util.Date;
+import java.util.concurrent.ExecutionException;
+import javax.security.auth.x500.X500Principal;
+import org.bouncycastle.cert.X509CertificateHolder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.OperatorCreationException;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class GcpConnectionFactoryProviderTest {
+  static final String PUBLIC_IP = "127.0.0.1";
+  static final String PRIVATE_IP = "127.0.0.2";
+
+  ListeningScheduledExecutorService defaultExecutor;
+  @Mock
+  CredentialFactory credentialFactory;
+
+  @Mock
+  SQLAdmin adminApi;
+  @Mock
+  SQLAdmin.Connect adminApiConnect;
+  @Mock
+  SQLAdmin.Connect.Get adminApiConnectGet;
+
+  @Mock
+  SQLAdmin.Connect.GenerateEphemeralCert adminApiConnectGenerateEphemeralCert;
+
+  @Mock
+  GenerateEphemeralCertResponse generateEphemeralCertResponse;
+
+  ListenableFuture<KeyPair> clientKeyPair;
+
+  CoreSocketFactory coreSocketFactoryStub;
+
+  String fakeInstanceName = "myProject:myRegion:myInstance";
+
+  private String createEphemeralCert(Duration shiftIntoPast)
+      throws GeneralSecurityException, ExecutionException, OperatorCreationException {
+    Duration validFor = Duration.ofHours(1);
+    ZonedDateTime notBefore = ZonedDateTime.now().minus(shiftIntoPast);
+    ZonedDateTime notAfter = notBefore.plus(validFor);
+
+    KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+    PKCS8EncodedKeySpec keySpec =
+        new PKCS8EncodedKeySpec(decodeBase64StripWhitespace(TestKeys.SIGNING_CA_PRIVATE_KEY));
+    PrivateKey signingKey = keyFactory.generatePrivate(keySpec);
+
+    final ContentSigner signer = new JcaContentSignerBuilder("SHA1withRSA")
+        .build(signingKey);
+
+    X500Principal issuer = new X500Principal(
+        "C = US, O = Google\\, Inc, CN=Google Cloud SQL Signing CA foo:baz");
+    X500Principal subject = new X500Principal("C = US, O = Google\\, Inc, CN=temporary-subject");
+
+    JcaX509v3CertificateBuilder certificateBuilder = new JcaX509v3CertificateBuilder(
+        issuer,
+        BigInteger.ONE,
+        Date.from(notBefore.toInstant()),
+        Date.from(notAfter.toInstant()),
+        subject,
+        Futures.getDone(clientKeyPair).getPublic()
+    );
+
+    X509CertificateHolder certificateHolder = certificateBuilder.build(signer);
+
+    Certificate cert = new JcaX509CertificateConverter()
+        .getCertificate(certificateHolder);
+
+    StringBuilder sb = new StringBuilder();
+    sb.append("-----BEGIN CERTIFICATE-----\n");
+    sb.append(Base64.getEncoder().encodeToString(cert.getEncoded())
+        .replaceAll("(.{64})", "$1\n"));
+    sb.append("\n");
+    sb.append("-----END CERTIFICATE-----\n");
+    return sb.toString();
+  }
+
+  private static byte[] decodeBase64StripWhitespace(String b64) {
+    return Base64.getDecoder().decode(b64.replaceAll("\\s", ""));
+  }
+
+  @BeforeClass
+  public void setup()
+      throws IOException, GeneralSecurityException, ExecutionException, OperatorCreationException {
+    MockitoAnnotations.openMocks(this);
+
+    KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+    PKCS8EncodedKeySpec privateKeySpec =
+        new PKCS8EncodedKeySpec(decodeBase64StripWhitespace(TestKeys.CLIENT_PRIVATE_KEY));
+    PrivateKey privateKey = keyFactory.generatePrivate(privateKeySpec);
+
+    X509EncodedKeySpec publicKeySpec =
+        new X509EncodedKeySpec(decodeBase64StripWhitespace(TestKeys.CLIENT_PUBLIC_KEY));
+    PublicKey publicKey = keyFactory.generatePublic(publicKeySpec);
+
+    clientKeyPair = Futures.immediateFuture(new KeyPair(publicKey, privateKey));
+
+    defaultExecutor = CoreSocketFactory.getDefaultExecutor();
+
+    // Stub the API client for testing
+    when(adminApi.connect()).thenReturn(adminApiConnect);
+
+    // Stub when correct instance
+    when(adminApiConnect.get(eq("myProject"), eq("myRegion~myInstance"))).thenReturn(adminApiConnectGet);
+
+
+    when(adminApiConnect.generateEphemeralCert(
+        anyString(), anyString(), isA(GenerateEphemeralCertRequest.class)))
+        .thenReturn(adminApiConnectGenerateEphemeralCert);
+
+    when(adminApiConnectGet.execute())
+        .thenReturn(
+            new ConnectSettings()
+                .setBackendType("SECOND_GEN")
+                .setIpAddresses(
+                    ImmutableList.of(
+                        new IpMapping().setIpAddress(PUBLIC_IP).setType("PRIMARY"),
+                        new IpMapping().setIpAddress(PRIVATE_IP).setType("PRIVATE")))
+                .setServerCaCert(new SslCert().setCert(TestKeys.SERVER_CA_CERT))
+                .setRegion("myRegion"));
+    when(adminApiConnectGenerateEphemeralCert.execute())
+        .thenReturn(generateEphemeralCertResponse);
+    when(generateEphemeralCertResponse.getEphemeralCert())
+        .thenReturn(new SslCert().setCert(createEphemeralCert(Duration.ofSeconds(0))));
+
+    coreSocketFactoryStub =
+        new CoreSocketFactory(clientKeyPair, adminApi, credentialFactory, 3307, defaultExecutor);
+  }
+
+}

--- a/r2dbc/core/src/test/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderTest.java
+++ b/r2dbc/core/src/test/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderTest.java
@@ -54,7 +54,7 @@ import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
 import org.bouncycastle.operator.ContentSigner;
 import org.bouncycastle.operator.OperatorCreationException;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
-import org.junit.BeforeClass;
+import org.junit.Before;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -123,7 +123,7 @@ public class GcpConnectionFactoryProviderTest {
     return sb.toString();
   }
 
-  @BeforeClass
+  @Before
   public void setup()
       throws IOException, GeneralSecurityException, ExecutionException, OperatorCreationException {
     MockitoAnnotations.openMocks(this);

--- a/r2dbc/core/src/test/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderTest.java
+++ b/r2dbc/core/src/test/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderTest.java
@@ -61,7 +61,7 @@ import org.mockito.MockitoAnnotations;
 public class GcpConnectionFactoryProviderTest {
 
   static final String PUBLIC_IP = "127.0.0.1";
-  static final String PRIVATE_IP = "127.0.0.2";
+  static final String PRIVATE_IP = "10.0.0.1";
 
   ListeningScheduledExecutorService defaultExecutor;
   @Mock

--- a/r2dbc/core/src/test/java/com/google/cloud/sql/core/TestKeys.java
+++ b/r2dbc/core/src/test/java/com/google/cloud/sql/core/TestKeys.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google Inc. All Rights Reserved.
+ * Copyright 2023 Google LLC. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/r2dbc/core/src/test/java/com/google/cloud/sql/core/TestKeys.java
+++ b/r2dbc/core/src/test/java/com/google/cloud/sql/core/TestKeys.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2023 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.sql.core;
+
+class TestKeys {
+  static final String SIGNING_CA_PRIVATE_KEY =
+      "MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDSd6WlH1OH+qBx\n"
+          + "wxPcZCbhktN1cL8q/bszvcqLsiuhnbMrYLojbL/qZ8agS6lqM7rGwmCrbZIZtati\n"
+          + "rBFixGGg6he3oD764Sqj12blk2DHiilRcWEtOivuGBfkCwpk28C5oG5r/sKRfQKh\n"
+          + "EQfWOEgQnN4UMc053rJJS0HmlUcO6CVS48/uj+RUbDzlaLeFfIHx7ungvoV+O1JZ\n"
+          + "6ZvJGhctIkKLn7a6o0a7rOVdB3GqYD7vT6DuerADc8ssOfiWS+tcZLeY9zcB6eZ6\n"
+          + "XLNn3OR9CUDqLqqtIwwsqM21vV989eWJgjCE0JjUvugAKs66xGzIkXoVrYoNW9h1\n"
+          + "71YTg0FJAgMBAAECggEAa/pUcnWy7kWIATV7QAvl4r7oXA0/FrhcTbxmaOs89Uqp\n"
+          + "/GxAsyH9CC67uct3nHPztDtPS0QIu8X3qsTqmoh0KhFPn7bH+QCCVtKRCOFmupjI\n"
+          + "f+8yUvjQRvP3ddiwOXSA2PtVC3UFr4y6R5YsNhxj5JoGWcf/KVx2jaHdqoYVkbBc\n"
+          + "ArmSx8GZDG0A+S6IhBzdzYOLSJJp+WXzwMD7bMJTFmob1Soml520C5TsqTSb1k8F\n"
+          + "SQZrOueIVIlixb/NoHZgGyJuE3KlkoxD8gWcFSf78IK38lBOxoosR0xEPPIBy57N\n"
+          + "PIKe6S2ZTm1SwqrPPM+VgQxf4xAshz7YcN8bq6absQKBgQDvfuLLpUklM19lPVu9\n"
+          + "bKKGnDWqwx87piusZfkzkko5snmiyjc92ArSokUOPxsvgmPmfPd71q2rE718KLvA\n"
+          + "oYlUdIWQClyMNmsLvO8WQUM2Cbyruzztp3zVErjMe3iFL/Nd5+NV80WIiy5aYh+4\n"
+          + "/Q40Hq38J7oai04y8I1QFxGblQKBgQDg+KcMPXy84A7dWaWsulxidCk9cJW6mzgy\n"
+          + "ycp5PZkKAb/eAQ9UzhD9oDOCMPCweUO2i7NdQ/CoaZqs+Zc2QZVtb9nJAHLHM11d\n"
+          + "c7y8biG9bj8E3thE9+BRW5w9rBgMGxLkneIahMdO50H0QnHL2gdtmQpG/BbfnGbl\n"
+          + "+WvTbKmB5QKBgFObqVNMtXdeMtxmCkPby/VQTU/65ElvnmmGA/RkCrOPwfT5wUU+\n"
+          + "ybB048SwdS4lx/hsAf3imShTMOBKXBlIi2fHceUyKNLuIHqtj43mZK9VwN7287NH\n"
+          + "uEWuToNcS1u7vKs4y91ymwCrDhiRjt+GwFGjsDuKJucjYL5Zygt+si/tAoGBALC+\n"
+          + "qX7UT8uTvBnq9F5fi3VODZhXe0q/58b/AjN+UV2rQjIIYyMdQfwAgHcoO/BpVOl1\n"
+          + "l9UOK2Qkk4CSFlpp7BuuZEumLoaRtChXZVAkth09IAWTjhWhKHrCnl1Vdw8Ltiwm\n"
+          + "Xhy3dF5pEUf1a7Hb+ToBojFinBXRqoXDDxNrq0CBAoGBAJnBXa63jw06ZNAqGR4m\n"
+          + "kyWoBypoN40Qc8SuAcSiuvidWzA2SRK7Obww8IKF1uL67KPtbcbgwx1Nlr7UyOoy\n"
+          + "xbRmZ9PYNFbhDSMXci1lCzwfMJI5WaTgHfvMle/EMyaayAxBWCTy1dLzzIvXM9af\n"
+          + "Ehw2r5FAJ1ufiLykBhkq87+h";
+
+  static final String CLIENT_PUBLIC_KEY =
+      "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApx+unYXDyoIBEdZouVaX\n"
+          + "es7v44rpzyscPxPxwKT1vhdSmugO0OwbojadKGb/iI7pNfKcbscdss9X5iX5ceev\n"
+          + "XtqvYFXpcQa+EyssTdeXD1yZ/sXkA5r9ChQwHSe5X+Gfs1NiyCO7IYHfg66TEJVr\n"
+          + "j6Rn82yLmKCybcH56bqqsj93X4DRpKUkc2y9SMM0+srDPVTNNmayBrL/rpcRiH8+\n"
+          + "E9KD/B2KnaNsBrJltfRZA/g7Gt+O0fBJJwZxi+AZ90N5oS9peK2qXipsr6TI04H3\n"
+          + "vuEW9Wvl3F0sgMPluVdlHvXD5E0lM71YxfnldYVSNL41S38GyM6I4WqWO4p+gz/j\n"
+          + "LwIDAQAB";
+
+  static final String CLIENT_PRIVATE_KEY =
+      "MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQCnH66dhcPKggER\n"
+          + "1mi5Vpd6zu/jiunPKxw/E/HApPW+F1Ka6A7Q7BuiNp0oZv+Ijuk18pxuxx2yz1fm\n"
+          + "Jflx569e2q9gVelxBr4TKyxN15cPXJn+xeQDmv0KFDAdJ7lf4Z+zU2LII7shgd+D\n"
+          + "rpMQlWuPpGfzbIuYoLJtwfnpuqqyP3dfgNGkpSRzbL1IwzT6ysM9VM02ZrIGsv+u\n"
+          + "lxGIfz4T0oP8HYqdo2wGsmW19FkD+Dsa347R8EknBnGL4Bn3Q3mhL2l4rapeKmyv\n"
+          + "pMjTgfe+4Rb1a+XcXSyAw+W5V2Ue9cPkTSUzvVjF+eV1hVI0vjVLfwbIzojhapY7\n"
+          + "in6DP+MvAgMBAAECggEAEWGaJ4fh9Q3QTqqd+ain2H3tNR0ddA5nwaexXPfLFxoV\n"
+          + "3UaFQ/VKanSDo9ASg4FZf+LboinTTOWDnswURWRzOMpFsx88SCULX7L9yJrDezWG\n"
+          + "TpkGPdnAt2uiFWYsQWyVz3C8tVQCAlofhPKDGRZxOV8/8HE5k4YjCIdEFqrzVdZY\n"
+          + "f2rIXLzhxv8VhfvLeIiCx7nSYlNkBTdTfQpsSeUXschdeDQ/iCvxFdmBBnmQB3rI\n"
+          + "uJOmKL2MzVA0052xhDB5Gx6uX4moffZtAET8fEqjXqEfJKwMYokY27dWbcPeXxyi\n"
+          + "e4UZJJg687BItYegLl32ceOG9mve8wjbT9xBXbjjAQKBgQDuPnvAEZBv0y8jMf5b\n"
+          + "f4OAz4Xzdnv8Yb4kYYMguHkLYI4OHL3RfdJJ7wijXhpVxx8klEUBJRdCXvsfv/oO\n"
+          + "UkPwRfpS1MdOyZ0QWS2DartUV5ybjXeL9321dpB0C4CTRY/RJ4wPKvxIw1Zo2YRn\n"
+          + "pB9xSaf3U+Q0nYerbKFVfv9lSwKBgQCzlEbhN4qLnc31PcfMswQhXk+sORbw0GYb\n"
+          + "cALDlHq4c5DOykbLSXOj0/XR9+eXB48qOwWRaprr7p3eRctpUf5vrnIHFSz3icaj\n"
+          + "mRhx1K1pXXvaIwbwyGxB+ffe27mE0Swyu0SEPi+m/9AXbuurPcKkKbp72l4b0Wow\n"
+          + "ymuEleUfLQKBgFFXtBjX5mDH0ghKQXYsC1IniKyff6WkGa+CO6soUOu5g8b9uTGV\n"
+          + "q/7iRijBMGypF9D9brH9X/uhQkyM12ucWuXmfplZXNNhsuaqDAgaoOsjHq1dl7uK\n"
+          + "PLmAScHVS4j87yWSQxfKrWiKiS4zVimst6+OXnLribcNMg0tgcgXHEwRAoGAHKJe\n"
+          + "EvdaPhzxhFNPkpJQ7EkvhxSrVcbFIUbhCfKZBuRWiMK0OyIBMHRR1CMlaG2qJF+4\n"
+          + "6ZEIFuq7fX+/iZGrcn9sazizLN1pMRjuTuhMpmpjn0rKhoZOzM5g+cYrdMQtugEm\n"
+          + "UbfgvU45DiN/rJRyft6wf6M4MlNYDWOZdVC5chkCgYBzdym2szffnFkJxdXnebqm\n"
+          + "UErZeLfeW+WV0VWa5ecBqgsp+bJaVcDF6+ASUPxcZpFXvxQLbX2eTKLYaZoWOWmU\n"
+          + "RCk7yv+CNAjdIAn9Q2eVY2pY9XABgKuY+gBS87/hK/lmyD22yhSKjcyYOn8pNCvp\n"
+          + "BbHwmDjF6MtFsAkKnLfI8A==";
+
+  static final String SIGNING_CA_CERT =
+      "-----BEGIN CERTIFICATE-----\n"
+          + "MIIDNTCCAh2gAwIBAgIBADANBgkqhkiG9w0BAQUFADBRMSwwKgYDVQQDEyNHb29n\n"
+          + "bGUgQ2xvdWQgU1FMIFNpZ25pbmcgQ0EgZm9vOmJhejEUMBIGA1UEChMLR29vZ2xl\n"
+          + "LCBJbmMxCzAJBgNVBAYTAlVTMCAXDTE2MDMxMzA2MTYxNVoYDzIxMTYwMjE4MDYx\n"
+          + "NzE1WjBRMSwwKgYDVQQDEyNHb29nbGUgQ2xvdWQgU1FMIFNpZ25pbmcgQ0EgZm9v\n"
+          + "OmJhejEUMBIGA1UEChMLR29vZ2xlLCBJbmMxCzAJBgNVBAYTAlVTMIIBIjANBgkq\n"
+          + "hkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0nelpR9Th/qgccMT3GQm4ZLTdXC/Kv27\n"
+          + "M73Ki7IroZ2zK2C6I2y/6mfGoEupajO6xsJgq22SGbWrYqwRYsRhoOoXt6A++uEq\n"
+          + "o9dm5ZNgx4opUXFhLTor7hgX5AsKZNvAuaBua/7CkX0CoREH1jhIEJzeFDHNOd6y\n"
+          + "SUtB5pVHDuglUuPP7o/kVGw85Wi3hXyB8e7p4L6FfjtSWembyRoXLSJCi5+2uqNG\n"
+          + "u6zlXQdxqmA+70+g7nqwA3PLLDn4lkvrXGS3mPc3AenmelyzZ9zkfQlA6i6qrSMM\n"
+          + "LKjNtb1ffPXliYIwhNCY1L7oACrOusRsyJF6Fa2KDVvYde9WE4NBSQIDAQABoxYw\n"
+          + "FDASBgNVHRMBAf8ECDAGAQH/AgEAMA0GCSqGSIb3DQEBBQUAA4IBAQA8UA4l5ens\n"
+          + "dw3pgHIEIOel5oL+aEo9UGwqgRFtrW3K6qE+DK95BrhOi7oFkzWbfiKAqxmbXj5d\n"
+          + "Rjs5EvU75qAg0tMA0iBBJ3jQyVRWVTD1uU07HhJBT/4AZgAIp95Pyn0w8x/3T4Xz\n"
+          + "nV5ib/mc9bgPKRE0ukG4U5ZKD0lzqrcdK6ZaXnzENWN/C1NamKgkETgFypb2dScS\n"
+          + "wzxJVk74noD9AtZyXuWxt1Zr7F0j8Atc7Vcy4sWAiNLIAG4iyCrDeGrRRRRN5EHw\n"
+          + "4ptfP/7xZYEPpcbPTMzl4A7Eyi5yrox3sRLHhINmyeVqIvGz6udXsG1NrCZgTTOd\n"
+          + "xw4ubc7zoGs2\n"
+          + "-----END CERTIFICATE-----";
+
+  static final String SERVER_CA_CERT =
+      "-----BEGIN CERTIFICATE-----\n"
+          + "MIIDIzCCAgugAwIBAgIBADANBgkqhkiG9w0BAQUFADBIMSMwIQYDVQQDExpHb29n\n"
+          + "bGUgQ2xvdWQgU1FMIFNlcnZlciBDQTEUMBIGA1UEChMLR29vZ2xlLCBJbmMxCzAJ\n"
+          + "BgNVBAYTAlVTMCAXDTE2MDMxMzA2MTYxNloYDzIxMTYwMjE4MDYxNzE2WjBIMSMw\n"
+          + "IQYDVQQDExpHb29nbGUgQ2xvdWQgU1FMIFNlcnZlciBDQTEUMBIGA1UEChMLR29v\n"
+          + "Z2xlLCBJbmMxCzAJBgNVBAYTAlVTMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB\n"
+          + "CgKCAQEAgyVrgTxDId18XvldIfh8JEz99zMKr8Yq36LlehfJAzXBiejU3mqVciok\n"
+          + "4C9Gh4tmOy/gzUXYzcOlmRveJLcSqzildmYbMVKjv9lSfstMDdrMd5MVgV3jVV/8\n"
+          + "q5zul6Gg/bHkWF+wgS51D8kofBDk1AYkH0pepvuKVsM6UUHYa1hXoTGVUwtlnSte\n"
+          + "X2PB9rTx9eL1S9MrD+6LcVEAiYCYMghFXXhY8KadXrW/haK9Al9tc4E9m9CY3nrL\n"
+          + "Q+15J7iG3vwwzUEIJa3l1m2vGfUCBR8RKUM310b4nTna+E8YxfOU9NZwabiK7L6z\n"
+          + "InE2Cx8j3eIU8MDPwqJPaAQXNEU3RQIDAQABoxYwFDASBgNVHRMBAf8ECDAGAQH/\n"
+          + "AgEAMA0GCSqGSIb3DQEBBQUAA4IBAQBXEW8ojlWrG9Ac4cQoHrQkk7O/ok5uf74U\n"
+          + "fdpNR00mmd7XIXIwE3Q5Cx+u/OJmuJ65sb5456Lhj6XPbP5OICdSqMxLIKncC783\n"
+          + "jWn9ZpySLLkf9MYTwWax9LFzTtx2FT446kJagAGFm9DGdYkfjEg7cj6KCGvVGePL\n"
+          + "J++eibx5TfDQhvMoyewSi//uWKVSoIlVYVfhPAiViQSRWgfEE0w5RQ0r4tqe2zsU\n"
+          + "AgxI+m9NQvwyLZXjgqGZYXap61eRjQyt6saEoARqgyQFJt23uVsZ+MWDNObs7ozH\n"
+          + "83dHBDTEiWkAxW6kEtjI0R6+32rBvgqhElwTI9icEJgwRPd+pBol\n"
+          + "-----END CERTIFICATE-----";
+
+  static final String SERVER_CERT =
+      "-----BEGIN CERTIFICATE-----\n"
+          + "MIIC/zCCAeegAwIBAgIEd/w5zjANBgkqhkiG9w0BAQUFADBIMSMwIQYDVQQDExpH\n"
+          + "b29nbGUgQ2xvdWQgU1FMIFNlcnZlciBDQTEUMBIGA1UEChMLR29vZ2xlLCBJbmMx\n"
+          + "CzAJBgNVBAYTAlVTMCAXDTE2MDMxMzA2MTYxNloYDzIxMTYwMjE4MDYxNzE2WjA1\n"
+          + "MRAwDgYDVQQDEwdmb286YmF6MRQwEgYDVQQKEwtHb29nbGUsIEluYzELMAkGA1UE\n"
+          + "BhMCVVMwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCgOl1rxWsS3MC0\n"
+          + "wZ4R0yYzGNumwMeuU9o0H9KXeOQ4Pfx1tZDlHNrl2N+sY6o0CojHIvlMulykw/c9\n"
+          + "0duT6Kbv/XO7neBZYXbIdMa3LFOCNQJt4JLy4Cke8j3+Jv+RMr7vWFGBJo3v+M9q\n"
+          + "0fiHgJ8fZOxUhxe3tZ5tgB6D+M6EVv36w4AVw73kg9lJldIjWC8TSNpPjusdhgyB\n"
+          + "mYNg476yC7iSz0vQ8DcKu0740ljEYkqCCm5QzycW+iz8HH16fLsLjgF1iJG85Ylu\n"
+          + "7uLNkK+ijTC2P4vVDaM1LzR4O9ILjZPiQ/NgFB4T6gf4hL3EnIuOiQrkWswC5ouT\n"
+          + "Gw5HXqEVAgMBAAGjAjAAMA0GCSqGSIb3DQEBBQUAA4IBAQAgbxjlZrhJSG7Pij+4\n"
+          + "r60IkoJtbckLzG3RGJshXwjW53D25wp/bSnpJK4EzJ3BjZCYSCF3jW6Cfqwr43mQ\n"
+          + "DCBuYa7HH30pHqXxaiZplbUE3o008qfV7mDChEcYm3avVVfpTD28h3ousZ4bL/hd\n"
+          + "8amFE7/K/jpDbakTSLIMnMfJMyHpaTH24Wmg2wdFwPYrZeOwn7zsHaRm+x7gQrsV\n"
+          + "V+lg9d4e7XmUmG2+hJ1FDBLzfJpQcSMjLGaX3OWGG+W5sIOpLPxA3P5v8sG0dGZu\n"
+          + "eJtxixrexVu6ULPplrsBN+6Ga843SCywkfIJf2nmpOOOSVqr5jnCIGQ5yHR17TlE\n"
+          + "12Jk\n"
+          + "-----END CERTIFICATE-----";
+
+  static final String SERVER_CERT_PRIVATE_KEY =
+      "MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCgOl1rxWsS3MC0\n"
+          + "wZ4R0yYzGNumwMeuU9o0H9KXeOQ4Pfx1tZDlHNrl2N+sY6o0CojHIvlMulykw/c9\n"
+          + "0duT6Kbv/XO7neBZYXbIdMa3LFOCNQJt4JLy4Cke8j3+Jv+RMr7vWFGBJo3v+M9q\n"
+          + "0fiHgJ8fZOxUhxe3tZ5tgB6D+M6EVv36w4AVw73kg9lJldIjWC8TSNpPjusdhgyB\n"
+          + "mYNg476yC7iSz0vQ8DcKu0740ljEYkqCCm5QzycW+iz8HH16fLsLjgF1iJG85Ylu\n"
+          + "7uLNkK+ijTC2P4vVDaM1LzR4O9ILjZPiQ/NgFB4T6gf4hL3EnIuOiQrkWswC5ouT\n"
+          + "Gw5HXqEVAgMBAAECggEAN6gufVolOHcgJWnAK7bp5QP0gLckZaTQ/hwzvdQLipHV\n"
+          + "mVnJjBx62S59e9de7xbdrjay3Hk75yv/PSUhnf5JxsGGqxxLKyEU7srJoCUwmOEr\n"
+          + "B9njkaRWBF7nM9p+GgTDmEZYgYFP+pS2EAgByaffHjujcDVBAtp+vtCrSPJrYkJ7\n"
+          + "cYRADSRNBZmYi83hxCC3VFQ3nlxMEPMIv0lKLbF/5zOrVZ3mJrAi2Qqf2TT5z+G2\n"
+          + "QySgcvssyHwOftv3gxfcggQiX6egkNwMyKhhKXD0lIdkqz8veODc2Z/KpDxaiE3u\n"
+          + "jW1AC/0wtJMCa2t4LdcX98/gZPufld5L7vwaVGizgQKBgQDplMfCidp+FbPwXoqf\n"
+          + "coE+NoJ8qkXnl2lDuU/XwcC0Eeob7av+dVRbCbKTNbMFjJ16O587NZ1H4O28XfEo\n"
+          + "yPiEgOJE4ELjIoirDf2JGM8SSNyopyhrbOHUtULXdy5gQQ9SRW2vCNYjz7FXfeyG\n"
+          + "ZOaHDOYpTNZaXvtva+khZgOZ4QKBgQCvm0GFxsmoxd17NyW4Jni7y5A4WYD8/NEp\n"
+          + "sOiHKhldIsjNLTzPJ/ePHiG4yLl50x3/qh8Bfwj8jdTavbIrYJ0DdJyNEu1y3L+P\n"
+          + "zLGXZmXDNTuFhYQ+QzcWuRZck5RKNhVT5L3qXTuyv7LKkC/XdX16bQ8df1E0KvQk\n"
+          + "Z22OR191tQKBgQDif9ENBZwHc4ge565IW0KUT0tNE9fhcOM0NrgDoe/5LP30ww1r\n"
+          + "G98GwGqXcRT9ppL1+ma3hY/UKXqelAHL6MWDx26iF00E73HTXSejD5mMQ3clW6JI\n"
+          + "OTbrijEcuocP80amIojvmAP+ieGP053N3H3mK03scoPQ8hWiv+M67a9EQQKBgEBe\n"
+          + "odL+vjbuaLRcz6fD+mekQ7ZUILMbnTQyE9pP9UItmPuUxICO/vDoM6Y/dbWRTKLF\n"
+          + "4l2zCkFBYC/aby/1VzjICwavVHjRMCru9n4v28eFgM791S7Zhpz+tZKzyhy13HWH\n"
+          + "GJKLIHHyUQBtgAvzlk5FIdBHNiXwRNP/UapgwT4tAoGAW91PH2YXPMIg71iIYTvm\n"
+          + "ngT8fznmvGO0D/28ItgvQzfd22P0CHNr/EHC4N3H2LkLWjYERb6Msn95zqt4b0dY\n"
+          + "P6VXe8hp4ObDka+D9mI6IfkYUuJzFlySXZxq/V2WWVIVAW6hl6VD13t/GfjGwbr6\n"
+          + "6g41F14dftbtendj7EJqi2Y=";
+}

--- a/r2dbc/core/src/test/java/com/google/cloud/sql/core/TestKeys.java
+++ b/r2dbc/core/src/test/java/com/google/cloud/sql/core/TestKeys.java
@@ -17,6 +17,7 @@
 package com.google.cloud.sql.core;
 
 class TestKeys {
+
   static final String SIGNING_CA_PRIVATE_KEY =
       "MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDSd6WlH1OH+qBx\n"
           + "wxPcZCbhktN1cL8q/bszvcqLsiuhnbMrYLojbL/qZ8agS6lqM7rGwmCrbZIZtati\n"

--- a/r2dbc/core/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/r2dbc/core/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/r2dbc/mysql/pom.xml
+++ b/r2dbc/mysql/pom.xml
@@ -243,6 +243,13 @@
       <version>4.11.0</version>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk15on</artifactId>
+      <version>1.70</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>com.google.cloud.sql</groupId>
       <artifactId>cloud-sql-connector-r2dbc-core</artifactId>

--- a/r2dbc/mysql/pom.xml
+++ b/r2dbc/mysql/pom.xml
@@ -239,14 +239,8 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-inline</artifactId>
+      <artifactId>mockito-core</artifactId>
       <version>4.11.0</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-jdk15on</artifactId>
-      <version>1.70</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/r2dbc/mysql/pom.xml
+++ b/r2dbc/mysql/pom.xml
@@ -237,6 +237,25 @@
       <version>1.0.0.RELEASE</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-inline</artifactId>
+      <version>4.11.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk15on</artifactId>
+      <version>1.70</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud.sql</groupId>
+      <artifactId>cloud-sql-connector-r2dbc-core</artifactId>
+      <version>${project.parent.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/r2dbc/mysql/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderMysql.java
+++ b/r2dbc/mysql/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderMysql.java
@@ -49,7 +49,6 @@ public class GcpConnectionFactoryProviderMysql extends GcpConnectionFactoryProvi
   @Override
   ConnectionFactory tcpConnectionFactory(
       Builder optionBuilder,
-      boolean enableIamAuth,
       String ipTypes,
       Function<SslContextBuilder, SslContextBuilder> customizer,
       String csqlHostName) {

--- a/r2dbc/mysql/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderMysql.java
+++ b/r2dbc/mysql/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderMysql.java
@@ -49,6 +49,8 @@ public class GcpConnectionFactoryProviderMysql extends GcpConnectionFactoryProvi
   @Override
   ConnectionFactory tcpConnectionFactory(
       Builder optionBuilder,
+      boolean enableIamAuth,
+      String ipTypes,
       Function<SslContextBuilder, SslContextBuilder> customizer,
       String csqlHostName) {
     optionBuilder
@@ -58,6 +60,8 @@ public class GcpConnectionFactoryProviderMysql extends GcpConnectionFactoryProvi
         .option(MySqlConnectionFactoryProvider.TCP_KEEP_ALIVE, true);
     return new CloudSqlConnectionFactory(
         (ConnectionFactoryOptions options) -> new MySqlConnectionFactoryProvider().create(options),
+        enableIamAuth,
+        ipTypes,
         optionBuilder,
         csqlHostName);
   }

--- a/r2dbc/mysql/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderMysql.java
+++ b/r2dbc/mysql/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderMysql.java
@@ -60,7 +60,6 @@ public class GcpConnectionFactoryProviderMysql extends GcpConnectionFactoryProvi
         .option(MySqlConnectionFactoryProvider.TCP_KEEP_ALIVE, true);
     return new CloudSqlConnectionFactory(
         (ConnectionFactoryOptions options) -> new MySqlConnectionFactoryProvider().create(options),
-        enableIamAuth,
         ipTypes,
         optionBuilder,
         csqlHostName);

--- a/r2dbc/mysql/src/test/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderMysqlTest.java
+++ b/r2dbc/mysql/src/test/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderMysqlTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google Inc. All Rights Reserved.
+ * Copyright 2023 Google LLC. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/r2dbc/mysql/src/test/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderMysqlTest.java
+++ b/r2dbc/mysql/src/test/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderMysqlTest.java
@@ -35,7 +35,6 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 
-
 @RunWith(JUnit4.class)
 public class GcpConnectionFactoryProviderMysqlTest extends GcpConnectionFactoryProviderTest {
 
@@ -47,14 +46,9 @@ public class GcpConnectionFactoryProviderMysqlTest extends GcpConnectionFactoryP
   public void setupOptions() {
 
     // Set up ConnectionFactoryOptions
-    privateIpOptions = ConnectionFactoryOptions.builder()
-        .option(DRIVER, "gcp")
-        .option(PROTOCOL, "mysql")
-        .option(USER, "fake_user")
-        .option(DATABASE, "fake_db")
-        .option(HOST, fakeInstanceName)
-        .option(IP_TYPES, "PRIVATE")
-        .build();
+    privateIpOptions = ConnectionFactoryOptions.builder().option(DRIVER, "gcp")
+        .option(PROTOCOL, "mysql").option(USER, "fake_user").option(DATABASE, "fake_db")
+        .option(HOST, fakeInstanceName).option(IP_TYPES, "PRIVATE").build();
 
     publicIpOptions = privateIpOptions.mutate().option(IP_TYPES, "PUBLIC").build();
   }
@@ -66,19 +60,15 @@ public class GcpConnectionFactoryProviderMysqlTest extends GcpConnectionFactoryP
 
       mockSocketFactory.when(CoreSocketFactory::getDefaultServerProxyPort).thenReturn(3307);
       mockSocketFactory.when(() -> CoreSocketFactory.getSslData(fakeInstanceName))
-          .thenReturn(
-              coreSocketFactoryStub.getCloudSqlInstance(fakeInstanceName).getSslData());
+          .thenReturn(coreSocketFactoryStub.getCloudSqlInstance(fakeInstanceName).getSslData());
 
       mockSocketFactory.when(() -> CoreSocketFactory.getHostIp(fakeInstanceName, "PRIVATE"))
-          .thenReturn(
-              coreSocketFactoryStub.getCloudSqlInstance(fakeInstanceName).getPreferredIp(
-                  Arrays.asList("PRIVATE")));
+          .thenReturn(coreSocketFactoryStub.getCloudSqlInstance(fakeInstanceName)
+              .getPreferredIp(Arrays.asList("PRIVATE")));
 
       mockSocketFactory.when(() -> CoreSocketFactory.getHostIp(fakeInstanceName, "PUBLIC"))
-          .thenReturn(
-              coreSocketFactoryStub.getCloudSqlInstance(fakeInstanceName).getPreferredIp(
-                  Arrays.asList("PRIMARY")));
-
+          .thenReturn(coreSocketFactoryStub.getCloudSqlInstance(fakeInstanceName)
+              .getPreferredIp(Arrays.asList("PRIMARY")));
 
       GcpConnectionFactoryProviderMysql mysqlProvider = new GcpConnectionFactoryProviderMysql();
 
@@ -89,8 +79,7 @@ public class GcpConnectionFactoryProviderMysqlTest extends GcpConnectionFactoryP
 
       // Check that Driver, Host, and Port are set properly
       ConnectionFactoryOptions mysqlOptions = csqlConnFactoryPrivate.getBuilder().build();
-      assertThat(
-          mysqlProvider.supportedProtocol((String) mysqlOptions.getValue(DRIVER))).isTrue();
+      assertThat(mysqlProvider.supportedProtocol((String) mysqlOptions.getValue(DRIVER))).isTrue();
       assertThat((String) mysqlOptions.getValue(HOST)).isEqualTo(PRIVATE_IP);
       assertThat((int) mysqlOptions.getValue(PORT)).isEqualTo(
           CoreSocketFactory.getDefaultServerProxyPort());
@@ -108,19 +97,15 @@ public class GcpConnectionFactoryProviderMysqlTest extends GcpConnectionFactoryP
 
       mockSocketFactory.when(CoreSocketFactory::getDefaultServerProxyPort).thenReturn(3307);
       mockSocketFactory.when(() -> CoreSocketFactory.getSslData(fakeInstanceName))
-          .thenReturn(
-              coreSocketFactoryStub.getCloudSqlInstance(fakeInstanceName).getSslData());
+          .thenReturn(coreSocketFactoryStub.getCloudSqlInstance(fakeInstanceName).getSslData());
 
       mockSocketFactory.when(() -> CoreSocketFactory.getHostIp(fakeInstanceName, "PRIVATE"))
-          .thenReturn(
-              coreSocketFactoryStub.getCloudSqlInstance(fakeInstanceName).getPreferredIp(
-                  Arrays.asList("PRIVATE")));
+          .thenReturn(coreSocketFactoryStub.getCloudSqlInstance(fakeInstanceName)
+              .getPreferredIp(Arrays.asList("PRIVATE")));
 
       mockSocketFactory.when(() -> CoreSocketFactory.getHostIp(fakeInstanceName, "PUBLIC"))
-          .thenReturn(
-              coreSocketFactoryStub.getCloudSqlInstance(fakeInstanceName).getPreferredIp(
-                  Arrays.asList("PRIMARY")));
-
+          .thenReturn(coreSocketFactoryStub.getCloudSqlInstance(fakeInstanceName)
+              .getPreferredIp(Arrays.asList("PRIMARY")));
 
       GcpConnectionFactoryProviderMysql mysqlProvider = new GcpConnectionFactoryProviderMysql();
 
@@ -131,8 +116,7 @@ public class GcpConnectionFactoryProviderMysqlTest extends GcpConnectionFactoryP
 
       // Check that Driver, Host, and Port are set properly
       ConnectionFactoryOptions mysqlOptions = csqlConnFactoryPublic.getBuilder().build();
-      assertThat(
-          mysqlProvider.supportedProtocol((String) mysqlOptions.getValue(DRIVER))).isTrue();
+      assertThat(mysqlProvider.supportedProtocol((String) mysqlOptions.getValue(DRIVER))).isTrue();
       assertThat((String) mysqlOptions.getValue(HOST)).isEqualTo(PUBLIC_IP);
       assertThat((int) mysqlOptions.getValue(PORT)).isEqualTo(
           CoreSocketFactory.getDefaultServerProxyPort());

--- a/r2dbc/mysql/src/test/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderMysqlTest.java
+++ b/r2dbc/mysql/src/test/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderMysqlTest.java
@@ -27,6 +27,8 @@ import static io.r2dbc.spi.ConnectionFactoryOptions.USER;
 import io.r2dbc.spi.ConnectionFactoryOptions;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -38,8 +40,11 @@ import org.mockito.Mockito;
 @RunWith(JUnit4.class)
 public class GcpConnectionFactoryProviderMysqlTest extends GcpConnectionFactoryProviderTest {
 
-  private static String PRIVATE_IP_LABEL = "PRIVATE";
-  private static String PUBLIC_IP_LABEL = "PRIMARY";
+  private static Map<String, String> IP_LABEL = new HashMap<String,String>() {{
+    put("PUBLIC", "PRIMARY");
+    put("PRIVATE", "PRIVATE");
+  }};
+
   private ConnectionFactoryOptions privateIpOptions;
   private ConnectionFactoryOptions publicIpOptions;
 
@@ -62,14 +67,10 @@ public class GcpConnectionFactoryProviderMysqlTest extends GcpConnectionFactoryP
       mockSocketFactory.when(CoreSocketFactory::getDefaultServerProxyPort).thenReturn(3307);
       mockSocketFactory.when(() -> CoreSocketFactory.getSslData(fakeInstanceName))
           .thenReturn(coreSocketFactoryStub.getCloudSqlInstance(fakeInstanceName).getSslData());
-
-      mockSocketFactory.when(() -> CoreSocketFactory.getHostIp(fakeInstanceName, "PRIVATE"))
+      
+      mockSocketFactory.when(() -> CoreSocketFactory.getHostIp(fakeInstanceName, ipType))
           .thenReturn(coreSocketFactoryStub.getCloudSqlInstance(fakeInstanceName)
-              .getPreferredIp(Arrays.asList("PRIVATE")));
-
-      mockSocketFactory.when(() -> CoreSocketFactory.getHostIp(fakeInstanceName, "PUBLIC"))
-          .thenReturn(coreSocketFactoryStub.getCloudSqlInstance(fakeInstanceName)
-              .getPreferredIp(Arrays.asList(ipType)));
+              .getPreferredIp(Arrays.asList(IP_LABEL.get(ipType))));
 
       GcpConnectionFactoryProviderMysql mysqlProvider = new GcpConnectionFactoryProviderMysql();
 
@@ -93,11 +94,11 @@ public class GcpConnectionFactoryProviderMysqlTest extends GcpConnectionFactoryP
 
   @Test
   public void setsCorrectOptionsForDriverHostAndPortPrivate() {
-    setsCorrectOptionsForDriverHostAndPort(PRIVATE_IP_LABEL, privateIpOptions, PRIVATE_IP);
+    setsCorrectOptionsForDriverHostAndPort("PRIVATE", privateIpOptions, PRIVATE_IP);
   }
 
   @Test
   public void setsCorrectOptionsForDriverHostAndPortPublic() {
-    setsCorrectOptionsForDriverHostAndPort(PUBLIC_IP_LABEL, publicIpOptions, PUBLIC_IP);
+    setsCorrectOptionsForDriverHostAndPort("PUBLIC", publicIpOptions, PUBLIC_IP);
   }
 }

--- a/r2dbc/mysql/src/test/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderMysqlTest.java
+++ b/r2dbc/mysql/src/test/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderMysqlTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2023 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.sql.core;
+
+import static com.google.cloud.sql.core.GcpConnectionFactoryProvider.IP_TYPES;
+import static com.google.common.truth.Truth.assertThat;
+import static io.r2dbc.spi.ConnectionFactoryOptions.DATABASE;
+import static io.r2dbc.spi.ConnectionFactoryOptions.DRIVER;
+import static io.r2dbc.spi.ConnectionFactoryOptions.HOST;
+import static io.r2dbc.spi.ConnectionFactoryOptions.PORT;
+import static io.r2dbc.spi.ConnectionFactoryOptions.PROTOCOL;
+import static io.r2dbc.spi.ConnectionFactoryOptions.USER;
+
+import io.r2dbc.spi.ConnectionFactoryOptions;
+import java.io.IOException;
+import java.util.Arrays;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+
+
+@RunWith(JUnit4.class)
+public class GcpConnectionFactoryProviderMysqlTest extends GcpConnectionFactoryProviderTest {
+
+  private ConnectionFactoryOptions privateIpOptions;
+
+  private ConnectionFactoryOptions publicIpOptions;
+
+  @Before
+  public void setupOptions() {
+
+    // Set up ConnectionFactoryOptions
+    privateIpOptions = ConnectionFactoryOptions.builder()
+        .option(DRIVER, "gcp")
+        .option(PROTOCOL, "mysql")
+        .option(USER, "fake_user")
+        .option(DATABASE, "fake_db")
+        .option(HOST, fakeInstanceName)
+        .option(IP_TYPES, "PRIVATE")
+        .build();
+
+    publicIpOptions = privateIpOptions.mutate().option(IP_TYPES, "PUBLIC").build();
+  }
+
+  @Test
+  public void setsCorrectOptionsForDriverHostAndPortPrivate() {
+    try (MockedStatic<CoreSocketFactory> mockSocketFactory = Mockito.mockStatic(
+        CoreSocketFactory.class)) {
+
+      mockSocketFactory.when(CoreSocketFactory::getDefaultServerProxyPort).thenReturn(3307);
+      mockSocketFactory.when(() -> CoreSocketFactory.getSslData(fakeInstanceName))
+          .thenReturn(
+              coreSocketFactoryStub.getCloudSqlInstance(fakeInstanceName).getSslData());
+
+      mockSocketFactory.when(() -> CoreSocketFactory.getHostIp(fakeInstanceName, "PRIVATE"))
+          .thenReturn(
+              coreSocketFactoryStub.getCloudSqlInstance(fakeInstanceName).getPreferredIp(
+                  Arrays.asList("PRIVATE")));
+
+      mockSocketFactory.when(() -> CoreSocketFactory.getHostIp(fakeInstanceName, "PUBLIC"))
+          .thenReturn(
+              coreSocketFactoryStub.getCloudSqlInstance(fakeInstanceName).getPreferredIp(
+                  Arrays.asList("PRIMARY")));
+
+
+      GcpConnectionFactoryProviderMysql mysqlProvider = new GcpConnectionFactoryProviderMysql();
+
+      // Use the PrivateIP options to make a Cloud SQL Connection Factory
+      CloudSqlConnectionFactory csqlConnFactoryPrivate = (CloudSqlConnectionFactory) mysqlProvider.create(
+          privateIpOptions);
+      csqlConnFactoryPrivate.setBuilderHostAndPort();
+
+      // Check that Driver, Host, and Port are set properly
+      ConnectionFactoryOptions mysqlOptions = csqlConnFactoryPrivate.getBuilder().build();
+      assertThat(
+          mysqlProvider.supportedProtocol((String) mysqlOptions.getValue(DRIVER))).isTrue();
+      assertThat((String) mysqlOptions.getValue(HOST)).isEqualTo(PRIVATE_IP);
+      assertThat((int) mysqlOptions.getValue(PORT)).isEqualTo(
+          CoreSocketFactory.getDefaultServerProxyPort());
+
+
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Test
+  public void setsCorrectOptionsForDriverHostAndPortPublic() {
+    try (MockedStatic<CoreSocketFactory> mockSocketFactory = Mockito.mockStatic(
+        CoreSocketFactory.class)) {
+
+      mockSocketFactory.when(CoreSocketFactory::getDefaultServerProxyPort).thenReturn(3307);
+      mockSocketFactory.when(() -> CoreSocketFactory.getSslData(fakeInstanceName))
+          .thenReturn(
+              coreSocketFactoryStub.getCloudSqlInstance(fakeInstanceName).getSslData());
+
+      mockSocketFactory.when(() -> CoreSocketFactory.getHostIp(fakeInstanceName, "PRIVATE"))
+          .thenReturn(
+              coreSocketFactoryStub.getCloudSqlInstance(fakeInstanceName).getPreferredIp(
+                  Arrays.asList("PRIVATE")));
+
+      mockSocketFactory.when(() -> CoreSocketFactory.getHostIp(fakeInstanceName, "PUBLIC"))
+          .thenReturn(
+              coreSocketFactoryStub.getCloudSqlInstance(fakeInstanceName).getPreferredIp(
+                  Arrays.asList("PRIMARY")));
+
+
+      GcpConnectionFactoryProviderMysql mysqlProvider = new GcpConnectionFactoryProviderMysql();
+
+      // Use the PublicIP options to make a Cloud SQL Connection Factory
+      CloudSqlConnectionFactory csqlConnFactoryPublic = (CloudSqlConnectionFactory) mysqlProvider.create(
+          publicIpOptions);
+      csqlConnFactoryPublic.setBuilderHostAndPort();
+
+      // Check that Driver, Host, and Port are set properly
+      ConnectionFactoryOptions mysqlOptions = csqlConnFactoryPublic.getBuilder().build();
+      assertThat(
+          mysqlProvider.supportedProtocol((String) mysqlOptions.getValue(DRIVER))).isTrue();
+      assertThat((String) mysqlOptions.getValue(HOST)).isEqualTo(PUBLIC_IP);
+      assertThat((int) mysqlOptions.getValue(PORT)).isEqualTo(
+          CoreSocketFactory.getDefaultServerProxyPort());
+
+
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+
+}

--- a/r2dbc/postgres/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderPostgres.java
+++ b/r2dbc/postgres/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderPostgres.java
@@ -54,6 +54,8 @@ public class GcpConnectionFactoryProviderPostgres extends GcpConnectionFactoryPr
   @Override
   ConnectionFactory tcpConnectionFactory(
       Builder optionBuilder,
+      boolean enableIamAuth,
+      String ipTypes,
       Function<SslContextBuilder, SslContextBuilder> customizer,
       String csqlHostName) {
     optionBuilder
@@ -64,6 +66,8 @@ public class GcpConnectionFactoryProviderPostgres extends GcpConnectionFactoryPr
     return new CloudSqlConnectionFactory(
         (ConnectionFactoryOptions options) ->
             new PostgresqlConnectionFactoryProvider().create(options),
+        enableIamAuth,
+        ipTypes,
         optionBuilder,
         csqlHostName);
   }

--- a/r2dbc/postgres/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderPostgres.java
+++ b/r2dbc/postgres/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderPostgres.java
@@ -54,7 +54,6 @@ public class GcpConnectionFactoryProviderPostgres extends GcpConnectionFactoryPr
   @Override
   ConnectionFactory tcpConnectionFactory(
       Builder optionBuilder,
-      boolean enableIamAuth,
       String ipTypes,
       Function<SslContextBuilder, SslContextBuilder> customizer,
       String csqlHostName) {

--- a/r2dbc/postgres/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderPostgres.java
+++ b/r2dbc/postgres/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderPostgres.java
@@ -66,7 +66,6 @@ public class GcpConnectionFactoryProviderPostgres extends GcpConnectionFactoryPr
     return new CloudSqlConnectionFactory(
         (ConnectionFactoryOptions options) ->
             new PostgresqlConnectionFactoryProvider().create(options),
-        enableIamAuth,
         ipTypes,
         optionBuilder,
         csqlHostName);

--- a/r2dbc/sqlserver/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderMssql.java
+++ b/r2dbc/sqlserver/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderMssql.java
@@ -48,7 +48,6 @@ public class GcpConnectionFactoryProviderMssql extends GcpConnectionFactoryProvi
   @Override
   ConnectionFactory tcpConnectionFactory(
       Builder optionBuilder,
-      boolean enableIamAuth,
       String ipTypes,
       Function<SslContextBuilder, SslContextBuilder> customizer,
       String csqlHostName) {

--- a/r2dbc/sqlserver/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderMssql.java
+++ b/r2dbc/sqlserver/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderMssql.java
@@ -59,7 +59,6 @@ public class GcpConnectionFactoryProviderMssql extends GcpConnectionFactoryProvi
 
     return new CloudSqlConnectionFactory(
         (ConnectionFactoryOptions options) -> new MssqlConnectionFactoryProvider().create(options),
-        enableIamAuth,
         ipTypes,
         optionBuilder,
         csqlHostName);

--- a/r2dbc/sqlserver/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderMssql.java
+++ b/r2dbc/sqlserver/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderMssql.java
@@ -48,6 +48,8 @@ public class GcpConnectionFactoryProviderMssql extends GcpConnectionFactoryProvi
   @Override
   ConnectionFactory tcpConnectionFactory(
       Builder optionBuilder,
+      boolean enableIamAuth,
+      String ipTypes,
       Function<SslContextBuilder, SslContextBuilder> customizer,
       String csqlHostName) {
     optionBuilder
@@ -57,6 +59,8 @@ public class GcpConnectionFactoryProviderMssql extends GcpConnectionFactoryProvi
 
     return new CloudSqlConnectionFactory(
         (ConnectionFactoryOptions options) -> new MssqlConnectionFactoryProvider().create(options),
+        enableIamAuth,
+        ipTypes,
         optionBuilder,
         csqlHostName);
   }


### PR DESCRIPTION
Currently there is no way to use the R2DBC connectors and specify IP Type, which is a glaring feature gap. This PR adds support for setting IP type when configuring an R2DBC connection factory and adds tests to make sure the right IP address is being used.

Lots of testing boilerplate here, but the relevant files to look at are:
- `CoreSocketFactory.java`
- `GcpConnectionFactoryProvider.java`
- `CloudSqlConnectionFactory.java`
- `GcpConnectionFactoryProviderMysqlTest.java` (for the test)

Also added `GcpConnectionFactoryProviderTest.java` which is mostly just providing a stub for the CoreSocketFactory which can be used in tests that extend the class