### PR TITLE
chore: update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: "update versions in pom.xml files and READMEs"
-          ref: ${{ fromJson(needs.release-please.outputs.pr).headBranchName }}   
+          branch: ${{ fromJson(needs.release-please.outputs.pr).headBranchName }}   
 
   upload_uberjars:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fix for this warning I'm seeing in the logs: 
<img width="1233" alt="image" src="https://user-images.githubusercontent.com/19631367/211689736-bde7c875-159a-4fab-8de0-abf30cb1e94f.png">
