### PR TITLE
Remove extra backslash on jdbc url examples

### DIFF
--- a/docs/jdbc-mysql.md
+++ b/docs/jdbc-mysql.md
@@ -30,7 +30,7 @@ compile 'com.google.cloud.sql:mysql-socket-factory-connector-j-8:1.11.0'
 
 ### Creating theJDBC URL
 
-Base JDBC URL: `jdbc:mysql:///<DATABASE_NAME>`
+Base JDBC URL: `jdbc:mysql://<DATABASE_NAME>`
 
 When specifying the JDBC connection URL, add the additional parameters:
 
@@ -43,7 +43,7 @@ When specifying the JDBC connection URL, add the additional parameters:
 
 The full JDBC URL should look like this:
 ```
-jdbc:mysql:///<DATABASE_NAME>?cloudSqlInstance=<INSTANCE_CONNECTION_NAME>&socketFactory=com.google.cloud.sql.mysql.SocketFactory&user=<MYSQL_USER_NAME>&password=<MYSQL_USER_PASSWORD>
+jdbc:mysql://<DATABASE_NAME>?cloudSqlInstance=<INSTANCE_CONNECTION_NAME>&socketFactory=com.google.cloud.sql.mysql.SocketFactory&user=<MYSQL_USER_NAME>&password=<MYSQL_USER_PASSWORD>
 ```
 
 Note: The host portion of the JDBC URL is currently unused, and has no effect on the connection process. The SocketFactory will get your instances IP address based on the provided `cloudSqlInstance` arg. 


### PR DESCRIPTION
The correct syntax only uses two backslashes 
for example: jdbc:mysql://localhost/dbname