### PR TITLE
chore: build with java 11 for java 8 tests

### DIFF
--- a/.github/scripts/run_tests.sh
+++ b/.github/scripts/run_tests.sh
@@ -21,12 +21,6 @@ function setJava() {
   export PATH=${JAVA_HOME}/bin:$PATH
 }
 
-
-
-
-
-
-
 if [[ $OSTYPE == 'darwin'* ]]; then
   # Add alias for 127.0.0.2 to be used as a loopback address
   # https://superuser.com/questions/458875/how-do-you-get-loopback-addresses-other-than-127-0-0-1-to-work-on-os-x

--- a/.github/scripts/run_tests.sh
+++ b/.github/scripts/run_tests.sh
@@ -58,5 +58,5 @@ echo "Running tests using Java:"
 java -version
 
 echo "Maven version: $(mvn --version)"
-mvn -e -B  -ntp  test -P e2e -Dcheckstyle.skip
+mvn -e -B  -ntp  surefire:test -P e2e -Dcheckstyle.skip
 echo -e "******************** Tests complete.  ********************\n"

--- a/.github/scripts/run_tests.sh
+++ b/.github/scripts/run_tests.sh
@@ -58,5 +58,5 @@ echo "Running tests using Java:"
 java -version
 
 echo "Maven version: $(mvn --version)"
-mvn -e -B  -ntp  surefire:test -P e2e -Dcheckstyle.skip
+mvn -e -B  -ntp  verify -P e2e -Dcheckstyle.skip
 echo -e "******************** Tests complete.  ********************\n"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        java-version: ["8", "11", "17"]
+        java-version: ["11", "17"]
       fail-fast: false
     permissions:
       contents: 'read'
@@ -111,3 +111,101 @@ jobs:
           SQLSERVER_DB: '${{ steps.secrets.outputs.SQLSERVER_DB }}'
         run: ./.github/scripts/run_tests.sh
         shell: bash
+      unit-e2e-java8:
+        # run job on proper workflow event triggers (skip job for pull_request event from forks and only run pull_request_target for "tests: run" label)
+        if: "${{ (github.event.action != 'labeled' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name) || github.event.label.name == 'tests: run' }}"
+        name: unit + e2e java8
+        runs-on: ${{ matrix.os }}
+        strategy:
+          matrix:
+            os: [ macos-latest, windows-latest, ubuntu-latest ]
+          fail-fast: false
+        permissions:
+          contents: 'read'
+          id-token: 'write'
+        steps:
+        - name: Remove PR label
+          if: "${{ github.event.action == 'labeled' && github.event.label.name == 'tests: run' }}"
+          uses: actions/github-script@v6
+          with:
+            github-token: ${{ secrets.GITHUB_TOKEN }}
+            script: |
+              try {
+                await github.rest.issues.removeLabel({
+                  name: 'tests: run',
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.payload.pull_request.number
+                });
+              } catch (e) {
+                console.log('Failed to remove label. Another job may have already removed it!');
+              }
+        - name: Checkout code
+          uses: 'actions/checkout@v3'
+          with:
+            ref: ${{ github.event.pull_request.head.sha }}
+            repository: ${{ github.event.pull_request.head.repo.full_name }}
+
+        # Set up Java 8 for testing
+        - name: Set up JDK 8
+          uses: actions/setup-java@v3
+          with:
+            distribution: 'zulu'
+            java-version: '8'
+        - run: echo "JAVA8_HOME=${JAVA_HOME}" >> $GITHUB_ENV
+            shell: bash
+
+        # Set up Java 11 for compilation
+        - name: Set up JDK 11
+          uses: actions/setup-java@v3
+          with:
+            distribution: 'zulu'
+            java-version: '11'
+        - run: echo "JAVA11_HOME=${JAVA_HOME}" >> $GITHUB_ENV
+            shell: bash
+
+        - id: 'auth'
+          name: 'Authenticate to Google Cloud'
+          uses: 'google-github-actions/auth@v0.8.3'
+          with:
+            workload_identity_provider: ${{ secrets.PROVIDER_NAME }}
+            service_account: ${{ secrets.SERVICE_ACCOUNT }}
+            access_token_lifetime: 600s
+
+        - id: 'secrets'
+          name: Get secrets
+          uses: 'google-github-actions/get-secretmanager-secrets@v0.5.3'
+          with:
+            secrets: |-
+              MYSQL_CONNECTION_NAME:${{ secrets.GOOGLE_CLOUD_PROJECT }}/MYSQL_CONNECTION_NAME
+              MYSQL_USER:${{ secrets.GOOGLE_CLOUD_PROJECT }}/MYSQL_USER
+              MYSQL_PASS:${{ secrets.GOOGLE_CLOUD_PROJECT }}/MYSQL_PASS
+              MYSQL_DB:${{ secrets.GOOGLE_CLOUD_PROJECT }}/MYSQL_DB
+              POSTGRES_CONNECTION_NAME:${{ secrets.GOOGLE_CLOUD_PROJECT }}/POSTGRES_CONNECTION_NAME
+              POSTGRES_IAM_CONNECTION_NAME:${{ secrets.GOOGLE_CLOUD_PROJECT }}/POSTGRES_IAM_CONNECTION_NAME
+              POSTGRES_USER:${{ secrets.GOOGLE_CLOUD_PROJECT }}/POSTGRES_USER
+              POSTGRES_IAM_USER:${{ secrets.GOOGLE_CLOUD_PROJECT }}/POSTGRES_USER_IAM_JAVA
+              POSTGRES_PASS:${{ secrets.GOOGLE_CLOUD_PROJECT }}/POSTGRES_PASS
+              POSTGRES_DB:${{ secrets.GOOGLE_CLOUD_PROJECT }}/POSTGRES_DB
+              SQLSERVER_CONNECTION_NAME:${{ secrets.GOOGLE_CLOUD_PROJECT }}/SQLSERVER_CONNECTION_NAME
+              SQLSERVER_USER:${{ secrets.GOOGLE_CLOUD_PROJECT }}/SQLSERVER_USER
+              SQLSERVER_PASS:${{ secrets.GOOGLE_CLOUD_PROJECT }}/SQLSERVER_PASS
+              SQLSERVER_DB:${{ secrets.GOOGLE_CLOUD_PROJECT }}/SQLSERVER_DB
+        - name: Run tests
+          env:
+            MYSQL_CONNECTION_NAME: '${{ steps.secrets.outputs.MYSQL_CONNECTION_NAME }}'
+            MYSQL_USER: '${{ steps.secrets.outputs.MYSQL_USER }}'
+            MYSQL_PASS: '${{ steps.secrets.outputs.MYSQL_PASS }}'
+            MYSQL_DB: '${{ steps.secrets.outputs.MYSQL_DB }}'
+            POSTGRES_CONNECTION_NAME: '${{ steps.secrets.outputs.POSTGRES_CONNECTION_NAME }}'
+            POSTGRES_IAM_CONNECTION_NAME: '${{ steps.secrets.outputs.POSTGRES_IAM_CONNECTION_NAME }}'
+            POSTGRES_USER: '${{ steps.secrets.outputs.POSTGRES_USER }}'
+            POSTGRES_IAM_USER: '${{ steps.secrets.outputs.POSTGRES_IAM_USER }}'
+            POSTGRES_PASS: '${{ steps.secrets.outputs.POSTGRES_PASS }}'
+            POSTGRES_DB: '${{ steps.secrets.outputs.POSTGRES_DB }}'
+            SQLSERVER_CONNECTION_NAME: '${{ steps.secrets.outputs.SQLSERVER_CONNECTION_NAME }}'
+            SQLSERVER_USER: '${{ steps.secrets.outputs.SQLSERVER_USER }}'
+            SQLSERVER_PASS: '${{ steps.secrets.outputs.SQLSERVER_PASS }}'
+            SQLSERVER_DB: '${{ steps.secrets.outputs.SQLSERVER_DB }}'
+          run: ./.github/scripts/run_tests.sh
+          shell: bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -111,7 +111,7 @@ jobs:
           SQLSERVER_DB: '${{ steps.secrets.outputs.SQLSERVER_DB }}'
         run: ./.github/scripts/run_tests.sh
         shell: bash
-    unit-e2e-java8:
+  unit-e2e-java8:
       # run job on proper workflow event triggers (skip job for pull_request event from forks and only run pull_request_target for "tests: run" label)
       if: "${{ (github.event.action != 'labeled' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name) || github.event.label.name == 'tests: run' }}"
       name: unit + e2e java8

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -111,101 +111,101 @@ jobs:
           SQLSERVER_DB: '${{ steps.secrets.outputs.SQLSERVER_DB }}'
         run: ./.github/scripts/run_tests.sh
         shell: bash
-      unit-e2e-java8:
-        # run job on proper workflow event triggers (skip job for pull_request event from forks and only run pull_request_target for "tests: run" label)
-        if: "${{ (github.event.action != 'labeled' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name) || github.event.label.name == 'tests: run' }}"
-        name: unit + e2e java8
-        runs-on: ${{ matrix.os }}
-        strategy:
-          matrix:
-            os: [ macos-latest, windows-latest, ubuntu-latest ]
-          fail-fast: false
-        permissions:
-          contents: 'read'
-          id-token: 'write'
-        steps:
-        - name: Remove PR label
-          if: "${{ github.event.action == 'labeled' && github.event.label.name == 'tests: run' }}"
-          uses: actions/github-script@v6
-          with:
-            github-token: ${{ secrets.GITHUB_TOKEN }}
-            script: |
-              try {
-                await github.rest.issues.removeLabel({
-                  name: 'tests: run',
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: context.payload.pull_request.number
-                });
-              } catch (e) {
-                console.log('Failed to remove label. Another job may have already removed it!');
-              }
-        - name: Checkout code
-          uses: 'actions/checkout@v3'
-          with:
-            ref: ${{ github.event.pull_request.head.sha }}
-            repository: ${{ github.event.pull_request.head.repo.full_name }}
+    unit-e2e-java8:
+      # run job on proper workflow event triggers (skip job for pull_request event from forks and only run pull_request_target for "tests: run" label)
+      if: "${{ (github.event.action != 'labeled' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name) || github.event.label.name == 'tests: run' }}"
+      name: unit + e2e java8
+      runs-on: ${{ matrix.os }}
+      strategy:
+        matrix:
+          os: [ macos-latest, windows-latest, ubuntu-latest ]
+        fail-fast: false
+      permissions:
+        contents: 'read'
+        id-token: 'write'
+      steps:
+      - name: Remove PR label
+        if: "${{ github.event.action == 'labeled' && github.event.label.name == 'tests: run' }}"
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                name: 'tests: run',
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number
+              });
+            } catch (e) {
+              console.log('Failed to remove label. Another job may have already removed it!');
+            }
+      - name: Checkout code
+        uses: 'actions/checkout@v3'
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
-        # Set up Java 8 for testing
-        - name: Set up JDK 8
-          uses: actions/setup-java@v3
-          with:
-            distribution: 'zulu'
-            java-version: '8'
-        - run: echo "JAVA8_HOME=${JAVA_HOME}" >> $GITHUB_ENV
-            shell: bash
-
-        # Set up Java 11 for compilation
-        - name: Set up JDK 11
-          uses: actions/setup-java@v3
-          with:
-            distribution: 'zulu'
-            java-version: '11'
-        - run: echo "JAVA11_HOME=${JAVA_HOME}" >> $GITHUB_ENV
-            shell: bash
-
-        - id: 'auth'
-          name: 'Authenticate to Google Cloud'
-          uses: 'google-github-actions/auth@v0.8.3'
-          with:
-            workload_identity_provider: ${{ secrets.PROVIDER_NAME }}
-            service_account: ${{ secrets.SERVICE_ACCOUNT }}
-            access_token_lifetime: 600s
-
-        - id: 'secrets'
-          name: Get secrets
-          uses: 'google-github-actions/get-secretmanager-secrets@v0.5.3'
-          with:
-            secrets: |-
-              MYSQL_CONNECTION_NAME:${{ secrets.GOOGLE_CLOUD_PROJECT }}/MYSQL_CONNECTION_NAME
-              MYSQL_USER:${{ secrets.GOOGLE_CLOUD_PROJECT }}/MYSQL_USER
-              MYSQL_PASS:${{ secrets.GOOGLE_CLOUD_PROJECT }}/MYSQL_PASS
-              MYSQL_DB:${{ secrets.GOOGLE_CLOUD_PROJECT }}/MYSQL_DB
-              POSTGRES_CONNECTION_NAME:${{ secrets.GOOGLE_CLOUD_PROJECT }}/POSTGRES_CONNECTION_NAME
-              POSTGRES_IAM_CONNECTION_NAME:${{ secrets.GOOGLE_CLOUD_PROJECT }}/POSTGRES_IAM_CONNECTION_NAME
-              POSTGRES_USER:${{ secrets.GOOGLE_CLOUD_PROJECT }}/POSTGRES_USER
-              POSTGRES_IAM_USER:${{ secrets.GOOGLE_CLOUD_PROJECT }}/POSTGRES_USER_IAM_JAVA
-              POSTGRES_PASS:${{ secrets.GOOGLE_CLOUD_PROJECT }}/POSTGRES_PASS
-              POSTGRES_DB:${{ secrets.GOOGLE_CLOUD_PROJECT }}/POSTGRES_DB
-              SQLSERVER_CONNECTION_NAME:${{ secrets.GOOGLE_CLOUD_PROJECT }}/SQLSERVER_CONNECTION_NAME
-              SQLSERVER_USER:${{ secrets.GOOGLE_CLOUD_PROJECT }}/SQLSERVER_USER
-              SQLSERVER_PASS:${{ secrets.GOOGLE_CLOUD_PROJECT }}/SQLSERVER_PASS
-              SQLSERVER_DB:${{ secrets.GOOGLE_CLOUD_PROJECT }}/SQLSERVER_DB
-        - name: Run tests
-          env:
-            MYSQL_CONNECTION_NAME: '${{ steps.secrets.outputs.MYSQL_CONNECTION_NAME }}'
-            MYSQL_USER: '${{ steps.secrets.outputs.MYSQL_USER }}'
-            MYSQL_PASS: '${{ steps.secrets.outputs.MYSQL_PASS }}'
-            MYSQL_DB: '${{ steps.secrets.outputs.MYSQL_DB }}'
-            POSTGRES_CONNECTION_NAME: '${{ steps.secrets.outputs.POSTGRES_CONNECTION_NAME }}'
-            POSTGRES_IAM_CONNECTION_NAME: '${{ steps.secrets.outputs.POSTGRES_IAM_CONNECTION_NAME }}'
-            POSTGRES_USER: '${{ steps.secrets.outputs.POSTGRES_USER }}'
-            POSTGRES_IAM_USER: '${{ steps.secrets.outputs.POSTGRES_IAM_USER }}'
-            POSTGRES_PASS: '${{ steps.secrets.outputs.POSTGRES_PASS }}'
-            POSTGRES_DB: '${{ steps.secrets.outputs.POSTGRES_DB }}'
-            SQLSERVER_CONNECTION_NAME: '${{ steps.secrets.outputs.SQLSERVER_CONNECTION_NAME }}'
-            SQLSERVER_USER: '${{ steps.secrets.outputs.SQLSERVER_USER }}'
-            SQLSERVER_PASS: '${{ steps.secrets.outputs.SQLSERVER_PASS }}'
-            SQLSERVER_DB: '${{ steps.secrets.outputs.SQLSERVER_DB }}'
-          run: ./.github/scripts/run_tests.sh
+      # Set up Java 8 for testing
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '8'
+      - run: echo "JAVA8_HOME=${JAVA_HOME}" >> $GITHUB_ENV
           shell: bash
+
+      # Set up Java 11 for compilation
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '11'
+      - run: echo "JAVA11_HOME=${JAVA_HOME}" >> $GITHUB_ENV
+          shell: bash
+
+      - id: 'auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v0.8.3'
+        with:
+          workload_identity_provider: ${{ secrets.PROVIDER_NAME }}
+          service_account: ${{ secrets.SERVICE_ACCOUNT }}
+          access_token_lifetime: 600s
+
+      - id: 'secrets'
+        name: Get secrets
+        uses: 'google-github-actions/get-secretmanager-secrets@v0.5.3'
+        with:
+          secrets: |-
+            MYSQL_CONNECTION_NAME:${{ secrets.GOOGLE_CLOUD_PROJECT }}/MYSQL_CONNECTION_NAME
+            MYSQL_USER:${{ secrets.GOOGLE_CLOUD_PROJECT }}/MYSQL_USER
+            MYSQL_PASS:${{ secrets.GOOGLE_CLOUD_PROJECT }}/MYSQL_PASS
+            MYSQL_DB:${{ secrets.GOOGLE_CLOUD_PROJECT }}/MYSQL_DB
+            POSTGRES_CONNECTION_NAME:${{ secrets.GOOGLE_CLOUD_PROJECT }}/POSTGRES_CONNECTION_NAME
+            POSTGRES_IAM_CONNECTION_NAME:${{ secrets.GOOGLE_CLOUD_PROJECT }}/POSTGRES_IAM_CONNECTION_NAME
+            POSTGRES_USER:${{ secrets.GOOGLE_CLOUD_PROJECT }}/POSTGRES_USER
+            POSTGRES_IAM_USER:${{ secrets.GOOGLE_CLOUD_PROJECT }}/POSTGRES_USER_IAM_JAVA
+            POSTGRES_PASS:${{ secrets.GOOGLE_CLOUD_PROJECT }}/POSTGRES_PASS
+            POSTGRES_DB:${{ secrets.GOOGLE_CLOUD_PROJECT }}/POSTGRES_DB
+            SQLSERVER_CONNECTION_NAME:${{ secrets.GOOGLE_CLOUD_PROJECT }}/SQLSERVER_CONNECTION_NAME
+            SQLSERVER_USER:${{ secrets.GOOGLE_CLOUD_PROJECT }}/SQLSERVER_USER
+            SQLSERVER_PASS:${{ secrets.GOOGLE_CLOUD_PROJECT }}/SQLSERVER_PASS
+            SQLSERVER_DB:${{ secrets.GOOGLE_CLOUD_PROJECT }}/SQLSERVER_DB
+      - name: Run tests
+        env:
+          MYSQL_CONNECTION_NAME: '${{ steps.secrets.outputs.MYSQL_CONNECTION_NAME }}'
+          MYSQL_USER: '${{ steps.secrets.outputs.MYSQL_USER }}'
+          MYSQL_PASS: '${{ steps.secrets.outputs.MYSQL_PASS }}'
+          MYSQL_DB: '${{ steps.secrets.outputs.MYSQL_DB }}'
+          POSTGRES_CONNECTION_NAME: '${{ steps.secrets.outputs.POSTGRES_CONNECTION_NAME }}'
+          POSTGRES_IAM_CONNECTION_NAME: '${{ steps.secrets.outputs.POSTGRES_IAM_CONNECTION_NAME }}'
+          POSTGRES_USER: '${{ steps.secrets.outputs.POSTGRES_USER }}'
+          POSTGRES_IAM_USER: '${{ steps.secrets.outputs.POSTGRES_IAM_USER }}'
+          POSTGRES_PASS: '${{ steps.secrets.outputs.POSTGRES_PASS }}'
+          POSTGRES_DB: '${{ steps.secrets.outputs.POSTGRES_DB }}'
+          SQLSERVER_CONNECTION_NAME: '${{ steps.secrets.outputs.SQLSERVER_CONNECTION_NAME }}'
+          SQLSERVER_USER: '${{ steps.secrets.outputs.SQLSERVER_USER }}'
+          SQLSERVER_PASS: '${{ steps.secrets.outputs.SQLSERVER_PASS }}'
+          SQLSERVER_DB: '${{ steps.secrets.outputs.SQLSERVER_DB }}'
+        run: ./.github/scripts/run_tests.sh
+        shell: bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -153,7 +153,7 @@ jobs:
           distribution: 'zulu'
           java-version: '8'
       - run: echo "JAVA8_HOME=${JAVA_HOME}" >> $GITHUB_ENV
-          shell: bash
+        shell: bash
 
       # Set up Java 11 for compilation
       - name: Set up JDK 11
@@ -162,7 +162,7 @@ jobs:
           distribution: 'zulu'
           java-version: '11'
       - run: echo "JAVA11_HOME=${JAVA_HOME}" >> $GITHUB_ENV
-          shell: bash
+        shell: bash
 
       - id: 'auth'
         name: 'Authenticate to Google Cloud'

--- a/.kokoro/release/common.cfg
+++ b/.kokoro/release/common.cfg
@@ -9,7 +9,7 @@ build_file: "cloud-sql-jdbc-socket-factory/.kokoro/trampoline.sh"
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
   key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-kokoro-resources/java8"
+  value: "gcr.io/cloud-devrel-kokoro-resources/java11"
 }
 
 before_action {


### PR DESCRIPTION
Compiling with Java 11 will allow us to merge the tests that are blocked on Java 8 test failures.
