### PR TITLE
fix: Use existing retry logic on initial connection when IAMAuth is enabled

### DIFF
--- a/core/src/main/java/com/google/cloud/sql/ApiFetcherFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/ApiFetcherFactory.java
@@ -16,11 +16,11 @@
 
 package com.google.cloud.sql;
 
-import com.google.api.client.http.HttpRequestInitializer;
+import com.google.auth.Credentials;
 import com.google.cloud.sql.core.SqlAdminApiFetcher;
 
 /** Factory interface for creating SQLAdmin clients to interact with Cloud SQL Admin API. */
 public interface ApiFetcherFactory {
 
-  SqlAdminApiFetcher create(HttpRequestInitializer credentials);
+  SqlAdminApiFetcher create(Credentials credentials);
 }

--- a/core/src/main/java/com/google/cloud/sql/ApplicationDefaultCredentialFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/ApplicationDefaultCredentialFactory.java
@@ -16,18 +16,15 @@
 
 package com.google.cloud.sql;
 
-import com.google.api.client.http.HttpRequestInitializer;
 import com.google.api.services.sqladmin.SQLAdminScopes;
-import com.google.auth.http.HttpCredentialsAdapter;
 import com.google.auth.oauth2.GoogleCredentials;
 import java.io.IOException;
 import java.util.Arrays;
 
 /** This class creates a HttpRequestInitializer from Application Default Credentials. */
 public class ApplicationDefaultCredentialFactory implements CredentialFactory {
-
   @Override
-  public HttpRequestInitializer create() {
+  public GoogleCredentials createGoogleCredentials() {
     GoogleCredentials credentials;
     try {
       credentials = GoogleCredentials.getApplicationDefault();
@@ -40,6 +37,6 @@ public class ApplicationDefaultCredentialFactory implements CredentialFactory {
           credentials.createScoped(
               Arrays.asList(SQLAdminScopes.SQLSERVICE_ADMIN, SQLAdminScopes.CLOUD_PLATFORM));
     }
-    return new HttpCredentialsAdapter(credentials);
+    return credentials;
   }
 }

--- a/core/src/main/java/com/google/cloud/sql/CredentialFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/CredentialFactory.java
@@ -17,7 +17,7 @@
 package com.google.cloud.sql;
 
 import com.google.api.client.auth.oauth2.Credential;
-import com.google.api.client.http.HttpRequestInitializer;
+import com.google.auth.oauth2.GoogleCredentials;
 
 /** Factory for creating {@link Credential}s for interaction with Cloud SQL Admin API. */
 public interface CredentialFactory {
@@ -25,5 +25,5 @@ public interface CredentialFactory {
   /** Name of system property that can specify an alternative credential factory. */
   String CREDENTIAL_FACTORY_PROPERTY = "cloudSql.socketFactory.credentialFactory";
 
-  HttpRequestInitializer create();
+  GoogleCredentials createGoogleCredentials();
 }

--- a/core/src/main/java/com/google/cloud/sql/SqlAdminApiFetcherFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/SqlAdminApiFetcherFactory.java
@@ -17,11 +17,12 @@
 package com.google.cloud.sql;
 
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
-import com.google.api.client.http.HttpRequestInitializer;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.services.sqladmin.SQLAdmin;
+import com.google.auth.Credentials;
+import com.google.auth.http.HttpCredentialsAdapter;
 import com.google.cloud.sql.core.SqlAdminApiFetcher;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -48,7 +49,7 @@ public class SqlAdminApiFetcherFactory implements ApiFetcherFactory {
   }
 
   @Override
-  public SqlAdminApiFetcher create(HttpRequestInitializer requestInitializer) {
+  public SqlAdminApiFetcher create(Credentials credential) {
     HttpTransport httpTransport;
     try {
       httpTransport = GoogleNetHttpTransport.newTrustedTransport();
@@ -58,7 +59,7 @@ public class SqlAdminApiFetcherFactory implements ApiFetcherFactory {
 
     JsonFactory jsonFactory = GsonFactory.getDefaultInstance();
     SQLAdmin.Builder adminApiBuilder =
-        new SQLAdmin.Builder(httpTransport, jsonFactory, requestInitializer)
+        new SQLAdmin.Builder(httpTransport, jsonFactory, new HttpCredentialsAdapter(credential))
             .setApplicationName(userAgents);
     if (rootUrl != null) {
       adminApiBuilder.setRootUrl(rootUrl);

--- a/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.sql.core;
 
-import com.google.api.client.http.HttpRequestInitializer;
 import com.google.cloud.sql.AuthType;
 import com.google.cloud.sql.CredentialFactory;
 import com.google.cloud.sql.SqlAdminApiFetcherFactory;
@@ -100,9 +99,9 @@ public final class CoreSocketFactory {
 
       CredentialFactory credentialFactory = CredentialFactoryProvider.getCredentialFactory();
 
-      HttpRequestInitializer credential = credentialFactory.create();
       SqlAdminApiFetcher adminApiService =
-          new SqlAdminApiFetcherFactory(getUserAgents()).create(credential);
+          new SqlAdminApiFetcherFactory(getUserAgents())
+              .create(credentialFactory.createGoogleCredentials());
       ListeningScheduledExecutorService executor = getDefaultExecutor();
 
       coreSocketFactory =

--- a/core/src/main/java/com/google/cloud/sql/core/SqlAdminApiFetcher.java
+++ b/core/src/main/java/com/google/cloud/sql/core/SqlAdminApiFetcher.java
@@ -23,6 +23,7 @@ import com.google.api.services.sqladmin.model.GenerateEphemeralCertRequest;
 import com.google.api.services.sqladmin.model.GenerateEphemeralCertResponse;
 import com.google.api.services.sqladmin.model.IpMapping;
 import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.GoogleCredentials;
 import com.google.auth.oauth2.OAuth2Credentials;
 import com.google.cloud.sql.AuthType;
 import com.google.common.base.CharMatcher;
@@ -134,7 +135,7 @@ public class SqlAdminApiFetcher {
 
   ListenableFuture<InstanceData> getInstanceData(
       CloudSqlInstanceName instanceName,
-      OAuth2Credentials credentials,
+      GoogleCredentials credentials,
       AuthType authType,
       ListeningScheduledExecutorService executor,
       ListenableFuture<KeyPair> keyPair) {

--- a/core/src/test/java/com/google/cloud/sql/core/CloudSqlInstanceTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/CloudSqlInstanceTest.java
@@ -16,13 +16,11 @@
 package com.google.cloud.sql.core;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.auth.oauth2.GoogleCredentials;
-import com.google.auth.oauth2.OAuth2Credentials;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Date;
@@ -39,7 +37,6 @@ public class CloudSqlInstanceTest {
 
   @Mock private GoogleCredentials googleCredentials;
   @Mock private GoogleCredentials scopedCredentials;
-  @Mock private OAuth2Credentials oAuth2Credentials;
 
   @Before
   public void setup() {
@@ -54,18 +51,6 @@ public class CloudSqlInstanceTest {
     assertThat(downscoped).isEqualTo(scopedCredentials);
     verify(googleCredentials, times(1))
         .createScoped("https://www.googleapis.com/auth/sqlservice.login");
-  }
-
-  @Test
-  public void throwsErrorForWrongCredentialType() {
-    RuntimeException ex =
-        assertThrows(
-            RuntimeException.class,
-            () -> CloudSqlInstance.getDownscopedCredentials(oAuth2Credentials));
-
-    assertThat(ex)
-        .hasMessageThat()
-        .contains("Failed to downscope credentials for IAM Authentication");
   }
 
   @Test

--- a/core/src/test/java/com/google/cloud/sql/core/MockGoogleCredentials.java
+++ b/core/src/test/java/com/google/cloud/sql/core/MockGoogleCredentials.java
@@ -1,0 +1,16 @@
+package com.google.cloud.sql.core;
+
+import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.GoogleCredentials;
+import java.io.IOException;
+
+class MockGoogleCredentials extends GoogleCredentials {
+  MockGoogleCredentials(AccessToken token) {
+    super(token);
+  }
+
+  @Override
+  public void refresh() throws IOException {
+    // noop refresh token
+  }
+}

--- a/core/src/test/java/com/google/cloud/sql/core/StubApiFetcherFactory.java
+++ b/core/src/test/java/com/google/cloud/sql/core/StubApiFetcherFactory.java
@@ -16,12 +16,13 @@
 
 package com.google.cloud.sql.core;
 
-import com.google.api.client.http.HttpRequestInitializer;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.client.testing.http.MockHttpTransport;
 import com.google.api.services.sqladmin.SQLAdmin;
 import com.google.api.services.sqladmin.SQLAdmin.Builder;
+import com.google.auth.Credentials;
+import com.google.auth.http.HttpCredentialsAdapter;
 import com.google.cloud.sql.ApiFetcherFactory;
 
 public class StubApiFetcherFactory implements ApiFetcherFactory {
@@ -33,12 +34,12 @@ public class StubApiFetcherFactory implements ApiFetcherFactory {
   }
 
   @Override
-  public SqlAdminApiFetcher create(HttpRequestInitializer credentials) {
+  public SqlAdminApiFetcher create(Credentials credentials) {
     SQLAdmin sqlAdmin =
         new Builder(
                 httpTransport != null ? httpTransport : new MockHttpTransport(),
                 GsonFactory.getDefaultInstance(),
-                credentials)
+                new HttpCredentialsAdapter(credentials))
             .setApplicationName("Mock SQL Admin")
             .build();
     return new SqlAdminApiFetcher(sqlAdmin);

--- a/core/src/test/java/com/google/cloud/sql/core/StubCredentialFactory.java
+++ b/core/src/test/java/com/google/cloud/sql/core/StubCredentialFactory.java
@@ -16,9 +16,10 @@
 
 package com.google.cloud.sql.core;
 
-import com.google.api.client.googleapis.testing.auth.oauth2.MockGoogleCredential;
-import com.google.api.client.http.HttpRequestInitializer;
+import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.sql.CredentialFactory;
+import java.util.Date;
 
 public class StubCredentialFactory implements CredentialFactory {
 
@@ -33,10 +34,12 @@ public class StubCredentialFactory implements CredentialFactory {
   }
 
   @Override
-  public HttpRequestInitializer create() {
-    MockGoogleCredential testCredential = new MockGoogleCredential.Builder().build();
-    testCredential.setAccessToken(accessToken);
-    testCredential.setExpirationTimeMilliseconds(expirationTimeInMilliseconds);
-    return testCredential;
+  public GoogleCredentials createGoogleCredentials() {
+    return new MockGoogleCredentials(
+        new AccessToken(
+            accessToken,
+            expirationTimeInMilliseconds != null
+                ? new Date(System.currentTimeMillis() + expirationTimeInMilliseconds)
+                : null));
   }
 }

--- a/r2dbc/core/src/test/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderTest.java
+++ b/r2dbc/core/src/test/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderTest.java
@@ -176,7 +176,7 @@ public class GcpConnectionFactoryProviderTest {
 
     SqlAdminApiFetcher fetcher =
         new StubApiFetcherFactory(fakeSuccessHttpTransport(Duration.ofSeconds(0)))
-            .create(credentialFactory.create());
+            .create(credentialFactory.createGoogleCredentials());
 
     coreSocketFactoryStub =
         new CoreSocketFactory(clientKeyPair, fetcher, credentialFactory, 3307, defaultExecutor);


### PR DESCRIPTION
Refactor so that the connector will use the existing refresh logic on the initial connection to
the database when IAM authentication is enabled.

Fixes #1289