### PR TITLE
chore: remove periodic logging of connection creation

### DIFF
--- a/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
@@ -253,7 +253,7 @@ public final class CoreSocketFactory {
     }
 
     final List<String> ipTypes = listIpTypes(props.getProperty("ipTypes", DEFAULT_IP_TYPES));
-    logger.info(
+    logger.fine(
         String.format("Connecting to Cloud SQL instance [%s] via SSL socket.", csqlInstanceName));
     return getInstance().createSslSocket(csqlInstanceName, ipTypes, enableIamAuth);
   }

--- a/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
@@ -253,8 +253,6 @@ public final class CoreSocketFactory {
     }
 
     final List<String> ipTypes = listIpTypes(props.getProperty("ipTypes", DEFAULT_IP_TYPES));
-    logger.fine(
-        String.format("Connecting to Cloud SQL instance [%s] via SSL socket.", csqlInstanceName));
     return getInstance().createSslSocket(csqlInstanceName, ipTypes, enableIamAuth);
   }
 


### PR DESCRIPTION
This change lowers the log level for subsequent connections to fine.  The reason is that the log doesn't offer any actionability for most users.  This log gets printed pretty frequently, scrolling up the other logs from the application.  Existing users who still want to know connections being made can increase their logger verbosity.