### PR TITLE
chore: remove use of regionalized API

### DIFF
--- a/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstance.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstance.java
@@ -104,7 +104,6 @@ class CloudSqlInstance {
   private final String projectId;
   private final String regionId;
   private final String instanceId;
-  private final String regionalizedInstanceId;
   private final ListenableFuture<KeyPair> keyPair;
   private final Object instanceDataGuard = new Object();
   // Limit forced refreshes to 1 every minute.
@@ -143,8 +142,6 @@ class CloudSqlInstance {
     this.projectId = matcher.group(1);
     this.regionId = matcher.group(3);
     this.instanceId = matcher.group(4);
-    this.regionalizedInstanceId = String.format("%s~%s", this.regionId, this.instanceId);
-
     this.apiClient = apiClient;
     this.enableIamAuth = enableIamAuth;
     this.executor = executor;
@@ -535,7 +532,7 @@ class CloudSqlInstance {
   private Metadata fetchMetadata() {
     try {
       ConnectSettings instanceMetadata =
-          apiClient.connect().get(projectId, regionalizedInstanceId).execute();
+          apiClient.connect().get(projectId, instanceId).execute();
 
       // Validate the instance will support the authenticated connection.
       if (!instanceMetadata.getRegion().equals(regionId)) {
@@ -615,7 +612,7 @@ class CloudSqlInstance {
     GenerateEphemeralCertResponse response;
     try {
       response = apiClient.connect()
-          .generateEphemeralCert(projectId, regionalizedInstanceId, request).execute();
+          .generateEphemeralCert(projectId, instanceId, request).execute();
     } catch (IOException ex) {
       throw addExceptionContext(
           ex,

--- a/core/src/test/java/com/google/cloud/sql/core/CoreSocketFactoryTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/CoreSocketFactoryTest.java
@@ -164,12 +164,9 @@ public class CoreSocketFactoryTest {
     when(adminApiConnect.get(eq("example.com:myProject"), eq("myInstance")))
         .thenReturn(adminApiConnectGet);
 
-    // Prefixing the region to the instance name is considered valid
-    when(adminApiConnect.get(eq("myProject"), eq("myRegion~myInstance")))
+    when(adminApiConnect.get(eq("myProject"), eq("myInstance")))
         .thenReturn(adminApiConnectGet);
-    when(adminApiConnect.get(eq("myProject"), eq("notMyRegion~myInstance")))
-        .thenReturn(adminApiConnectGet);
-    when(adminApiConnect.get(eq("example.com:myProject"), eq("myRegion~myInstance")))
+    when(adminApiConnect.get(eq("example.com:myProject"), eq("myInstance")))
         .thenReturn(adminApiConnectGet);
 
     when(adminApiConnect.generateEphemeralCert(
@@ -248,10 +245,10 @@ public class CoreSocketFactoryTest {
         coreSocketFactory.createSslSocket(
             "myProject:myRegion:myInstance", Arrays.asList("PRIVATE"));
 
-    verify(adminApiConnect).get("myProject", "myRegion~myInstance");
+    verify(adminApiConnect).get("myProject", "myInstance");
     verify(adminApiConnect)
         .generateEphemeralCert(
-            eq("myProject"), eq("myRegion~myInstance"), isA(GenerateEphemeralCertRequest.class));
+            eq("myProject"), eq("myInstance"), isA(GenerateEphemeralCertRequest.class));
 
     assertThat(readLine(socket)).isEqualTo(SERVER_MESSAGE);
   }
@@ -267,10 +264,10 @@ public class CoreSocketFactoryTest {
         coreSocketFactory.createSslSocket(
             "myProject:myRegion:myInstance", Arrays.asList("PRIMARY"));
 
-    verify(adminApiConnect).get("myProject", "myRegion~myInstance");
+    verify(adminApiConnect).get("myProject", "myInstance");
     verify(adminApiConnect)
         .generateEphemeralCert(
-            eq("myProject"), eq("myRegion~myInstance"), isA(GenerateEphemeralCertRequest.class));
+            eq("myProject"), eq("myInstance"), isA(GenerateEphemeralCertRequest.class));
 
     assertThat(readLine(socket)).isEqualTo(SERVER_MESSAGE);
   }
@@ -286,10 +283,10 @@ public class CoreSocketFactoryTest {
         coreSocketFactory.createSslSocket(
             "example.com:myProject:myRegion:myInstance", Arrays.asList("PRIMARY"));
 
-    verify(adminApiConnect).get("example.com:myProject", "myRegion~myInstance");
+    verify(adminApiConnect).get("example.com:myProject", "myInstance");
     verify(adminApiConnect)
         .generateEphemeralCert(
-            eq("example.com:myProject"), eq("myRegion~myInstance"),
+            eq("example.com:myProject"), eq("myInstance"),
             isA(GenerateEphemeralCertRequest.class));
 
     assertThat(readLine(socket)).isEqualTo(SERVER_MESSAGE);
@@ -318,10 +315,10 @@ public class CoreSocketFactoryTest {
         coreSocketFactory.createSslSocket(
             "myProject:myRegion:myInstance", Arrays.asList("PRIMARY"));
 
-    verify(adminApiConnect, times(2)).get("myProject", "myRegion~myInstance");
+    verify(adminApiConnect, times(2)).get("myProject", "myInstance");
     verify(adminApiConnect, times(2))
         .generateEphemeralCert(
-            eq("myProject"), eq("myRegion~myInstance"), isA(GenerateEphemeralCertRequest.class));
+            eq("myProject"), eq("myInstance"), isA(GenerateEphemeralCertRequest.class));
 
     assertThat(readLine(socket)).isEqualTo(SERVER_MESSAGE);
   }
@@ -335,10 +332,10 @@ public class CoreSocketFactoryTest {
         new CoreSocketFactory(clientKeyPair, adminApi, credentialFactory, port, defaultExecutor);
     coreSocketFactory.createSslSocket("myProject:myRegion:myInstance", Arrays.asList("PRIMARY"));
 
-    verify(adminApiConnect).get("myProject", "myRegion~myInstance");
+    verify(adminApiConnect).get("myProject", "myInstance");
     verify(adminApiConnect)
         .generateEphemeralCert(
-            eq("myProject"), eq("myRegion~myInstance"), isA(GenerateEphemeralCertRequest.class));
+            eq("myProject"), eq("myInstance"), isA(GenerateEphemeralCertRequest.class));
 
     coreSocketFactory.createSslSocket("myProject:myRegion:myInstance", Arrays.asList("PRIMARY"));
 

--- a/r2dbc/core/src/test/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderTest.java
+++ b/r2dbc/core/src/test/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderTest.java
@@ -145,7 +145,7 @@ public class GcpConnectionFactoryProviderTest {
     when(adminApi.connect()).thenReturn(adminApiConnect);
 
     // Stub when correct instance
-    when(adminApiConnect.get(eq("myProject"), eq("myRegion~myInstance"))).thenReturn(
+    when(adminApiConnect.get(eq("myProject"), eq("myInstance"))).thenReturn(
         adminApiConnectGet);
 
     when(adminApiConnect.generateEphemeralCert(anyString(), anyString(),


### PR DESCRIPTION
None of the other connectors use it and it never launched anyway.