### PR TITLE
ci: Update kokoro stage job to store release artifacts

### DIFF
--- a/.kokoro/release/stage.cfg
+++ b/.kokoro/release/stage.cfg
@@ -12,3 +12,12 @@ action {
     strip_prefix: "github/cloud-sql-jdbc-socket-factory"
   }
 }
+
+# Save artifacts for EO 14028
+action {
+  define_artifacts {
+    regex: "**/target/*.jar"
+    regex: "**/target/*.pom"
+    strip_prefix: "github/cloud-sql-jdbc-socket-factory"
+  }
+}


### PR DESCRIPTION
We need to store release artifacts in Kokoro to generate SBOMs for released software.
When reviewing, please check that:

- The build passes
- All software artifacts generated by `mvn install` are accounted for