### PR TITLE
fix: Revert Update dependency com.google.errorprone:error_prone_core to v2.19.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
             <path>
               <groupId>com.google.errorprone</groupId>
               <artifactId>error_prone_core</artifactId>
-              <version>2.19.1</version>
+              <version>2.10.0</version>
             </path>
           </annotationProcessorPaths>
         </configuration>


### PR DESCRIPTION
This was merged by mistake.

This reverts commit 6b9d7dc5628cd5992c08a3ea232ae57c322a538d.