### PR TITLE
fix: Fix futures to avoid a hanging future when an api request fails on refresh

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -194,12 +194,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.checkerframework</groupId>
-      <artifactId>checker-compat-qual</artifactId>
-      <version>2.5.5</version>
-    </dependency>
-
-    <dependency>
       <groupId>com.google.apis</groupId>
       <artifactId>google-api-services-sqladmin</artifactId>
       <version>v1beta4-rev20230403-2.0.0</version>


### PR DESCRIPTION
There was a subtle bug in the way we were using futures during the process to refresh the tokens and ephemeral
certificates. Occasionally an API request would fail, causing the refresh process to hang. 

Now the code uses `Futures.whenAllComplete()` instead of  `Futures.whenAllSucceded()` so that an api request error
will be propagated rather than ignored.