### PR TITLE
fix: Retry when attempting to get the auth token

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -204,6 +204,12 @@
       <artifactId>google-api-services-sqladmin</artifactId>
       <version>v1beta4-rev20230403-2.0.0</version>
     </dependency>
+    
+    <dependency>
+      <groupId>com.google.auth</groupId>
+      <artifactId>google-auth-library-credentials</artifactId>
+      <version>1.13.0</version>
+    </dependency>
 
     <dependency>
       <groupId>com.google.auth</groupId>

--- a/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstance.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstance.java
@@ -164,7 +164,7 @@ class CloudSqlInstance {
     throw new RuntimeException(
         String.format(
             "[%s] Unable to connect via automatic IAM authentication: "
-                + "Not supporting credentials of type %s",
+                + "Unsupported credentials of type %s",
             instanceName.getConnectionName(), source.getClass().getName()));
   }
 

--- a/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstance.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstance.java
@@ -161,8 +161,11 @@ class CloudSqlInstance {
         }
       };
     }
-
-    throw new RuntimeException("Not supporting credentials of type " + source.getClass().getName());
+    throw new RuntimeException(
+        String.format(
+            "[%s] Unable to connect via automatic IAM authentication: "
+                + "Not supporting credentials of type %s",
+            instanceName.getConnectionName(), source.getClass().getName()));
   }
 
   /**

--- a/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstance.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstance.java
@@ -63,7 +63,7 @@ class CloudSqlInstance {
   private final ListeningScheduledExecutorService executor;
   private final SqlAdminApiFetcher apiFetcher;
   private final AuthType authType;
-  private final Optional<OAuth2Credentials> credentials;
+  private final Optional<OAuth2Credentials> iamAuthnCredentials;
   private final CloudSqlInstanceName instanceName;
   private final ListenableFuture<KeyPair> keyPair;
   private final Object instanceDataGuard = new Object();
@@ -101,10 +101,9 @@ class CloudSqlInstance {
 
     if (authType == AuthType.IAM) {
       HttpRequestInitializer source = tokenSourceFactory.create();
-      this.credentials = Optional.of(parseCredentials(source));
-      this.credentials.get().refresh();
+      this.iamAuthnCredentials = Optional.of(parseCredentials(source));
     } else {
-      this.credentials = Optional.empty();
+      this.iamAuthnCredentials = Optional.empty();
     }
 
     synchronized (instanceDataGuard) {
@@ -245,23 +244,17 @@ class CloudSqlInstance {
     forcedRenewRateLimiter.acquirePermit();
 
     ListenableFuture<InstanceData> refreshFuture;
-    if (authType == AuthType.IAM) {
-      if (credentials.isPresent()) {
-        GoogleCredentials downscopedCredentials = getDownscopedCredentials(credentials.get());
-        refreshFuture =
-            apiFetcher.getInstanceData(
-                instanceName, downscopedCredentials, AuthType.IAM, executor, keyPair);
-      } else {
-        throw new RuntimeException(
-            String.format(
-                "[%s] Unable to connect via automatic IAM authentication: Missing credentials.",
-                instanceName.getConnectionName()));
-      }
 
+    if (iamAuthnCredentials.isPresent()) {
+      GoogleCredentials downscopedCredentials = getDownscopedCredentials(iamAuthnCredentials.get());
+      refreshFuture =
+          apiFetcher.getInstanceData(
+              instanceName, downscopedCredentials, AuthType.IAM, executor, keyPair);
     } else {
       refreshFuture =
           apiFetcher.getInstanceData(instanceName, null, AuthType.PASSWORD, executor, keyPair);
     }
+
     Futures.addCallback(
         refreshFuture,
         new FutureCallback<InstanceData>() {

--- a/core/src/main/java/com/google/cloud/sql/core/RetryingCallable.java
+++ b/core/src/main/java/com/google/cloud/sql/core/RetryingCallable.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.sql.core;
+
+import java.time.Duration;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * RetryLogic attempts to call a Callable multiple times, sleeping between failed attempts. The
+ * sleep duration is chosen randomly in the range [sleepDuration, sleepDuration * 2] to avoid
+ * causing a thundering herd of requests on failure.
+ *
+ * @param <T> the result type of the Callable.
+ */
+public class RetryingCallable<T> implements Callable<T> {
+
+  /** The callable that should be retried. */
+  private final Callable<T> call;
+  /** The number of times to attempt to retry. */
+  private final int retryCount;
+  /** The duration to sleep after a failed retry attempt. */
+  private final Duration sleepDuration;
+
+  /**
+   * Construct a new RetryLogic.
+   *
+   * @param call the callable that should be retried
+   * @param retryCount the number of times to retry
+   * @param sleepDuration the duration wait after a failed attempt.
+   */
+  public RetryingCallable(Callable<T> call, int retryCount, Duration sleepDuration) {
+    if (retryCount <= 0) {
+      throw new IllegalArgumentException("retryCount must be > 0");
+    }
+    if (sleepDuration.isNegative() || sleepDuration.isZero()) {
+      throw new IllegalArgumentException("sleepDuration must be positive");
+    }
+    if (call == null) {
+      throw new IllegalArgumentException("call must not be null");
+    }
+    this.call = call;
+    this.retryCount = retryCount;
+    this.sleepDuration = sleepDuration;
+  }
+
+  @Override
+  public T call() throws Exception {
+
+    for (int i = retryCount - 1; i >= 0; i--) {
+      // Attempt to call the Callable.
+      try {
+        return call.call();
+      } catch (Exception e) {
+        // Callable threw an exception.
+
+        // If this is the last iteration, then
+        // throw the exception
+        if (i == 0) {
+          throw e;
+        }
+
+        // Else, sleep a random amount of time, then retry
+        long sleep =
+            ThreadLocalRandom.current()
+                .nextLong(sleepDuration.toMillis(), sleepDuration.toMillis() * 2);
+        try {
+          Thread.sleep(sleep);
+        } catch (InterruptedException ie) {
+          throw e; // if sleep is interrupted, then throw 'e', don't take another iteration
+        }
+      }
+    }
+
+    // If the callable was never called, then throw an exception. This will never happen
+    // as long as the preconditions in the constructor are properly met.
+    throw new RuntimeException("call was never called.");
+  }
+}

--- a/core/src/main/java/com/google/cloud/sql/core/SqlAdminApiFetcher.java
+++ b/core/src/main/java/com/google/cloud/sql/core/SqlAdminApiFetcher.java
@@ -340,7 +340,8 @@ public class SqlAdminApiFetcher {
     } catch (IOException e) {
       throw e;
     } catch (Exception e) {
-      throw new RuntimeException("Unexpected retry exception", e);
+      throw new RuntimeException(
+          "Unexpected exception while attempting to refresh oauth credentials", e);
     }
   }
 

--- a/core/src/main/java/com/google/cloud/sql/core/SqlAdminApiFetcher.java
+++ b/core/src/main/java/com/google/cloud/sql/core/SqlAdminApiFetcher.java
@@ -318,6 +318,7 @@ public class SqlAdminApiFetcher {
 
     return ephemeralCertificate;
   }
+
   /**
    * refreshWithRetry attempts to refresh the credentials 3 times, waiting 3-6 seconds between
    * attempts.

--- a/core/src/main/java/com/google/cloud/sql/core/SqlAdminApiFetcher.java
+++ b/core/src/main/java/com/google/cloud/sql/core/SqlAdminApiFetcher.java
@@ -54,6 +54,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -272,7 +273,7 @@ public class SqlAdminApiFetcher {
 
     if (authType == AuthType.IAM) {
       try {
-        credentials.refresh();
+        refreshWithRetry(credentials);
         AccessToken accessToken = credentials.getAccessToken();
 
         validateAccessToken(accessToken);
@@ -316,6 +317,39 @@ public class SqlAdminApiFetcher {
     }
 
     return ephemeralCertificate;
+  }
+  /**
+   * refreshWithRetry attempts to refresh the credentials 3 times, waiting 3-6 seconds between
+   * attempts.
+   *
+   * @param credentials the credentials to refresh
+   * @throws IOException when the credentials.refresh() has failed 3 times
+   */
+  private void refreshWithRetry(OAuth2Credentials credentials) throws IOException {
+    final int retryCount = 3;
+    final int sleepAfterFailedMs = 3000;
+    for (int i = retryCount; i >= 0; i--) {
+      // Try to refresh the credentials.
+      try {
+        credentials.refresh();
+        return; // if successful, return
+      } catch (IOException e) {
+        // failed to refresh
+        // If this is the last iteration, then
+        // throw the exception
+        if (i == 0) {
+          throw e;
+        }
+        // else, sleep a random amount of time between 3 and 6 seconds, then retry
+        long sleep =
+            ThreadLocalRandom.current().nextInt(sleepAfterFailedMs, sleepAfterFailedMs * 2);
+        try {
+          Thread.sleep(sleep);
+        } catch (InterruptedException ie) {
+          throw e; // if sleep is interrupted, then throw 'e', don't take another iteration
+        }
+      }
+    }
   }
 
   private void validateAccessToken(AccessToken accessToken) {

--- a/core/src/main/java/com/google/cloud/sql/core/SqlAdminApiFetcher.java
+++ b/core/src/main/java/com/google/cloud/sql/core/SqlAdminApiFetcher.java
@@ -341,7 +341,7 @@ public class SqlAdminApiFetcher {
       throw e;
     } catch (Exception e) {
       throw new RuntimeException(
-          "Unexpected exception while attempting to refresh oauth credentials", e);
+          "Unexpected exception while attempting to refresh OAuth2 credentials", e);
     }
   }
 

--- a/core/src/test/java/com/google/cloud/sql/core/BadConnectionFactory.java
+++ b/core/src/test/java/com/google/cloud/sql/core/BadConnectionFactory.java
@@ -1,0 +1,32 @@
+package com.google.cloud.sql.core;
+
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.http.LowLevelHttpRequest;
+import com.google.api.client.http.LowLevelHttpResponse;
+import java.io.IOException;
+import java.net.SocketTimeoutException;
+
+public class BadConnectionFactory extends HttpTransport {
+
+  @Override
+  protected LowLevelHttpRequest buildRequest(String method, String url) throws IOException {
+    return new FailToConnectRequest();
+  }
+
+  private class FailToConnectRequest extends LowLevelHttpRequest {
+
+    @Override
+    public void addHeader(String name, String value) throws IOException {
+      // do nothing.
+    }
+
+    @Override
+    public LowLevelHttpResponse execute() throws IOException {
+      try {
+        Thread.sleep(10000);
+      } catch (InterruptedException e) {
+      }
+      throw new SocketTimeoutException("Fake connect timeout");
+    }
+  }
+}

--- a/core/src/test/java/com/google/cloud/sql/core/BadConnectionFactory.java
+++ b/core/src/test/java/com/google/cloud/sql/core/BadConnectionFactory.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.cloud.sql.core;
 
 import com.google.api.client.http.HttpTransport;
@@ -13,7 +29,7 @@ public class BadConnectionFactory extends HttpTransport {
     return new FailToConnectRequest();
   }
 
-  private class FailToConnectRequest extends LowLevelHttpRequest {
+  private static class FailToConnectRequest extends LowLevelHttpRequest {
 
     @Override
     public void addHeader(String name, String value) throws IOException {
@@ -22,10 +38,6 @@ public class BadConnectionFactory extends HttpTransport {
 
     @Override
     public LowLevelHttpResponse execute() throws IOException {
-      try {
-        Thread.sleep(10000);
-      } catch (InterruptedException e) {
-      }
       throw new SocketTimeoutException("Fake connect timeout");
     }
   }

--- a/core/src/test/java/com/google/cloud/sql/core/RetryingCallableTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/RetryingCallableTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.sql.core;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class RetryingCallableTest {
+  @Test
+  public void testNoRetryRequired() throws Exception {
+    RetryingCallable<Integer> r = new RetryingCallable<>(() -> 1, 5, Duration.ofSeconds(1));
+    int v = r.call();
+    assertThat(v).isEqualTo(1);
+  }
+
+  @Test
+  public void testAlwaysFails() {
+    final AtomicInteger counter = new AtomicInteger();
+    RetryingCallable<Integer> r =
+        new RetryingCallable<>(
+            () -> {
+              counter.incrementAndGet();
+              throw new Exception("nope");
+            },
+            3,
+            Duration.ofSeconds(1));
+
+    try {
+      r.call();
+      Assert.fail("got no exception, wants an exception to be thrown");
+    } catch (Exception e) {
+      // Expected to throw an exception
+    }
+
+    assertThat(counter.get()).isEqualTo(3);
+  }
+
+  @Test
+  public void testRetrySucceedsAfterFailures() throws Exception {
+    final AtomicInteger counter = new AtomicInteger();
+    RetryingCallable<Integer> r =
+        new RetryingCallable<>(
+            () -> {
+              int i = counter.incrementAndGet();
+              if (i < 3) {
+                throw new Exception("nope");
+              }
+              return i;
+            },
+            5,
+            Duration.ofSeconds(1));
+
+    int v = r.call();
+    assertThat(counter.get()).isEqualTo(3);
+    assertThat(v).isEqualTo(3);
+  }
+}

--- a/core/src/test/java/com/google/cloud/sql/core/RetryingCallableTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/RetryingCallableTest.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 public class RetryingCallableTest {
   @Test
   public void testNoRetryRequired() throws Exception {
-    RetryingCallable<Integer> r = new RetryingCallable<>(() -> 1, 5, Duration.ofSeconds(1));
+    RetryingCallable<Integer> r = new RetryingCallable<>(() -> 1, 5, Duration.ofMillis(100));
     int v = r.call();
     assertThat(v).isEqualTo(1);
   }
@@ -41,7 +41,7 @@ public class RetryingCallableTest {
               throw new Exception("nope");
             },
             3,
-            Duration.ofSeconds(1));
+            Duration.ofMillis(100));
 
     try {
       r.call();
@@ -66,7 +66,7 @@ public class RetryingCallableTest {
               return i;
             },
             5,
-            Duration.ofSeconds(1));
+            Duration.ofMillis(100));
 
     int v = r.call();
     assertThat(counter.get()).isEqualTo(3);

--- a/core/src/test/java/com/google/cloud/sql/core/RetryingCallableTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/RetryingCallableTest.java
@@ -25,6 +25,30 @@ import org.junit.Test;
 
 public class RetryingCallableTest {
   @Test
+  public void testConstructorIllegalArguments() throws Exception {
+    // Callable must not be null
+    Assert.assertThrows(
+        IllegalArgumentException.class,
+        () -> new RetryingCallable<>(null, 1, Duration.ofMillis(1)));
+
+    // Must have a positive retryCount
+    Assert.assertThrows(
+        IllegalArgumentException.class,
+        () -> new RetryingCallable<>(() -> null, 0, Duration.ofMillis(1)));
+    Assert.assertThrows(
+        IllegalArgumentException.class,
+        () -> new RetryingCallable<>(() -> null, -1, Duration.ofMillis(1)));
+
+    // Must have a positive duration
+    Assert.assertThrows(
+        IllegalArgumentException.class,
+        () -> new RetryingCallable<>(() -> null, 2, Duration.ofMillis(-5)));
+    Assert.assertThrows(
+        IllegalArgumentException.class,
+        () -> new RetryingCallable<>(() -> null, 2, Duration.ofMillis(0)));
+  }
+
+  @Test
   public void testNoRetryRequired() throws Exception {
     RetryingCallable<Integer> r = new RetryingCallable<>(() -> 1, 5, Duration.ofMillis(100));
     int v = r.call();

--- a/core/src/test/java/com/google/cloud/sql/core/SqlAdminApiFetcherTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/SqlAdminApiFetcherTest.java
@@ -185,7 +185,7 @@ public class SqlAdminApiFetcherTest {
 
     ExecutionException ex = assertThrows(ExecutionException.class, instanceData::get);
 
-    assertThat(ex).hasMessageThat().contains("Fake connect timeout");
+    assertThat(ex.getCause().getCause()).hasMessageThat().contains("Fake connect timeout");
   }
 
   @SuppressWarnings("SameParameterValue")

--- a/core/src/test/java/com/google/cloud/sql/core/SqlAdminApiFetcherTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/SqlAdminApiFetcherTest.java
@@ -161,6 +161,33 @@ public class SqlAdminApiFetcherTest {
     assertThat(ex).hasMessageThat().contains("Access Token expiration time is in the past");
   }
 
+  @Test
+  public void testFetchInstanceData_throwsException_whenRequestsTimeout()
+      throws GeneralSecurityException, OperatorCreationException {
+    MockAdminApi mockAdminApi = buildMockAdminApi(INSTANCE_CONNECTION_NAME, DATABASE_VERSION);
+    SqlAdminApiFetcher fetcher =
+        new StubApiFetcherFactory(new BadConnectionFactory())
+            .create(new StubCredentialFactory().create());
+
+    ListenableFuture<InstanceData> instanceData =
+        fetcher.getInstanceData(
+            new CloudSqlInstanceName(INSTANCE_CONNECTION_NAME),
+            OAuth2CredentialsWithRefresh.newBuilder()
+                .setRefreshHandler(
+                    mockAdminApi.getRefreshHandler(
+                        "refresh-token",
+                        Date.from(Instant.now().plus(1, ChronoUnit.HOURS)) /* 1 hour from now */))
+                .setAccessToken(new AccessToken("original-token", Date.from(Instant.now())))
+                .build(),
+            AuthType.IAM,
+            newTestExecutor(),
+            Futures.immediateFuture(mockAdminApi.getClientKeyPair()));
+
+    ExecutionException ex = assertThrows(ExecutionException.class, instanceData::get);
+
+    assertThat(ex).hasMessageThat().contains("Fake connect timeout");
+  }
+
   @SuppressWarnings("SameParameterValue")
   private MockAdminApi buildMockAdminApi(String instanceConnectionName, String databaseVersion)
       throws GeneralSecurityException, OperatorCreationException {


### PR DESCRIPTION
Simplifies the logic when attempting to get the first token for a connection with IAM AuthN enabled. Also, adds logic
to retry the token request 3 times if it initially fails. 

Fixes #1288 
Fixes #1127
