### PR TITLE
chore(deps): Update dependency com.google.auth:google-auth-library-oauth2-http to v1.16.0

### DIFF
--- a/.github/scripts/run_tests.sh
+++ b/.github/scripts/run_tests.sh
@@ -63,8 +63,9 @@ if mvn -e -B  -ntp  verify -P e2e -Dcheckstyle.skip ; then
 else
   echo -e "******************** Tests Failed.  ********************\n"
   set +x
-  for report in $(find . -path '*/surefire-reports/*') ; do
-    echo "Surefire Report: $report"
+  for report in $(find . -path '*/surefire-reports/*.txt') ; do
+    if grep -q FAILURE "$report"
+    echo "Failed Test Report: $report"
     cat "$report"
   done
   exit 1

--- a/.github/scripts/run_tests.sh
+++ b/.github/scripts/run_tests.sh
@@ -58,5 +58,14 @@ echo "Running tests using Java:"
 java -version
 
 echo "Maven version: $(mvn --version)"
-mvn -e -B  -ntp  verify -P e2e -Dcheckstyle.skip
-echo -e "******************** Tests complete.  ********************\n"
+if mvn -e -B  -ntp  verify -P e2e -Dcheckstyle.skip ; then
+  echo -e "******************** Tests complete.  ********************\n"
+else
+  echo -e "******************** Tests Failed.  ********************\n"
+  set +x
+  for report in $(find . -path '*/surefire-reports/*') ; do
+    echo "Surefire Report: $report"
+    cat "$report"
+  done
+  exit 1
+fi

--- a/.github/scripts/run_tests.sh
+++ b/.github/scripts/run_tests.sh
@@ -64,9 +64,10 @@ else
   echo -e "******************** Tests Failed.  ********************\n"
   set +x
   for report in $(find . -path '*/surefire-reports/*.txt') ; do
-    if grep -q FAILURE "$report"
-    echo "Failed Test Report: $report"
-    cat "$report"
+    if grep -q FAILURE "$report" > /dev/null 2>&1 ; then
+      echo "Failed Test Report: $report"
+      cat "$report"
+    fi
   done
   exit 1
 fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -118,6 +118,7 @@ jobs:
         SQLSERVER_USER: '${{ steps.secrets.outputs.SQLSERVER_USER }}'
         SQLSERVER_PASS: '${{ steps.secrets.outputs.SQLSERVER_PASS }}'
         SQLSERVER_DB: '${{ steps.secrets.outputs.SQLSERVER_DB }}'
+        GOOGLE_CLOUD_QUOTA_PROJECT: '${{ secrets.GOOGLE_CLOUD_PROJECT }}'
       run: ./.github/scripts/run_tests.sh
       shell: bash
     - name: FlakyBot (Linux)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -118,7 +118,6 @@ jobs:
         SQLSERVER_USER: '${{ steps.secrets.outputs.SQLSERVER_USER }}'
         SQLSERVER_PASS: '${{ steps.secrets.outputs.SQLSERVER_PASS }}'
         SQLSERVER_DB: '${{ steps.secrets.outputs.SQLSERVER_DB }}'
-        GOOGLE_CLOUD_QUOTA_PROJECT: '${{ secrets.GOOGLE_CLOUD_PROJECT }}'
       run: ./.github/scripts/run_tests.sh
       shell: bash
     - name: FlakyBot (Linux)

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -202,19 +202,19 @@
     <dependency>
       <groupId>com.google.auth</groupId>
       <artifactId>google-auth-library-credentials</artifactId>
-      <version>1.16.0</version>
+      <version>1.17.1</version>
     </dependency>
 
     <dependency>
       <groupId>com.google.auth</groupId>
       <artifactId>google-auth-library-oauth2-http</artifactId>
-      <version>1.16.0</version>
+      <version>1.17.1</version>
     </dependency>
 
     <dependency>
       <groupId>com.google.auth</groupId>
       <artifactId>google-auth-library-credentials</artifactId>
-      <version>1.16.0</version>
+      <version>1.17.1</version>
     </dependency>
 
     <dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -202,19 +202,19 @@
     <dependency>
       <groupId>com.google.auth</groupId>
       <artifactId>google-auth-library-credentials</artifactId>
-      <version>1.13.0</version>
+      <version>1.16.0</version>
     </dependency>
 
     <dependency>
       <groupId>com.google.auth</groupId>
       <artifactId>google-auth-library-oauth2-http</artifactId>
-      <version>1.13.0</version>
+      <version>1.16.0</version>
     </dependency>
 
     <dependency>
       <groupId>com.google.auth</groupId>
       <artifactId>google-auth-library-credentials</artifactId>
-      <version>1.13.0</version>
+      <version>1.16.0</version>
     </dependency>
 
     <dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -202,19 +202,19 @@
     <dependency>
       <groupId>com.google.auth</groupId>
       <artifactId>google-auth-library-credentials</artifactId>
-      <version>1.14.0</version>
+      <version>1.13.0</version>
     </dependency>
 
     <dependency>
       <groupId>com.google.auth</groupId>
       <artifactId>google-auth-library-oauth2-http</artifactId>
-      <version>1.14.0</version>
+      <version>1.13.0</version>
     </dependency>
 
     <dependency>
       <groupId>com.google.auth</groupId>
       <artifactId>google-auth-library-credentials</artifactId>
-      <version>1.14.0</version>
+      <version>1.13.0</version>
     </dependency>
 
     <dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -202,19 +202,19 @@
     <dependency>
       <groupId>com.google.auth</groupId>
       <artifactId>google-auth-library-credentials</artifactId>
-      <version>1.17.0</version>
+      <version>1.14.0</version>
     </dependency>
 
     <dependency>
       <groupId>com.google.auth</groupId>
       <artifactId>google-auth-library-oauth2-http</artifactId>
-      <version>1.17.0</version>
+      <version>1.14.0</version>
     </dependency>
 
     <dependency>
       <groupId>com.google.auth</groupId>
       <artifactId>google-auth-library-credentials</artifactId>
-      <version>1.17.0</version>
+      <version>1.14.0</version>
     </dependency>
 
     <dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -202,19 +202,19 @@
     <dependency>
       <groupId>com.google.auth</groupId>
       <artifactId>google-auth-library-credentials</artifactId>
-      <version>1.13.0</version>
+      <version>1.17.0</version>
     </dependency>
 
     <dependency>
       <groupId>com.google.auth</groupId>
       <artifactId>google-auth-library-oauth2-http</artifactId>
-      <version>1.13.0</version>
+      <version>1.17.0</version>
     </dependency>
 
     <dependency>
       <groupId>com.google.auth</groupId>
       <artifactId>google-auth-library-credentials</artifactId>
-      <version>1.13.0</version>
+      <version>1.17.0</version>
     </dependency>
 
     <dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -202,19 +202,19 @@
     <dependency>
       <groupId>com.google.auth</groupId>
       <artifactId>google-auth-library-credentials</artifactId>
-      <version>1.17.1</version>
+      <version>1.17.0</version>
     </dependency>
 
     <dependency>
       <groupId>com.google.auth</groupId>
       <artifactId>google-auth-library-oauth2-http</artifactId>
-      <version>1.17.1</version>
+      <version>1.17.0</version>
     </dependency>
 
     <dependency>
       <groupId>com.google.auth</groupId>
       <artifactId>google-auth-library-credentials</artifactId>
-      <version>1.17.1</version>
+      <version>1.17.0</version>
     </dependency>
 
     <dependency>

--- a/core/src/main/java/com/google/cloud/sql/core/AccessTokenSupplier.java
+++ b/core/src/main/java/com/google/cloud/sql/core/AccessTokenSupplier.java
@@ -1,0 +1,10 @@
+package com.google.cloud.sql.core;
+
+import com.google.auth.oauth2.AccessToken;
+import java.io.IOException;
+import java.util.Optional;
+
+@FunctionalInterface
+public interface AccessTokenSupplier {
+  Optional<AccessToken> get() throws IOException;
+}

--- a/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstance.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstance.java
@@ -228,7 +228,7 @@ class CloudSqlInstance {
     final GoogleCredentials credentials;
     if (iamAuthnCredentials.isPresent()) {
       credentials = getDownscopedCredentials(iamAuthnCredentials.get());
-      logger.info("Credentials type: "+credentials.getClass().getName()+" "+credentials);
+      logger.info("Credentials type: " + credentials.getClass().getName() + " " + credentials);
     } else {
       credentials = null;
     }

--- a/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstance.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstance.java
@@ -228,6 +228,7 @@ class CloudSqlInstance {
     final GoogleCredentials credentials;
     if (iamAuthnCredentials.isPresent()) {
       credentials = getDownscopedCredentials(iamAuthnCredentials.get());
+      logger.info("Credentials type: "+credentials.getClass().getName()+" "+credentials);
     } else {
       credentials = null;
     }

--- a/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstance.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstance.java
@@ -18,6 +18,7 @@ package com.google.cloud.sql.core;
 
 import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.http.HttpRequestInitializer;
+import com.google.auth.Credentials;
 import com.google.auth.http.HttpCredentialsAdapter;
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
@@ -121,7 +122,15 @@ class CloudSqlInstance {
   private OAuth2Credentials parseCredentials(HttpRequestInitializer source) {
     if (source instanceof HttpCredentialsAdapter) {
       HttpCredentialsAdapter adapter = (HttpCredentialsAdapter) source;
-      return (OAuth2Credentials) adapter.getCredentials();
+      Credentials c = adapter.getCredentials();
+      if (c != null && c instanceof OAuth2Credentials) {
+        return (OAuth2Credentials) c;
+      }
+      throw new RuntimeException(
+          String.format(
+              "[%s] Unable to connect via automatic IAM authentication: "
+                  + "HttpCredentialsAdapter did not create valid credentials. %s, %s",
+              instanceName.getConnectionName(), source.getClass().getName(), c));
     }
 
     if (source instanceof Credential) {

--- a/core/src/main/java/com/google/cloud/sql/core/SqlAdminApiFetcher.java
+++ b/core/src/main/java/com/google/cloud/sql/core/SqlAdminApiFetcher.java
@@ -307,7 +307,8 @@ public class SqlAdminApiFetcher {
             throw new IllegalStateException(
                 String.format(
                     "Illegal state while attempting to refresh credentials %s, %s %s",
-                    credentials.getClass().getName(), e.getMessage(), credentials.toString()), e);
+                    credentials.getClass().getName(), e.getMessage(), credentials.toString()),
+                e);
           }
           return credentials;
         };

--- a/core/src/main/java/com/google/cloud/sql/core/SqlAdminApiFetcher.java
+++ b/core/src/main/java/com/google/cloud/sql/core/SqlAdminApiFetcher.java
@@ -302,7 +302,7 @@ public class SqlAdminApiFetcher {
 
     // if the access token has not expired, do not attempt to refresh
     AccessToken token = credentials.getAccessToken();
-    if( token == null || token.getExpirationTime().toInstant().isAfter(Instant.now()) ) {
+    if (token == null || token.getExpirationTime().toInstant().isAfter(Instant.now())) {
       return;
     }
 

--- a/core/src/main/java/com/google/cloud/sql/core/SqlAdminApiFetcher.java
+++ b/core/src/main/java/com/google/cloud/sql/core/SqlAdminApiFetcher.java
@@ -301,7 +301,12 @@ public class SqlAdminApiFetcher {
   private void refreshWithRetry(OAuth2Credentials credentials) throws IOException {
     Callable<OAuth2Credentials> refresh =
         () -> {
-          credentials.refresh();
+          try {
+            credentials.refresh();
+          } catch (IllegalStateException e) {
+            logger.warning(
+                String.format("Illegal state while attempting to refresh credentials %s, %s", credentials.getClass().getName(), e.getMessage()));
+          }
           return credentials;
         };
 

--- a/core/src/main/java/com/google/cloud/sql/core/SqlAdminApiFetcher.java
+++ b/core/src/main/java/com/google/cloud/sql/core/SqlAdminApiFetcher.java
@@ -302,7 +302,9 @@ public class SqlAdminApiFetcher {
 
     // if the access token has not expired, do not attempt to refresh
     AccessToken token = credentials.getAccessToken();
-    if (token == null || token.getExpirationTime() == null || token.getExpirationTime().toInstant().isAfter(Instant.now())) {
+    if (token == null
+        || token.getExpirationTime() == null
+        || token.getExpirationTime().toInstant().isAfter(Instant.now())) {
       return;
     }
 

--- a/core/src/main/java/com/google/cloud/sql/core/SqlAdminApiFetcher.java
+++ b/core/src/main/java/com/google/cloud/sql/core/SqlAdminApiFetcher.java
@@ -304,10 +304,10 @@ public class SqlAdminApiFetcher {
           try {
             credentials.refresh();
           } catch (IllegalStateException e) {
-            logger.warning(
+            throw new IllegalStateException(
                 String.format(
-                    "Illegal state while attempting to refresh credentials %s, %s",
-                    credentials.getClass().getName(), e.getMessage()));
+                    "Illegal state while attempting to refresh credentials %s, %s %s",
+                    credentials.getClass().getName(), e.getMessage(), credentials.toString()), e);
           }
           return credentials;
         };

--- a/core/src/main/java/com/google/cloud/sql/core/SqlAdminApiFetcher.java
+++ b/core/src/main/java/com/google/cloud/sql/core/SqlAdminApiFetcher.java
@@ -305,7 +305,9 @@ public class SqlAdminApiFetcher {
             credentials.refresh();
           } catch (IllegalStateException e) {
             logger.warning(
-                String.format("Illegal state while attempting to refresh credentials %s, %s", credentials.getClass().getName(), e.getMessage()));
+                String.format(
+                    "Illegal state while attempting to refresh credentials %s, %s",
+                    credentials.getClass().getName(), e.getMessage()));
           }
           return credentials;
         };

--- a/core/src/main/java/com/google/cloud/sql/core/SqlAdminApiFetcher.java
+++ b/core/src/main/java/com/google/cloud/sql/core/SqlAdminApiFetcher.java
@@ -302,7 +302,7 @@ public class SqlAdminApiFetcher {
 
     // if the access token has not expired, do not attempt to refresh
     AccessToken token = credentials.getAccessToken();
-    if (token == null || token.getExpirationTime().toInstant().isAfter(Instant.now())) {
+    if (token == null || token.getExpirationTime() == null || token.getExpirationTime().toInstant().isAfter(Instant.now())) {
       return;
     }
 

--- a/core/src/main/java/com/google/cloud/sql/core/SqlAdminApiFetcher.java
+++ b/core/src/main/java/com/google/cloud/sql/core/SqlAdminApiFetcher.java
@@ -299,10 +299,17 @@ public class SqlAdminApiFetcher {
    * @throws IOException when the credentials.refresh() has failed 3 times
    */
   private void refreshWithRetry(OAuth2Credentials credentials) throws IOException {
+
+    // if the access token has not expired, do not attempt to refresh
+    AccessToken token = credentials.getAccessToken();
+    if( token == null || token.getExpirationTime().toInstant().isAfter(Instant.now()) ) {
+      return;
+    }
+
     Callable<OAuth2Credentials> refresh =
         () -> {
           try {
-            credentials.refresh();
+            credentials.refreshIfExpired();
           } catch (IllegalStateException e) {
             throw new IllegalStateException(
                 String.format(

--- a/core/src/main/java/com/google/cloud/sql/core/SqlAdminApiFetcher.java
+++ b/core/src/main/java/com/google/cloud/sql/core/SqlAdminApiFetcher.java
@@ -300,18 +300,10 @@ public class SqlAdminApiFetcher {
    */
   private void refreshWithRetry(OAuth2Credentials credentials) throws IOException {
 
-    // if the access token has not expired, do not attempt to refresh
-    AccessToken token = credentials.getAccessToken();
-    if (token == null
-        || token.getExpirationTime() == null
-        || token.getExpirationTime().toInstant().isAfter(Instant.now())) {
-      return;
-    }
-
     Callable<OAuth2Credentials> refresh =
         () -> {
           try {
-            credentials.refreshIfExpired();
+            credentials.refresh();
           } catch (IllegalStateException e) {
             throw new IllegalStateException(
                 String.format(


### PR DESCRIPTION
Manual update of this dependency. Something changed between versions 1.13.0 and 1.14.0 that broke authentication across all versions for GitHub Action service account impersonation.

I suspect it has something to do with the bugfix where quota project was handeled improperly in 1.13 and fixed in 1.14. We probably need to set GOOGLE_CLOUD_QUOTA_PROJECT to an appropriate value to fix the tests in the github runner.

See https://github.com/googleapis/google-auth-library-java/issues/1082

```
Error:  Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 12.232 s <<< FAILURE! - in com.google.cloud.sql.mariadb.JdbcMariaDBIamAuthIntegrationTests
Error:  com.google.cloud.sql.mariadb.JdbcMariaDBIamAuthIntegrationTests.pooledConnectionTest  Time elapsed: 12.225 s  <<< ERROR!
com.zaxxer.hikari.pool.HikariPool$PoolInitializationException: Failed to initialize pool: Socket fail to connect to host:address=(host=ignoreme)(port=123)(type=primary). Socket factory failed to initialized with option "socketFactory" set to "com.google.cloud.sql.mariadb.SocketFactory"
	at com.zaxxer.hikari.pool.HikariPool.throwPoolInitializationException(HikariPool.java:596)
	at com.zaxxer.hikari.pool.HikariPool.checkFailFast(HikariPool.java:582)
	at com.zaxxer.hikari.pool.HikariPool.<init>(HikariPool.java:115)
	at com.zaxxer.hikari.HikariDataSource.<init>(HikariDataSource.java:81)
	at com.google.cloud.sql.mariadb.JdbcMariaDBIamAuthIntegrationTests.setUpPool(JdbcMariaDBIamAuthIntegrationTests.java:82)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.RunBefores.invokeMethod(RunBefores.java:33)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:24)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: java.sql.SQLNonTransientConnectionException: Socket fail to connect to host:address=(host=ignoreme)(port=123)(type=primary). Socket factory failed to initialized with option "socketFactory" set to "com.google.cloud.sql.mariadb.SocketFactory"
	at org.mariadb.jdbc.client.impl.ConnectionHelper.connectSocket(ConnectionHelper.java:137)
	at org.mariadb.jdbc.client.impl.StandardClient.<init>(StandardClient.java:99)
	at org.mariadb.jdbc.Driver.connect(Driver.java:70)
	at org.mariadb.jdbc.Driver.connect(Driver.java:101)
	at org.mariadb.jdbc.Driver.connect(Driver.java:27)
	at com.zaxxer.hikari.util.DriverDataSource.getConnection(DriverDataSource.java:121)
	at com.zaxxer.hikari.pool.PoolBase.newConnection(PoolBase.java:364)
	at com.zaxxer.hikari.pool.PoolBase.newPoolEntry(PoolBase.java:206)
	at com.zaxxer.hikari.pool.HikariPool.createPoolEntry(HikariPool.java:476)
	at com.zaxxer.hikari.pool.HikariPool.checkFailFast(HikariPool.java:561)
	... 16 more
Caused by: java.io.IOException: Socket factory failed to initialized with option "socketFactory" set to "com.google.cloud.sql.mariadb.SocketFactory"
	at org.mariadb.jdbc.client.impl.ConnectionHelper.standardSocket(ConnectionHelper.java:100)
	at org.mariadb.jdbc.client.socket.impl.SocketUtility.lambda$getSocketHandler$0(SocketUtility.java:38)
	at org.mariadb.jdbc.client.impl.ConnectionHelper.createSocket(ConnectionHelper.java:69)
	at org.mariadb.jdbc.client.impl.ConnectionHelper.connectSocket(ConnectionHelper.java:124)
	... 25 more
Caused by: java.lang.RuntimeException: java.util.concurrent.ExecutionException: java.lang.RuntimeException: An exception occurred while fetching IAM auth token:
	at com.google.cloud.sql.core.CloudSqlInstance.getInstanceData(CloudSqlInstance.java:165)
	at com.google.cloud.sql.core.CloudSqlInstance.createSslSocket(CloudSqlInstance.java:174)
	at com.google.cloud.sql.core.CoreSocketFactory.createSslSocket(CoreSocketFactory.java:329)
	at com.google.cloud.sql.core.CoreSocketFactory.connect(CoreSocketFactory.java:199)
	at com.google.cloud.sql.core.CoreSocketFactory.connect(CoreSocketFactory.java:157)
	at com.google.cloud.sql.mariadb.SocketFactory.createSocket(SocketFactory.java:51)
	at org.mariadb.jdbc.client.impl.ConnectionHelper.standardSocket(ConnectionHelper.java:96)
	... 28 more
Caused by: java.util.concurrent.ExecutionException: java.lang.RuntimeException: An exception occurred while fetching IAM auth token:
	at com.google.common.util.concurrent.AbstractFuture.getDoneValue(AbstractFuture.java:588)
	at com.google.common.util.concurrent.AbstractFuture.get(AbstractFuture.java:567)
	at com.google.common.util.concurrent.AbstractFuture$TrustedFuture.get(AbstractFuture.java:113)
	at com.google.cloud.sql.core.SqlAdminApiFetcher.getInstanceData(SqlAdminApiFetcher.java:158)
	at com.google.cloud.sql.core.CloudSqlInstance.performRefresh(CloudSqlInstance.java:237)
	at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:131)
	at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:74)
	at com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:82)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	... 1 more
Caused by: java.lang.RuntimeException: An exception occurred while fetching IAM auth token:
	at com.google.cloud.sql.core.SqlAdminApiFetcher.addExceptionContext(SqlAdminApiFetcher.java:426)
	at com.google.cloud.sql.core.SqlAdminApiFetcher.fetchEphemeralCertificate(SqlAdminApiFetcher.java:258)
	at com.google.cloud.sql.core.SqlAdminApiFetcher.lambda$getInstanceData$1(SqlAdminApiFetcher.java:114)
	at com.google.common.util.concurrent.CombinedFuture$CallableInterruptibleTask.runInterruptibly(CombinedFuture.java:196)
	at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:74)
	... 6 more
Caused by: java.io.IOException: Error requesting access token
	at com.google.auth.oauth2.ImpersonatedCredentials.refreshAccessToken(ImpersonatedCredentials.java:511)
	at com.google.auth.oauth2.ExternalAccountCredentials.exchangeExternalCredentialForAccessToken(ExternalAccountCredentials.java:480)
	at com.google.auth.oauth2.IdentityPoolCredentials.refreshAccessToken(IdentityPoolCredentials.java:179)
	at com.google.auth.oauth2.OAuth2Credentials$1.call(OAuth2Credentials.java:257)
	at com.google.auth.oauth2.OAuth2Credentials$1.call(OAuth2Credentials.java:254)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at com.google.auth.oauth2.OAuth2Credentials$RefreshTask.run(OAuth2Credentials.java:623)
	at com.google.common.util.concurrent.DirectExecutor.execute(DirectExecutor.java:31)
	at com.google.auth.oauth2.OAuth2Credentials$AsyncRefreshResult.executeIfNew(OAuth2Credentials.java:571)
	at com.google.auth.oauth2.OAuth2Credentials.refresh(OAuth2Credentials.java:180)
	at com.google.cloud.sql.core.SqlAdminApiFetcher.lambda$refreshWithRetry$5(SqlAdminApiFetcher.java:304)
	at com.google.cloud.sql.core.RetryingCallable.call(RetryingCallable.java:67)
	at com.google.cloud.sql.core.SqlAdminApiFetcher.refreshWithRetry(SqlAdminApiFetcher.java:311)
	at com.google.cloud.sql.core.SqlAdminApiFetcher.fetchEphemeralCertificate(SqlAdminApiFetcher.java:248)
	... 9 more
Caused by: com.google.api.client.http.HttpResponseException: 403 Forbidden
POST https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/***:generateAccessToken
{
  "error": {
    "code": 403,
    "message": "Permission 'iam.serviceAccounts.getAccessToken' denied on resource (or it may not exist).",
    "errors": [
      {
        "message": "Permission 'iam.serviceAccounts.getAccessToken' denied on resource (or it may not exist).",
        "domain": "global",
        "reason": "forbidden"
      }
    ],
    "status": "PERMISSION_DENIED",
    "details": [
      {
        "@type": "type.googleapis.com/google.rpc.ErrorInfo",
        "reason": "IAM_PERMISSION_DENIED",
        "domain": "iam.googleapis.com",
        "metadata": {
          "permission": "iam.serviceAccounts.getAccessToken"
        }
      }
    ]
  }
}

	at com.google.api.client.http.HttpResponseException$Builder.build(HttpResponseException.java:293)
	at com.google.api.client.http.HttpRequest.execute(HttpRequest.java:1118)
	at com.google.auth.oauth2.ImpersonatedCredentials.refreshAccessToken(ImpersonatedCredentials.java:509)
	... 22 more
```