### PR TITLE
ci: make top-level workflow permissions read-only

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,12 +18,18 @@ on:
   pull_request_target:
     types: [labeled]
 
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   build:
     # run job on proper workflow event triggers (skip job for pull_request event from forks and only run pull_request_target for "tests: run" label)
     if: "${{ (github.event.action != 'labeled' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name) || github.event.label.name == 'tests: run' }}"
     name: Coverage check
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - name: Remove PR Label
         if: "${{ github.event.action == 'labeled' && github.event.label.name == 'tests: run' }}"

--- a/.github/workflows/labels.yaml
+++ b/.github/workflows/labels.yaml
@@ -18,6 +18,9 @@ on:
     branches:
       - main
 
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,11 +18,17 @@ on:
   pull_request_target:
     types: [labeled]
 
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   lint:
     if: "${{ github.event.action != 'labeled' || github.event.label.name == 'tests: run' }}"
     name: checkstyle
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - name: Remove PR Label
         if: "${{ github.event.action == 'labeled' && github.event.label.name == 'tests: run' }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,10 @@ on:
   push:
     branches:
       - main
+
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   release-please:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,9 @@ on:
   schedule:
   - cron: '0 2 * * *'
 
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   unit-e2e:
     # run job on proper workflow event triggers (skip job for pull_request event from forks and only run pull_request_target for "tests: run" label)
@@ -37,6 +40,8 @@ jobs:
     permissions:
       contents: 'read'
       id-token: 'write'
+      issues: write
+      pull-requests: write
     steps:
     - name: Remove PR label
       if: "${{ github.event.action == 'labeled' && github.event.label.name == 'tests: run' }}"
@@ -147,6 +152,8 @@ jobs:
     permissions:
       contents: 'read'
       id-token: 'write'
+      issues: write
+      pull-requests: write
     steps:
     - name: Remove PR label
       if: "${{ github.event.action == 'labeled' && github.event.label.name == 'tests: run' }}"
@@ -265,6 +272,8 @@ jobs:
     permissions:
       contents: 'read'
       id-token: 'write'
+      issues: write
+      pull-requests: write
     steps:
     - name: Remove PR label
       if: "${{ github.event.action == 'labeled' && github.event.label.name == 'tests: run' }}"


### PR DESCRIPTION
Remove `Token-Permissions` alerts