### PR TITLE
feat: Use new certificate refresh logic 

### DIFF
--- a/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstance.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstance.java
@@ -55,10 +55,6 @@ class CloudSqlInstance {
 
   private static final Logger logger = Logger.getLogger(CloudSqlInstance.class.getName());
   private static final String SQL_LOGIN_SCOPE = "https://www.googleapis.com/auth/sqlservice.login";
-  // defaultRefreshBuffer is the minimum amount of time for which a
-  // certificate must be valid to ensure the next refresh attempt has adequate
-  // time to complete.
-  private static final Duration DEFAULT_REFRESH_BUFFER = Duration.ofMinutes(4);
 
   private final ListeningScheduledExecutorService executor;
   private final SqlAdminApiFetcher apiFetcher;

--- a/core/src/main/java/com/google/cloud/sql/core/RefreshCalculator.java
+++ b/core/src/main/java/com/google/cloud/sql/core/RefreshCalculator.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.sql.core;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+/**
+ * RefreshCalculator determines the number of seconds until the next refresh operation using the
+ * same algorithm used by the other Connectors.
+ */
+class RefreshCalculator {
+
+  private static final int ONE_HOUR_IN_SECONDS = 3600;
+  private static final int REFRESH_BUFFER_IN_SECONDS = 240; // Four minutes
+
+  long calculateSecondsUntilNextRefresh(Instant now, Instant clientCertificateExpiration) {
+    long secondsUntilExpiration = ChronoUnit.SECONDS.between(now, clientCertificateExpiration);
+    if (secondsUntilExpiration < ONE_HOUR_IN_SECONDS) {
+      if (secondsUntilExpiration < REFRESH_BUFFER_IN_SECONDS) {
+        return 0;
+      }
+      return secondsUntilExpiration - REFRESH_BUFFER_IN_SECONDS;
+    }
+    return secondsUntilExpiration / 2;
+  }
+}

--- a/core/src/test/java/com/google/cloud/sql/core/CloudSqlInstanceTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/CloudSqlInstanceTest.java
@@ -23,10 +23,6 @@ import static org.mockito.Mockito.when;
 
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.auth.oauth2.OAuth2Credentials;
-import java.time.Duration;
-import java.time.Instant;
-import java.util.Date;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -66,27 +62,5 @@ public class CloudSqlInstanceTest {
     assertThat(ex)
         .hasMessageThat()
         .contains("Failed to downscope credentials for IAM Authentication");
-  }
-
-  @Test
-  public void timeUntilRefreshImmediate() {
-    Date expiration = Date.from(Instant.now().plus(Duration.ofMinutes(3)));
-    assertThat(CloudSqlInstance.secondsUntilRefresh(expiration)).isEqualTo(0L);
-  }
-
-  @Test
-  public void timeUntilRefresh1Hr() {
-    Date expiration = Date.from(Instant.now().plus(Duration.ofMinutes(59)));
-    long expected = Duration.ofMinutes(59).minus(Duration.ofMinutes(4)).getSeconds();
-    Assert.assertEquals(
-        (float) CloudSqlInstance.secondsUntilRefresh(expiration), (float) expected, 1);
-  }
-
-  @Test
-  public void timeUntilRefresh24Hr() {
-    Date expiration = Date.from(Instant.now().plus(Duration.ofHours(23)));
-    long expected = Duration.ofHours(23).dividedBy(2).getSeconds();
-    Assert.assertEquals(
-        (float) CloudSqlInstance.secondsUntilRefresh(expiration), (float) expected, 1);
   }
 }

--- a/core/src/test/java/com/google/cloud/sql/core/RefreshCalculatorTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/RefreshCalculatorTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.sql.core;
+
+import static com.google.common.truth.Truth.assertThat;
+import static java.time.temporal.ChronoUnit.SECONDS;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import org.junit.Before;
+import org.junit.Test;
+
+public class RefreshCalculatorTest {
+
+  private static final Instant NOW = Instant.now().truncatedTo(SECONDS);
+  private static final Instant SIXTY_TWO_MINUTES_FROM_NOW = NOW.plus(62, ChronoUnit.MINUTES);
+  private static final Instant FIFTY_EIGHT_MINUTES_FROM_NOW = NOW.plus(58, ChronoUnit.MINUTES);
+  private static final Instant THREE_MINUTES_FROM_NOW = NOW.plus(3, ChronoUnit.MINUTES);
+  private static final int THIRTY_ONE_MINUTES_FROM_NOW_IN_SECONDS = 1860;
+  private RefreshCalculator refreshCalculator;
+
+  @Before
+  public void setUp() {
+    refreshCalculator = new RefreshCalculator();
+  }
+
+  @Test
+  public void testCalculateSecondsUntilNextRefresh_whenDurationIsGreaterThanOneHour() {
+    long secondsUntilNextRefresh =
+        refreshCalculator.calculateSecondsUntilNextRefresh(NOW, SIXTY_TWO_MINUTES_FROM_NOW);
+    // Seconds until next refresh = time remaining on certificate / 2
+    assertThat(secondsUntilNextRefresh).isEqualTo(THIRTY_ONE_MINUTES_FROM_NOW_IN_SECONDS);
+  }
+
+  @Test
+  public void testCalculateSecondsUntilNextRefresh_whenDurationIsLessThanOneHour() {
+    long secondsUntilNextRefresh =
+        refreshCalculator.calculateSecondsUntilNextRefresh(NOW, FIFTY_EIGHT_MINUTES_FROM_NOW);
+    // Seconds until next refresh = 4 minutes before expiration
+    assertThat(secondsUntilNextRefresh)
+        .isEqualTo(SECONDS.between(NOW, FIFTY_EIGHT_MINUTES_FROM_NOW.minus(4, ChronoUnit.MINUTES)));
+  }
+
+  @Test
+  public void testCalculateSecondsUntilNextRefresh_whenDurationIsLessThanFourMinutes() {
+    long secondsUntilNextRefresh =
+        refreshCalculator.calculateSecondsUntilNextRefresh(NOW, THREE_MINUTES_FROM_NOW);
+
+    // Seconds until next refresh = now, certificate is expired
+    assertThat(secondsUntilNextRefresh).isEqualTo(0L);
+  }
+}


### PR DESCRIPTION
This will make the certificate refresh timing in the java jdbc connector consistent with the other connectors.