### PR TITLE
test: Simplify r2dbc integration tests.

### DIFF
--- a/r2dbc/mysql/src/test/java/com/google/cloud/sql/core/R2dbcMysqlIamAuthIntegrationTests.java
+++ b/r2dbc/mysql/src/test/java/com/google/cloud/sql/core/R2dbcMysqlIamAuthIntegrationTests.java
@@ -32,9 +32,7 @@ import io.r2dbc.spi.ConnectionFactories;
 import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.ConnectionFactoryOptions;
 import java.util.List;
-import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -56,7 +54,6 @@ public class R2dbcMysqlIamAuthIntegrationTests {
   @Rule public Timeout globalTimeout = new Timeout(20, TimeUnit.SECONDS);
 
   private ConnectionPool connectionPool;
-  private String tableName;
 
   @Before
   public void setUpPool() {
@@ -89,53 +86,17 @@ public class R2dbcMysqlIamAuthIntegrationTests {
     this.connectionPool = new ConnectionPool(configuration);
     // [END cloud_sql_connector_mysql_r2dbc_iam_auth]
 
-    this.tableName = String.format("books_%s", UUID.randomUUID().toString().replace("-", ""));
-
-    // Create table
-    Mono.from(this.connectionPool.create())
-        .flatMapMany(
-            c ->
-                c.createStatement(
-                        String.format("CREATE TABLE %s (", this.tableName)
-                            + "  ID CHAR(20) NOT NULL,"
-                            + "  TITLE TEXT NOT NULL"
-                            + ")")
-                    .execute())
-        .blockLast();
-  }
-
-  @After
-  public void dropTableIfPresent() {
-    String dropStmt = String.format("DROP TABLE %s", this.tableName);
-    Mono.from(this.connectionPool.create())
-        .delayUntil(c -> c.createStatement(dropStmt).execute())
-        .block();
   }
 
   @Test
   public void pooledConnectionTest() {
-    String insertStmt = String.format("INSERT INTO %s (ID, TITLE) VALUES (?, ?)", this.tableName);
-    Mono.from(this.connectionPool.create())
-        .flatMapMany(
-            c ->
-                c.createStatement(insertStmt)
-                    .bind(0, "book1")
-                    .bind(1, "Book One")
-                    .add()
-                    .bind(0, "book2")
-                    .bind(1, "Book Two")
-                    .execute())
-        .flatMap(result -> result.map((row, rowMetadata) -> row.get(0)))
-        .blockLast();
-
-    String selectStmt = String.format("SELECT TITLE FROM %s ORDER BY ID", this.tableName);
-    List<String> books =
+    List<Object> rows =
         Mono.from(this.connectionPool.create())
-            .flatMapMany(connection -> connection.createStatement(selectStmt).execute())
-            .flatMap(result -> result.map((r, meta) -> r.get("TITLE", String.class)))
+            .flatMapMany(connection -> connection.createStatement("SELECT NOW() as TS").execute())
+            .flatMap(result -> result.map((r, meta) -> r.get("TS", Object.class)))
             .collectList()
             .block();
 
-    assertThat(books).containsExactly("Book One", "Book Two");
+    assertThat(rows.size()).isEqualTo(1);
   }
 }

--- a/r2dbc/mysql/src/test/java/com/google/cloud/sql/core/R2dbcMysqlIamAuthIntegrationTests.java
+++ b/r2dbc/mysql/src/test/java/com/google/cloud/sql/core/R2dbcMysqlIamAuthIntegrationTests.java
@@ -31,6 +31,7 @@ import io.r2dbc.pool.ConnectionPoolConfiguration;
 import io.r2dbc.spi.ConnectionFactories;
 import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.ConnectionFactoryOptions;
+import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.junit.Before;
@@ -90,10 +91,10 @@ public class R2dbcMysqlIamAuthIntegrationTests {
 
   @Test
   public void pooledConnectionTest() {
-    List<Object> rows =
+    List<Instant> rows =
         Mono.from(this.connectionPool.create())
             .flatMapMany(connection -> connection.createStatement("SELECT NOW() as TS").execute())
-            .flatMap(result -> result.map((r, meta) -> r.get("TS", Object.class)))
+            .flatMap(result -> result.map((r, meta) -> r.get("TS", Instant.class)))
             .collectList()
             .block();
 

--- a/r2dbc/mysql/src/test/java/com/google/cloud/sql/core/R2dbcMysqlIntegrationTests.java
+++ b/r2dbc/mysql/src/test/java/com/google/cloud/sql/core/R2dbcMysqlIntegrationTests.java
@@ -25,9 +25,7 @@ import io.r2dbc.pool.ConnectionPoolConfiguration;
 import io.r2dbc.spi.ConnectionFactories;
 import io.r2dbc.spi.ConnectionFactory;
 import java.util.List;
-import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -50,7 +48,6 @@ public class R2dbcMysqlIntegrationTests {
   @Rule public Timeout globalTimeout = new Timeout(20, TimeUnit.SECONDS);
 
   private ConnectionPool connectionPool;
-  private String tableName;
 
   @Before
   public void setUpPool() {
@@ -74,53 +71,17 @@ public class R2dbcMysqlIntegrationTests {
         ConnectionPoolConfiguration.builder(connectionFactory).build();
 
     this.connectionPool = new ConnectionPool(configuration);
-    this.tableName = String.format("books_%s", UUID.randomUUID().toString().replace("-", ""));
-
-    // Create table
-    Mono.from(this.connectionPool.create())
-        .flatMapMany(
-            c ->
-                c.createStatement(
-                        String.format("CREATE TABLE %s (", this.tableName)
-                            + "  ID CHAR(20) NOT NULL,"
-                            + "  TITLE TEXT NOT NULL"
-                            + ")")
-                    .execute())
-        .blockLast();
-  }
-
-  @After
-  public void dropTableIfPresent() {
-    String dropStmt = String.format("DROP TABLE %s", this.tableName);
-    Mono.from(this.connectionPool.create())
-        .delayUntil(c -> c.createStatement(dropStmt).execute())
-        .block();
   }
 
   @Test
   public void pooledConnectionTest() {
-    String insertStmt = String.format("INSERT INTO %s (ID, TITLE) VALUES (?, ?)", this.tableName);
-    Mono.from(this.connectionPool.create())
-        .flatMapMany(
-            c ->
-                c.createStatement(insertStmt)
-                    .bind(0, "book1")
-                    .bind(1, "Book One")
-                    .add()
-                    .bind(0, "book2")
-                    .bind(1, "Book Two")
-                    .execute())
-        .flatMap(result -> result.map((row, rowMetadata) -> row.get(0)))
-        .blockLast();
-
-    String selectStmt = String.format("SELECT TITLE FROM %s ORDER BY ID", this.tableName);
-    List<String> books =
+    List<Object> rows =
         Mono.from(this.connectionPool.create())
-            .flatMapMany(connection -> connection.createStatement(selectStmt).execute())
-            .flatMap(result -> result.map((r, meta) -> r.get("TITLE", String.class)))
+            .flatMapMany(connection -> connection.createStatement("SELECT NOW() as TS").execute())
+            .flatMap(result -> result.map((r, meta) -> r.get("TS", Object.class)))
             .collectList()
             .block();
 
-    assertThat(books).containsExactly("Book One", "Book Two");
+    assertThat(rows.size()).isEqualTo(1);
   }
 }

--- a/r2dbc/mysql/src/test/java/com/google/cloud/sql/core/R2dbcMysqlIntegrationTests.java
+++ b/r2dbc/mysql/src/test/java/com/google/cloud/sql/core/R2dbcMysqlIntegrationTests.java
@@ -24,6 +24,7 @@ import io.r2dbc.pool.ConnectionPool;
 import io.r2dbc.pool.ConnectionPoolConfiguration;
 import io.r2dbc.spi.ConnectionFactories;
 import io.r2dbc.spi.ConnectionFactory;
+import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.junit.Before;
@@ -75,10 +76,10 @@ public class R2dbcMysqlIntegrationTests {
 
   @Test
   public void pooledConnectionTest() {
-    List<Object> rows =
+    List<Instant> rows =
         Mono.from(this.connectionPool.create())
             .flatMapMany(connection -> connection.createStatement("SELECT NOW() as TS").execute())
-            .flatMap(result -> result.map((r, meta) -> r.get("TS", Object.class)))
+            .flatMap(result -> result.map((r, meta) -> r.get("TS", Instant.class)))
             .collectList()
             .block();
 

--- a/r2dbc/postgres/src/test/java/com/google/cloud/sql/core/R2dbcPostgresIamAuthIntegrationTests.java
+++ b/r2dbc/postgres/src/test/java/com/google/cloud/sql/core/R2dbcPostgresIamAuthIntegrationTests.java
@@ -32,6 +32,7 @@ import io.r2dbc.pool.ConnectionPoolConfiguration;
 import io.r2dbc.spi.ConnectionFactories;
 import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.ConnectionFactoryOptions;
+import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.junit.Before;
@@ -93,10 +94,10 @@ public class R2dbcPostgresIamAuthIntegrationTests {
 
   @Test
   public void pooledConnectionTest() {
-    List<Object> rows =
+    List<Instant> rows =
         Mono.from(this.connectionPool.create())
             .flatMapMany(connection -> connection.createStatement("SELECT NOW() as TS").execute())
-            .flatMap(result -> result.map((r, meta) -> r.get("TS", Object.class)))
+            .flatMap(result -> result.map((r, meta) -> r.get("TS", Instant.class)))
             .collectList()
             .block();
 
@@ -112,10 +113,10 @@ public class R2dbcPostgresIamAuthIntegrationTests {
             DB_USER, "password", CONNECTION_NAME, DB_NAME);
     ConnectionFactory connectionPool = ConnectionFactories.get(url);
 
-    List<Object> rows =
+    List<Instant> rows =
         Mono.from(connectionPool.create())
             .flatMapMany(connection -> connection.createStatement("SELECT NOW() as TS").execute())
-            .flatMap(result -> result.map((r, meta) -> r.get("TS", Object.class)))
+            .flatMap(result -> result.map((r, meta) -> r.get("TS", Instant.class)))
             .collectList()
             .block();
 

--- a/r2dbc/postgres/src/test/java/com/google/cloud/sql/core/R2dbcPostgresIntegrationTests.java
+++ b/r2dbc/postgres/src/test/java/com/google/cloud/sql/core/R2dbcPostgresIntegrationTests.java
@@ -25,9 +25,7 @@ import io.r2dbc.pool.ConnectionPoolConfiguration;
 import io.r2dbc.spi.ConnectionFactories;
 import io.r2dbc.spi.ConnectionFactory;
 import java.util.List;
-import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -48,7 +46,6 @@ public class R2dbcPostgresIntegrationTests {
   @Rule public Timeout globalTimeout = new Timeout(20, TimeUnit.SECONDS);
 
   private ConnectionFactory connectionPool;
-  private String tableName;
 
   @Before
   public void setUpPool() {
@@ -72,54 +69,17 @@ public class R2dbcPostgresIntegrationTests {
         ConnectionPoolConfiguration.builder(connectionFactory).build();
 
     this.connectionPool = new ConnectionPool(configuration);
-    this.tableName = String.format("books_%s", UUID.randomUUID().toString().replace("-", ""));
-
-    // Create table
-    Mono.from(this.connectionPool.create())
-        .flatMapMany(
-            c ->
-                c.createStatement(
-                        String.format("CREATE TABLE %s (", this.tableName)
-                            + "  ID CHAR(20) NOT NULL,"
-                            + "  TITLE TEXT NOT NULL"
-                            + ")")
-                    .execute())
-        .blockLast();
-  }
-
-  @After
-  public void dropTableIfPresent() {
-    String dropStmt = String.format("DROP TABLE %s", this.tableName);
-    Mono.from(this.connectionPool.create())
-        .delayUntil(c -> c.createStatement(dropStmt).execute())
-        .block();
   }
 
   @Test
   public void pooledConnectionTest() {
-    String insertStmt =
-        String.format("INSERT INTO  %s (ID, TITLE) VALUES ($1, $2)", this.tableName);
-    Mono.from(this.connectionPool.create())
-        .flatMapMany(
-            c ->
-                c.createStatement(insertStmt)
-                    .bind("$1", "book1")
-                    .bind("$2", "Book One")
-                    .add()
-                    .bind("$1", "book2")
-                    .bind("$2", "Book Two")
-                    .execute())
-        .flatMap(result -> result.map((row, rowMetadata) -> row.get(0)))
-        .blockLast();
-
-    String selectStmt = String.format("SELECT TITLE FROM %s ORDER BY ID", this.tableName);
-    List<String> books =
+    List<Object> rows =
         Mono.from(this.connectionPool.create())
-            .flatMapMany(connection -> connection.createStatement(selectStmt).execute())
-            .flatMap(result -> result.map((r, meta) -> r.get("TITLE", String.class)))
+            .flatMapMany(connection -> connection.createStatement("SELECT NOW() as TS").execute())
+            .flatMap(result -> result.map((r, meta) -> r.get("TS", Object.class)))
             .collectList()
             .block();
 
-    assertThat(books).containsExactly("Book One", "Book Two");
+    assertThat(rows.size()).isEqualTo(1);
   }
 }

--- a/r2dbc/postgres/src/test/java/com/google/cloud/sql/core/R2dbcPostgresIntegrationTests.java
+++ b/r2dbc/postgres/src/test/java/com/google/cloud/sql/core/R2dbcPostgresIntegrationTests.java
@@ -24,6 +24,7 @@ import io.r2dbc.pool.ConnectionPool;
 import io.r2dbc.pool.ConnectionPoolConfiguration;
 import io.r2dbc.spi.ConnectionFactories;
 import io.r2dbc.spi.ConnectionFactory;
+import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.junit.Before;
@@ -73,10 +74,10 @@ public class R2dbcPostgresIntegrationTests {
 
   @Test
   public void pooledConnectionTest() {
-    List<Object> rows =
+    List<Instant> rows =
         Mono.from(this.connectionPool.create())
             .flatMapMany(connection -> connection.createStatement("SELECT NOW() as TS").execute())
-            .flatMap(result -> result.map((r, meta) -> r.get("TS", Object.class)))
+            .flatMap(result -> result.map((r, meta) -> r.get("TS", Instant.class)))
             .collectList()
             .block();
 

--- a/r2dbc/sqlserver/src/test/java/com/google/cloud/sql/core/R2dbcSqlserverIntegrationTests.java
+++ b/r2dbc/sqlserver/src/test/java/com/google/cloud/sql/core/R2dbcSqlserverIntegrationTests.java
@@ -76,10 +76,10 @@ public class R2dbcSqlserverIntegrationTests {
 
   @Test
   public void pooledConnectionTest() {
-    List<Object> rows =
+    List<Integer> rows =
         Mono.from(this.connectionPool.create())
             .flatMapMany(connection -> connection.createStatement("SELECT 1 as TS").execute())
-            .flatMap(result -> result.map((r, meta) -> r.get("TS", Object.class)))
+            .flatMap(result -> result.map((r, meta) -> r.get("TS", Integer.class)))
             .collectList()
             .block();
 


### PR DESCRIPTION
Remove extraneous test code that created tables and inserted data. If the client 
can perform `select 1` or `select now`, the connection succeeded.

Fixes #1273 
Fixes #1262 
Fixes #1272 