### PR TITLE
test: Simplify jdbc integration tests.

### DIFF
--- a/jdbc/mariadb/src/test/java/com/google/cloud/sql/mariadb/JdbcMariaDBIamAuthIntegrationTests.java
+++ b/jdbc/mariadb/src/test/java/com/google/cloud/sql/mariadb/JdbcMariaDBIamAuthIntegrationTests.java
@@ -22,10 +22,7 @@ import static com.google.common.truth.Truth.assertWithMessage;
 import com.google.common.collect.ImmutableList;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
+import java.sql.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
@@ -89,12 +86,12 @@ public class JdbcMariaDBIamAuthIntegrationTests {
   @Test
   public void pooledConnectionTest() throws SQLException {
 
-    List<String> rows = new ArrayList<>();
+    List<Timestamp> rows = new ArrayList<>();
     try (Connection conn = connectionPool.getConnection()) {
       try (PreparedStatement selectStmt = conn.prepareStatement("SELECT NOW() as TS")) {
         ResultSet rs = selectStmt.executeQuery();
         while (rs.next()) {
-          rows.add(rs.getString("TS"));
+          rows.add(rs.getTimestamp("TS"));
         }
       }
     }

--- a/jdbc/mariadb/src/test/java/com/google/cloud/sql/mariadb/JdbcMariaDBIamAuthIntegrationTests.java
+++ b/jdbc/mariadb/src/test/java/com/google/cloud/sql/mariadb/JdbcMariaDBIamAuthIntegrationTests.java
@@ -29,9 +29,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
-import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -86,58 +84,20 @@ public class JdbcMariaDBIamAuthIntegrationTests {
 
     this.connectionPool = new HikariDataSource(config);
     // [END cloud_sql_connector_postgres_jdbc_iam_auth]
-
-    this.tableName = String.format("books_%s", UUID.randomUUID().toString().replace("-", ""));
-
-    // Create table
-    try (Connection conn = connectionPool.getConnection()) {
-      String stmt =
-          String.format("CREATE TABLE %s (", this.tableName)
-              + "  ID CHAR(20) NOT NULL,"
-              + "  TITLE TEXT NOT NULL"
-              + ");";
-      try (PreparedStatement createTableStatement = conn.prepareStatement(stmt)) {
-        createTableStatement.execute();
-      }
-    }
-  }
-
-  @After
-  public void dropTableIfPresent() throws SQLException {
-    try (Connection conn = connectionPool.getConnection()) {
-      String stmt = String.format("DROP TABLE %s;", this.tableName);
-      try (PreparedStatement dropTableStatement = conn.prepareStatement(stmt)) {
-        dropTableStatement.execute();
-      }
-    }
   }
 
   @Test
   public void pooledConnectionTest() throws SQLException {
-    try (Connection conn = connectionPool.getConnection()) {
-      String stmt = String.format("INSERT INTO %s (ID, TITLE) VALUES (?, ?)", this.tableName);
-      try (PreparedStatement insertStmt = conn.prepareStatement(stmt)) {
-        insertStmt.setQueryTimeout(10);
-        insertStmt.setString(1, "book1");
-        insertStmt.setString(2, "Book One");
-        insertStmt.execute();
-        insertStmt.setString(1, "book2");
-        insertStmt.setString(2, "Book Two");
-        insertStmt.execute();
-      }
-    }
 
-    List<String> bookList = new ArrayList<>();
+    List<String> rows = new ArrayList<>();
     try (Connection conn = connectionPool.getConnection()) {
-      String stmt = String.format("SELECT TITLE FROM %s ORDER BY ID", this.tableName);
-      try (PreparedStatement selectStmt = conn.prepareStatement(stmt)) {
-        selectStmt.setQueryTimeout(10); // 10s
+      try (PreparedStatement selectStmt = conn.prepareStatement("SELECT NOW() as TS")) {
         ResultSet rs = selectStmt.executeQuery();
         while (rs.next()) {
-          bookList.add(rs.getString("TITLE"));
+          rows.add(rs.getString("TS"));
         }
       }
     }
-    assertThat(bookList).containsExactly("Book One", "Book Two");
+    assertThat(rows.size()).isEqualTo(1);
   }
 }

--- a/jdbc/mariadb/src/test/java/com/google/cloud/sql/mariadb/JdbcMariaDBIntegrationTests.java
+++ b/jdbc/mariadb/src/test/java/com/google/cloud/sql/mariadb/JdbcMariaDBIntegrationTests.java
@@ -29,9 +29,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
-import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -53,7 +51,6 @@ public class JdbcMariaDBIntegrationTests {
   @Rule public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
 
   private HikariDataSource connectionPool;
-  private String tableName;
 
   @BeforeClass
   public static void checkEnvVars() {
@@ -84,57 +81,20 @@ public class JdbcMariaDBIntegrationTests {
     config.setConnectionTimeout(10000); // 10s
 
     this.connectionPool = new HikariDataSource(config);
-    this.tableName = String.format("books_%s", UUID.randomUUID().toString().replace("-", ""));
-
-    // Create table
-    try (Connection conn = connectionPool.getConnection()) {
-      String stmt =
-          String.format("CREATE TABLE %s (", this.tableName)
-              + "  ID CHAR(20) NOT NULL,"
-              + "  TITLE TEXT NOT NULL"
-              + ");";
-      try (PreparedStatement createTableStatement = conn.prepareStatement(stmt)) {
-        createTableStatement.execute();
-      }
-    }
-  }
-
-  @After
-  public void dropTableIfPresent() throws SQLException {
-    try (Connection conn = connectionPool.getConnection()) {
-      String stmt = String.format("DROP TABLE %s;", this.tableName);
-      try (PreparedStatement dropTableStatement = conn.prepareStatement(stmt)) {
-        dropTableStatement.execute();
-      }
-    }
   }
 
   @Test
   public void pooledConnectionTest() throws SQLException {
-    try (Connection conn = connectionPool.getConnection()) {
-      String stmt = String.format("INSERT INTO %s (ID, TITLE) VALUES (?, ?)", this.tableName);
-      try (PreparedStatement insertStmt = conn.prepareStatement(stmt)) {
-        insertStmt.setQueryTimeout(10);
-        insertStmt.setString(1, "book1");
-        insertStmt.setString(2, "Book One");
-        insertStmt.execute();
-        insertStmt.setString(1, "book2");
-        insertStmt.setString(2, "Book Two");
-        insertStmt.execute();
-      }
-    }
 
-    List<String> bookList = new ArrayList<>();
+    List<String> rows = new ArrayList<>();
     try (Connection conn = connectionPool.getConnection()) {
-      String stmt = String.format("SELECT TITLE FROM %s ORDER BY ID", this.tableName);
-      try (PreparedStatement selectStmt = conn.prepareStatement(stmt)) {
-        selectStmt.setQueryTimeout(10); // 10s
+      try (PreparedStatement selectStmt = conn.prepareStatement("SELECT NOW() as TS")) {
         ResultSet rs = selectStmt.executeQuery();
         while (rs.next()) {
-          bookList.add(rs.getString("TITLE"));
+          rows.add(rs.getString("TS"));
         }
       }
     }
-    assertThat(bookList).containsExactly("Book One", "Book Two");
+    assertThat(rows.size()).isEqualTo(1);
   }
 }

--- a/jdbc/mariadb/src/test/java/com/google/cloud/sql/mariadb/JdbcMariaDBIntegrationTests.java
+++ b/jdbc/mariadb/src/test/java/com/google/cloud/sql/mariadb/JdbcMariaDBIntegrationTests.java
@@ -22,10 +22,7 @@ import static com.google.common.truth.Truth.assertWithMessage;
 import com.google.common.collect.ImmutableList;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
+import java.sql.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
@@ -86,12 +83,12 @@ public class JdbcMariaDBIntegrationTests {
   @Test
   public void pooledConnectionTest() throws SQLException {
 
-    List<String> rows = new ArrayList<>();
+    List<Timestamp> rows = new ArrayList<>();
     try (Connection conn = connectionPool.getConnection()) {
       try (PreparedStatement selectStmt = conn.prepareStatement("SELECT NOW() as TS")) {
         ResultSet rs = selectStmt.executeQuery();
         while (rs.next()) {
-          rows.add(rs.getString("TS"));
+          rows.add(rs.getTimestamp("TS"));
         }
       }
     }

--- a/jdbc/mysql-j-5/src/test/java/com/google/cloud/sql/mysql/JdbcMysqlJ5IntegrationTests.java
+++ b/jdbc/mysql-j-5/src/test/java/com/google/cloud/sql/mysql/JdbcMysqlJ5IntegrationTests.java
@@ -22,10 +22,7 @@ import static com.google.common.truth.Truth.assertWithMessage;
 import com.google.common.collect.ImmutableList;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
+import java.sql.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
@@ -85,12 +82,12 @@ public class JdbcMysqlJ5IntegrationTests {
   @Test
   public void pooledConnectionTest() throws SQLException {
 
-    List<String> rows = new ArrayList<>();
+    List<Timestamp> rows = new ArrayList<>();
     try (Connection conn = connectionPool.getConnection()) {
       try (PreparedStatement selectStmt = conn.prepareStatement("SELECT NOW() as TS")) {
         ResultSet rs = selectStmt.executeQuery();
         while (rs.next()) {
-          rows.add(rs.getString("TS"));
+          rows.add(rs.getTimestamp("TS"));
         }
       }
     }

--- a/jdbc/mysql-j-5/src/test/java/com/google/cloud/sql/mysql/JdbcMysqlJ5IntegrationTests.java
+++ b/jdbc/mysql-j-5/src/test/java/com/google/cloud/sql/mysql/JdbcMysqlJ5IntegrationTests.java
@@ -29,9 +29,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
-import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -49,8 +47,6 @@ public class JdbcMysqlJ5IntegrationTests {
   private static final String DB_PASSWORD = System.getenv("MYSQL_PASS");
   private static final ImmutableList<String> requiredEnvVars =
       ImmutableList.of("MYSQL_USER", "MYSQL_PASS", "MYSQL_DB", "MYSQL_CONNECTION_NAME");
-
-  private String tableName;
 
   @Rule public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
 
@@ -82,60 +78,22 @@ public class JdbcMysqlJ5IntegrationTests {
     HikariConfig config = new HikariConfig();
     config.setJdbcUrl(jdbcURL);
     config.setDataSourceProperties(connProps);
-    config.setConnectionTimeout(10000); // 10s
 
     this.connectionPool = new HikariDataSource(config);
-    this.tableName = String.format("books_%s", UUID.randomUUID().toString().replace("-", ""));
-
-    // Create table
-    try (Connection conn = connectionPool.getConnection()) {
-      String stmt =
-          String.format("CREATE TABLE %s (", this.tableName)
-              + "  ID CHAR(20) NOT NULL,"
-              + "  TITLE TEXT NOT NULL"
-              + ");";
-      try (PreparedStatement createTableStatement = conn.prepareStatement(stmt)) {
-        createTableStatement.execute();
-      }
-    }
-  }
-
-  @After
-  public void dropTableIfPresent() throws SQLException {
-    try (Connection conn = connectionPool.getConnection()) {
-      String stmt = String.format("DROP TABLE %s;", this.tableName);
-      try (PreparedStatement dropTableStatement = conn.prepareStatement(stmt)) {
-        dropTableStatement.execute();
-      }
-    }
   }
 
   @Test
   public void pooledConnectionTest() throws SQLException {
-    try (Connection conn = connectionPool.getConnection()) {
-      String stmt = String.format("INSERT INTO %s (ID, TITLE) VALUES (?, ?)", this.tableName);
-      try (PreparedStatement insertStmt = conn.prepareStatement(stmt)) {
-        insertStmt.setQueryTimeout(10);
-        insertStmt.setString(1, "book1");
-        insertStmt.setString(2, "Book One");
-        insertStmt.execute();
-        insertStmt.setString(1, "book2");
-        insertStmt.setString(2, "Book Two");
-        insertStmt.execute();
-      }
-    }
 
-    List<String> bookList = new ArrayList<>();
+    List<String> rows = new ArrayList<>();
     try (Connection conn = connectionPool.getConnection()) {
-      String stmt = String.format("SELECT TITLE FROM %s ORDER BY ID", this.tableName);
-      try (PreparedStatement selectStmt = conn.prepareStatement(stmt)) {
-        selectStmt.setQueryTimeout(10); // 10s
+      try (PreparedStatement selectStmt = conn.prepareStatement("SELECT NOW() as TS")) {
         ResultSet rs = selectStmt.executeQuery();
         while (rs.next()) {
-          bookList.add(rs.getString("TITLE"));
+          rows.add(rs.getString("TS"));
         }
       }
     }
-    assertThat(bookList).containsExactly("Book One", "Book Two");
+    assertThat(rows.size()).isEqualTo(1);
   }
 }

--- a/jdbc/mysql-j-8/src/test/java/com/google/cloud/sql/mysql/JdbcMysqlJ8IamAuthIntegrationTests.java
+++ b/jdbc/mysql-j-8/src/test/java/com/google/cloud/sql/mysql/JdbcMysqlJ8IamAuthIntegrationTests.java
@@ -29,9 +29,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
-import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -50,7 +48,6 @@ public class JdbcMysqlJ8IamAuthIntegrationTests {
   private static final ImmutableList<String> requiredEnvVars =
       ImmutableList.of("MYSQL_IAM_USER", "MYSQL_DB", "MYSQL_IAM_CONNECTION_NAME");
   @Rule public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
-  private String tableName;
   private HikariDataSource connectionPool;
 
   @BeforeClass
@@ -83,57 +80,20 @@ public class JdbcMysqlJ8IamAuthIntegrationTests {
     config.setConnectionTimeout(10000); // 10s
 
     this.connectionPool = new HikariDataSource(config);
-    this.tableName = String.format("books_%s", UUID.randomUUID().toString().replace("-", ""));
-
-    // Create table
-    try (Connection conn = connectionPool.getConnection()) {
-      String stmt =
-          String.format("CREATE TABLE %s (", this.tableName)
-              + "  ID CHAR(20) NOT NULL,"
-              + "  TITLE TEXT NOT NULL"
-              + ");";
-      try (PreparedStatement createTableStatement = conn.prepareStatement(stmt)) {
-        createTableStatement.execute();
-      }
-    }
-  }
-
-  @After
-  public void dropTableIfPresent() throws SQLException {
-    try (Connection conn = connectionPool.getConnection()) {
-      String stmt = String.format("DROP TABLE %s;", this.tableName);
-      try (PreparedStatement dropTableStatement = conn.prepareStatement(stmt)) {
-        dropTableStatement.execute();
-      }
-    }
   }
 
   @Test
   public void pooledConnectionTest() throws SQLException {
-    try (Connection conn = connectionPool.getConnection()) {
-      String stmt = String.format("INSERT INTO %s (ID, TITLE) VALUES (?, ?)", this.tableName);
-      try (PreparedStatement insertStmt = conn.prepareStatement(stmt)) {
-        insertStmt.setQueryTimeout(10);
-        insertStmt.setString(1, "book1");
-        insertStmt.setString(2, "Book One");
-        insertStmt.execute();
-        insertStmt.setString(1, "book2");
-        insertStmt.setString(2, "Book Two");
-        insertStmt.execute();
-      }
-    }
 
-    List<String> bookList = new ArrayList<>();
+    List<String> rows = new ArrayList<>();
     try (Connection conn = connectionPool.getConnection()) {
-      String stmt = String.format("SELECT TITLE FROM %s ORDER BY ID", this.tableName);
-      try (PreparedStatement selectStmt = conn.prepareStatement(stmt)) {
-        selectStmt.setQueryTimeout(10); // 10s
+      try (PreparedStatement selectStmt = conn.prepareStatement("SELECT NOW() as TS")) {
         ResultSet rs = selectStmt.executeQuery();
         while (rs.next()) {
-          bookList.add(rs.getString("TITLE"));
+          rows.add(rs.getString("TS"));
         }
       }
     }
-    assertThat(bookList).containsExactly("Book One", "Book Two");
+    assertThat(rows.size()).isEqualTo(1);
   }
 }

--- a/jdbc/mysql-j-8/src/test/java/com/google/cloud/sql/mysql/JdbcMysqlJ8IamAuthIntegrationTests.java
+++ b/jdbc/mysql-j-8/src/test/java/com/google/cloud/sql/mysql/JdbcMysqlJ8IamAuthIntegrationTests.java
@@ -22,10 +22,7 @@ import static com.google.common.truth.Truth.assertWithMessage;
 import com.google.common.collect.ImmutableList;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
+import java.sql.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
@@ -85,12 +82,12 @@ public class JdbcMysqlJ8IamAuthIntegrationTests {
   @Test
   public void pooledConnectionTest() throws SQLException {
 
-    List<String> rows = new ArrayList<>();
+    List<Timestamp> rows = new ArrayList<>();
     try (Connection conn = connectionPool.getConnection()) {
       try (PreparedStatement selectStmt = conn.prepareStatement("SELECT NOW() as TS")) {
         ResultSet rs = selectStmt.executeQuery();
         while (rs.next()) {
-          rows.add(rs.getString("TS"));
+          rows.add(rs.getTimestamp("TS"));
         }
       }
     }

--- a/jdbc/mysql-j-8/src/test/java/com/google/cloud/sql/mysql/JdbcMysqlJ8IntegrationTests.java
+++ b/jdbc/mysql-j-8/src/test/java/com/google/cloud/sql/mysql/JdbcMysqlJ8IntegrationTests.java
@@ -22,10 +22,7 @@ import static com.google.common.truth.Truth.assertWithMessage;
 import com.google.common.collect.ImmutableList;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
+import java.sql.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
@@ -84,12 +81,12 @@ public class JdbcMysqlJ8IntegrationTests {
   @Test
   public void pooledConnectionTest() throws SQLException {
 
-    List<String> rows = new ArrayList<>();
+    List<Timestamp> rows = new ArrayList<>();
     try (Connection conn = connectionPool.getConnection()) {
       try (PreparedStatement selectStmt = conn.prepareStatement("SELECT NOW() as TS")) {
         ResultSet rs = selectStmt.executeQuery();
         while (rs.next()) {
-          rows.add(rs.getString("TS"));
+          rows.add(rs.getTimestamp("TS"));
         }
       }
     }

--- a/jdbc/mysql-j-8/src/test/java/com/google/cloud/sql/mysql/JdbcMysqlJ8IntegrationTests.java
+++ b/jdbc/mysql-j-8/src/test/java/com/google/cloud/sql/mysql/JdbcMysqlJ8IntegrationTests.java
@@ -29,9 +29,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
-import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -50,7 +48,6 @@ public class JdbcMysqlJ8IntegrationTests {
   private static final ImmutableList<String> requiredEnvVars =
       ImmutableList.of("MYSQL_USER", "MYSQL_PASS", "MYSQL_DB", "MYSQL_CONNECTION_NAME");
   @Rule public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
-  private String tableName;
   private HikariDataSource connectionPool;
 
   @BeforeClass
@@ -82,57 +79,20 @@ public class JdbcMysqlJ8IntegrationTests {
     config.setConnectionTimeout(10000); // 10s
 
     this.connectionPool = new HikariDataSource(config);
-    this.tableName = String.format("books_%s", UUID.randomUUID().toString().replace("-", ""));
-
-    // Create table
-    try (Connection conn = connectionPool.getConnection()) {
-      String stmt =
-          String.format("CREATE TABLE %s (", this.tableName)
-              + "  ID CHAR(20) NOT NULL,"
-              + "  TITLE TEXT NOT NULL"
-              + ");";
-      try (PreparedStatement createTableStatement = conn.prepareStatement(stmt)) {
-        createTableStatement.execute();
-      }
-    }
-  }
-
-  @After
-  public void dropTableIfPresent() throws SQLException {
-    try (Connection conn = connectionPool.getConnection()) {
-      String stmt = String.format("DROP TABLE %s;", this.tableName);
-      try (PreparedStatement dropTableStatement = conn.prepareStatement(stmt)) {
-        dropTableStatement.execute();
-      }
-    }
   }
 
   @Test
   public void pooledConnectionTest() throws SQLException {
-    try (Connection conn = connectionPool.getConnection()) {
-      String stmt = String.format("INSERT INTO %s (ID, TITLE) VALUES (?, ?)", this.tableName);
-      try (PreparedStatement insertStmt = conn.prepareStatement(stmt)) {
-        insertStmt.setQueryTimeout(10);
-        insertStmt.setString(1, "book1");
-        insertStmt.setString(2, "Book One");
-        insertStmt.execute();
-        insertStmt.setString(1, "book2");
-        insertStmt.setString(2, "Book Two");
-        insertStmt.execute();
-      }
-    }
 
-    List<String> bookList = new ArrayList<>();
+    List<String> rows = new ArrayList<>();
     try (Connection conn = connectionPool.getConnection()) {
-      String stmt = String.format("SELECT TITLE FROM %s ORDER BY ID", this.tableName);
-      try (PreparedStatement selectStmt = conn.prepareStatement(stmt)) {
-        selectStmt.setQueryTimeout(10); // 10s
+      try (PreparedStatement selectStmt = conn.prepareStatement("SELECT NOW() as TS")) {
         ResultSet rs = selectStmt.executeQuery();
         while (rs.next()) {
-          bookList.add(rs.getString("TITLE"));
+          rows.add(rs.getString("TS"));
         }
       }
     }
-    assertThat(bookList).containsExactly("Book One", "Book Two");
+    assertThat(rows.size()).isEqualTo(1);
   }
 }

--- a/jdbc/postgres/src/test/java/com/google/cloud/sql/postgres/JdbcPostgresIamAuthIntegrationTests.java
+++ b/jdbc/postgres/src/test/java/com/google/cloud/sql/postgres/JdbcPostgresIamAuthIntegrationTests.java
@@ -29,9 +29,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
-import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -53,7 +51,6 @@ public class JdbcPostgresIamAuthIntegrationTests {
   @Rule public Timeout globalTimeout = new Timeout(60, TimeUnit.SECONDS);
 
   private HikariDataSource connectionPool;
-  private String tableName;
 
   @BeforeClass
   public static void checkEnvVars() {
@@ -85,62 +82,23 @@ public class JdbcPostgresIamAuthIntegrationTests {
     HikariConfig config = new HikariConfig();
     config.setJdbcUrl(jdbcURL);
     config.setDataSourceProperties(connProps);
-    config.setConnectionTimeout(10000); // 10s
 
     this.connectionPool = new HikariDataSource(config);
     // [END cloud_sql_connector_postgres_jdbc_iam_auth]
-
-    this.tableName = String.format("books_%s", UUID.randomUUID().toString().replace("-", ""));
-
-    // Create table
-    try (Connection conn = connectionPool.getConnection()) {
-      String stmt =
-          String.format("CREATE TABLE %s (", this.tableName)
-              + "  ID CHAR(20) NOT NULL,"
-              + "  TITLE TEXT NOT NULL"
-              + ");";
-      try (PreparedStatement createTableStatement = conn.prepareStatement(stmt)) {
-        createTableStatement.execute();
-      }
-    }
-  }
-
-  @After
-  public void dropTableIfPresent() throws SQLException {
-    try (Connection conn = connectionPool.getConnection()) {
-      String stmt = String.format("DROP TABLE %s;", this.tableName);
-      try (PreparedStatement dropTableStatement = conn.prepareStatement(stmt)) {
-        dropTableStatement.execute();
-      }
-    }
   }
 
   @Test
   public void pooledConnectionTest() throws SQLException {
-    try (Connection conn = connectionPool.getConnection()) {
-      String stmt = String.format("INSERT INTO %s (ID, TITLE) VALUES (?, ?)", this.tableName);
-      try (PreparedStatement insertStmt = conn.prepareStatement(stmt)) {
-        insertStmt.setQueryTimeout(10);
-        insertStmt.setString(1, "book1");
-        insertStmt.setString(2, "Book One");
-        insertStmt.execute();
-        insertStmt.setString(1, "book2");
-        insertStmt.setString(2, "Book Two");
-        insertStmt.execute();
-      }
-    }
 
-    List<String> bookList = new ArrayList<>();
+    List<String> rows = new ArrayList<>();
     try (Connection conn = connectionPool.getConnection()) {
-      String stmt = String.format("SELECT TITLE FROM %s ORDER BY ID", this.tableName);
-      try (PreparedStatement selectStmt = conn.prepareStatement(stmt)) {
-        selectStmt.setQueryTimeout(10); // 10s
+      try (PreparedStatement selectStmt = conn.prepareStatement("SELECT NOW() as TS")) {
         ResultSet rs = selectStmt.executeQuery();
         while (rs.next()) {
-          bookList.add(rs.getString("TITLE"));
+          rows.add(rs.getString("TS"));
         }
       }
     }
-    assertThat(bookList).containsExactly("Book One", "Book Two");
+    assertThat(rows.size()).isEqualTo(1);
   }
 }

--- a/jdbc/postgres/src/test/java/com/google/cloud/sql/postgres/JdbcPostgresIamAuthIntegrationTests.java
+++ b/jdbc/postgres/src/test/java/com/google/cloud/sql/postgres/JdbcPostgresIamAuthIntegrationTests.java
@@ -22,10 +22,7 @@ import static com.google.common.truth.Truth.assertWithMessage;
 import com.google.common.collect.ImmutableList;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
+import java.sql.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
@@ -90,12 +87,12 @@ public class JdbcPostgresIamAuthIntegrationTests {
   @Test
   public void pooledConnectionTest() throws SQLException {
 
-    List<String> rows = new ArrayList<>();
+    List<Timestamp> rows = new ArrayList<>();
     try (Connection conn = connectionPool.getConnection()) {
       try (PreparedStatement selectStmt = conn.prepareStatement("SELECT NOW() as TS")) {
         ResultSet rs = selectStmt.executeQuery();
         while (rs.next()) {
-          rows.add(rs.getString("TS"));
+          rows.add(rs.getTimestamp("TS"));
         }
       }
     }

--- a/jdbc/postgres/src/test/java/com/google/cloud/sql/postgres/JdbcPostgresIntegrationTests.java
+++ b/jdbc/postgres/src/test/java/com/google/cloud/sql/postgres/JdbcPostgresIntegrationTests.java
@@ -22,10 +22,7 @@ import static com.google.common.truth.Truth.assertWithMessage;
 import com.google.common.collect.ImmutableList;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
+import java.sql.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
@@ -85,12 +82,12 @@ public class JdbcPostgresIntegrationTests {
   @Test
   public void pooledConnectionTest() throws SQLException {
 
-    List<String> rows = new ArrayList<>();
+    List<Timestamp> rows = new ArrayList<>();
     try (Connection conn = connectionPool.getConnection()) {
       try (PreparedStatement selectStmt = conn.prepareStatement("SELECT NOW() as TS")) {
         ResultSet rs = selectStmt.executeQuery();
         while (rs.next()) {
-          rows.add(rs.getString("TS"));
+          rows.add(rs.getTimestamp("TS"));
         }
       }
     }

--- a/jdbc/postgres/src/test/java/com/google/cloud/sql/postgres/JdbcPostgresIntegrationTests.java
+++ b/jdbc/postgres/src/test/java/com/google/cloud/sql/postgres/JdbcPostgresIntegrationTests.java
@@ -29,9 +29,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
-import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -52,7 +50,6 @@ public class JdbcPostgresIntegrationTests {
   @Rule public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
 
   private HikariDataSource connectionPool;
-  private String tableName;
 
   @BeforeClass
   public static void checkEnvVars() {
@@ -83,57 +80,20 @@ public class JdbcPostgresIntegrationTests {
     config.setConnectionTimeout(10000); // 10s
 
     this.connectionPool = new HikariDataSource(config);
-    this.tableName = String.format("books_%s", UUID.randomUUID().toString().replace("-", ""));
-
-    // Create table
-    try (Connection conn = connectionPool.getConnection()) {
-      String stmt =
-          String.format("CREATE TABLE %s (", this.tableName)
-              + "  ID CHAR(20) NOT NULL,"
-              + "  TITLE TEXT NOT NULL"
-              + ");";
-      try (PreparedStatement createTableStatement = conn.prepareStatement(stmt)) {
-        createTableStatement.execute();
-      }
-    }
-  }
-
-  @After
-  public void dropTableIfPresent() throws SQLException {
-    try (Connection conn = connectionPool.getConnection()) {
-      String stmt = String.format("DROP TABLE %s;", this.tableName);
-      try (PreparedStatement dropTableStatement = conn.prepareStatement(stmt)) {
-        dropTableStatement.execute();
-      }
-    }
   }
 
   @Test
   public void pooledConnectionTest() throws SQLException {
-    try (Connection conn = connectionPool.getConnection()) {
-      String stmt = String.format("INSERT INTO %s (ID, TITLE) VALUES (?, ?)", this.tableName);
-      try (PreparedStatement insertStmt = conn.prepareStatement(stmt)) {
-        insertStmt.setQueryTimeout(10);
-        insertStmt.setString(1, "book1");
-        insertStmt.setString(2, "Book One");
-        insertStmt.execute();
-        insertStmt.setString(1, "book2");
-        insertStmt.setString(2, "Book Two");
-        insertStmt.execute();
-      }
-    }
 
-    List<String> bookList = new ArrayList<>();
+    List<String> rows = new ArrayList<>();
     try (Connection conn = connectionPool.getConnection()) {
-      String stmt = String.format("SELECT TITLE FROM %s ORDER BY ID", this.tableName);
-      try (PreparedStatement selectStmt = conn.prepareStatement(stmt)) {
-        selectStmt.setQueryTimeout(10); // 10s
+      try (PreparedStatement selectStmt = conn.prepareStatement("SELECT NOW() as TS")) {
         ResultSet rs = selectStmt.executeQuery();
         while (rs.next()) {
-          bookList.add(rs.getString("TITLE"));
+          rows.add(rs.getString("TS"));
         }
       }
     }
-    assertThat(bookList).containsExactly("Book One", "Book Two");
+    assertThat(rows.size()).isEqualTo(1);
   }
 }

--- a/jdbc/sqlserver/src/test/java/com/google/cloud/sql/sqlserver/JdbcSqlServerIntegrationTests.java
+++ b/jdbc/sqlserver/src/test/java/com/google/cloud/sql/sqlserver/JdbcSqlServerIntegrationTests.java
@@ -22,10 +22,7 @@ import static com.google.common.truth.Truth.assertWithMessage;
 import com.google.common.collect.ImmutableList;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
+import java.sql.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -85,12 +82,12 @@ public class JdbcSqlServerIntegrationTests {
   @Test
   public void pooledConnectionTest() throws SQLException {
 
-    List<String> rows = new ArrayList<>();
+    List<Integer> rows = new ArrayList<>();
     try (Connection conn = connectionPool.getConnection()) {
       try (PreparedStatement selectStmt = conn.prepareStatement("SELECT 1 as TS")) {
         ResultSet rs = selectStmt.executeQuery();
         while (rs.next()) {
-          rows.add(rs.getString("TS"));
+          rows.add(rs.getInt("TS"));
         }
       }
     }

--- a/jdbc/sqlserver/src/test/java/com/google/cloud/sql/sqlserver/JdbcSqlServerIntegrationTests.java
+++ b/jdbc/sqlserver/src/test/java/com/google/cloud/sql/sqlserver/JdbcSqlServerIntegrationTests.java
@@ -28,9 +28,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -52,7 +50,6 @@ public class JdbcSqlServerIntegrationTests {
   @Rule public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
 
   private HikariDataSource connectionPool;
-  private String tableName;
 
   @BeforeClass
   public static void checkEnvVars() {
@@ -83,57 +80,20 @@ public class JdbcSqlServerIntegrationTests {
     config.setConnectionTimeout(10000); // 10s
 
     this.connectionPool = new HikariDataSource(config);
-    this.tableName = String.format("books_%s", UUID.randomUUID().toString().replace("-", ""));
-
-    // Create table
-    try (Connection conn = connectionPool.getConnection()) {
-      String stmt =
-          String.format("CREATE TABLE %s (", this.tableName)
-              + "  ID CHAR(20) NOT NULL,"
-              + "  TITLE TEXT NOT NULL"
-              + ");";
-      try (PreparedStatement createTableStatement = conn.prepareStatement(stmt)) {
-        createTableStatement.execute();
-      }
-    }
-  }
-
-  @After
-  public void dropTableIfPresent() throws SQLException {
-    try (Connection conn = connectionPool.getConnection()) {
-      String stmt = String.format("DROP TABLE %s;", this.tableName);
-      try (PreparedStatement dropTableStatement = conn.prepareStatement(stmt)) {
-        dropTableStatement.execute();
-      }
-    }
   }
 
   @Test
   public void pooledConnectionTest() throws SQLException {
-    try (Connection conn = connectionPool.getConnection()) {
-      String stmt = String.format("INSERT INTO %s (ID, TITLE) VALUES (?, ?)", this.tableName);
-      try (PreparedStatement insertStmt = conn.prepareStatement(stmt)) {
-        insertStmt.setQueryTimeout(10);
-        insertStmt.setString(1, "book1");
-        insertStmt.setString(2, "Book One");
-        insertStmt.execute();
-        insertStmt.setString(1, "book2");
-        insertStmt.setString(2, "Book Two");
-        insertStmt.execute();
-      }
-    }
 
-    List<String> bookList = new ArrayList<>();
+    List<String> rows = new ArrayList<>();
     try (Connection conn = connectionPool.getConnection()) {
-      String stmt = String.format("SELECT TITLE FROM %s ORDER BY ID", this.tableName);
-      try (PreparedStatement selectStmt = conn.prepareStatement(stmt)) {
-        selectStmt.setQueryTimeout(10); // 10s
+      try (PreparedStatement selectStmt = conn.prepareStatement("SELECT 1 as TS")) {
         ResultSet rs = selectStmt.executeQuery();
         while (rs.next()) {
-          bookList.add(rs.getString("TITLE"));
+          rows.add(rs.getString("TS"));
         }
       }
     }
-    assertThat(bookList).containsExactly("Book One", "Book Two");
+    assertThat(rows.size()).isEqualTo(1);
   }
 }


### PR DESCRIPTION
Remove extraneous test code that created tables and inserted data. If the client 
can perform `select 1` or `select now`, the connection succeeded.