### PR TITLE
chore: disable test logging with pom.xml

### DIFF
--- a/core/src/test/java/com/google/cloud/sql/core/SqlAdminApiFetcherTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/SqlAdminApiFetcherTest.java
@@ -34,19 +34,11 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
-import java.util.logging.LogManager;
 import javax.net.ssl.SSLContext;
 import org.bouncycastle.operator.OperatorCreationException;
-import org.junit.Before;
 import org.junit.Test;
 
-public class SqlAdminApiFetcherTest extends CloudSqlCoreTestingBase {
-  @Before
-  public void setUp() {
-    // Disable logs in test. Comment this line out to restore them.
-    LogManager.getLogManager().reset();
-  }
-
+public class SqlAdminApiFetcherTest {
   @Test
   public void fetchesInstanceData()
       throws ExecutionException, InterruptedException, GeneralSecurityException,

--- a/core/src/test/resources/logging.properties
+++ b/core/src/test/resources/logging.properties
@@ -1,0 +1,2 @@
+handlers=java.util.logging.ConsoleHandler
+java.util.logging.ConsoleHandler.level=FINEST

--- a/core/src/test/resources/logging.properties
+++ b/core/src/test/resources/logging.properties
@@ -1,2 +1,0 @@
-handlers=java.util.logging.ConsoleHandler
-java.util.logging.ConsoleHandler.level=FINEST

--- a/pom.xml
+++ b/pom.xml
@@ -192,6 +192,10 @@
           <excludes>
             <exclude>**/*IntegrationTests</exclude>
           </excludes>
+          <systemPropertyVariables>
+            <!-- Disable logging in test. Comment out the following line to re-enable logging. -->
+            <java.util.logging.config.file />
+          </systemPropertyVariables>
         </configuration>
       </plugin>
 


### PR DESCRIPTION
By commenting out the java.util.logging.config.file configuration, the test logging can be restored. This change ensures the build log is clean.