### PR TITLE
feat: prefer io.asyncer:r2dbc-mysql

### DIFF
--- a/docs/r2dbc-mysql.md
+++ b/docs/r2dbc-mysql.md
@@ -20,7 +20,7 @@ Include the following the project's `build.gradle`
 compile 'com.google.cloud.sql:cloud-sql-connector-r2dbc-mysql:1.11.1'
 ```
 
-*Note: Also include the R2DBC Driver for MySQL, `dev.miku:r2dbc-mysql:<LATEST-VERSION>`
+*Note: Also include the R2DBC Driver for MySQL, `io.asyncer:r2dbc-mysql:<LATEST-VERSION>`
 
 ### Creating the R2DBC URL
 

--- a/r2dbc/mysql/pom.xml
+++ b/r2dbc/mysql/pom.xml
@@ -190,9 +190,9 @@
       <version>1.0.0.RELEASE</version>
     </dependency>
     <dependency>
-      <groupId>dev.miku</groupId>
+      <groupId>io.asyncer</groupId>
       <artifactId>r2dbc-mysql</artifactId>
-      <version>0.8.2.RELEASE</version>
+      <version>1.0.0</version>
       <scope>provided</scope>
       <exclusions>
         <exclusion>
@@ -257,9 +257,9 @@
       <id>jar-with-driver-and-dependencies</id>
       <dependencies>
         <dependency>
-          <groupId>dev.miku</groupId>
+          <groupId>io.asyncer</groupId>
           <artifactId>r2dbc-mysql</artifactId>
-          <version>0.8.2.RELEASE</version>
+          <version>1.0.0</version>
         </dependency>
       </dependencies>
     </profile>

--- a/r2dbc/mysql/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderMysql.java
+++ b/r2dbc/mysql/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderMysql.java
@@ -19,8 +19,8 @@ package com.google.cloud.sql.core;
 import static io.r2dbc.spi.ConnectionFactoryOptions.Builder;
 import static io.r2dbc.spi.ConnectionFactoryOptions.DRIVER;
 
-import dev.miku.r2dbc.mysql.MySqlConnectionFactoryProvider;
-import dev.miku.r2dbc.mysql.constant.SslMode;
+import io.asyncer.r2dbc.mysql.MySqlConnectionFactoryProvider;
+import io.asyncer.r2dbc.mysql.constant.SslMode;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.ConnectionFactoryOptions;


### PR DESCRIPTION
The R2DBC driver, r2dbc-mysql, has transitioned to new maintainership as detailed in [this GitHub issue](https://github.com/mirromutth/r2dbc-mysql/issues/251). The new fork has been updated to accommodate recent r2dbc-spi changes, making it compatible with the General Availability (GA) version 1.0.0.

Given that this fork was officially endorsed by the original owner, it is a reliable alternative to switch to io.asyncer:r2dbc-mysql. We kindly request that this change be expedited and released, as it is currently impeding our migration from Spring Boot 2 to Spring Boot 3.