### PR TITLE
chore: Clean up existing public java api 

### DIFF
--- a/core/src/main/java/com/google/cloud/sql/core/ApiFetcherFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/core/ApiFetcherFactory.java
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-package com.google.cloud.sql;
+package com.google.cloud.sql.core;
 
 import com.google.api.client.http.HttpRequestInitializer;
-import com.google.cloud.sql.core.SqlAdminApiFetcher;
 
 /** Factory interface for creating SQLAdmin clients to interact with Cloud SQL Admin API. */
 public interface ApiFetcherFactory {

--- a/core/src/main/java/com/google/cloud/sql/core/ApplicationDefaultCredentialFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/core/ApplicationDefaultCredentialFactory.java
@@ -14,17 +14,18 @@
  * limitations under the License.
  */
 
-package com.google.cloud.sql;
+package com.google.cloud.sql.core;
 
 import com.google.api.client.http.HttpRequestInitializer;
 import com.google.api.services.sqladmin.SQLAdminScopes;
 import com.google.auth.http.HttpCredentialsAdapter;
 import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.sql.CredentialFactory;
 import java.io.IOException;
 import java.util.Arrays;
 
 /** This class creates a HttpRequestInitializer from Application Default Credentials. */
-public class ApplicationDefaultCredentialFactory implements CredentialFactory {
+class ApplicationDefaultCredentialFactory implements CredentialFactory {
 
   @Override
   public HttpRequestInitializer create() {

--- a/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
@@ -258,7 +258,13 @@ public final class CoreSocketFactory {
     }
   }
 
-  /** Sets the default string which is appended to the SQLAdmin API client User-Agent header. */
+  /**
+   * Internal use only: Sets the default string which is appended to the SQLAdmin API client
+   * User-Agent header.
+   *
+   * <p>This is used by the specific database connector socket factory implementations to append
+   * their database name to the user agent.
+   */
   public static void addArtifactId(String artifactId) {
     String userAgent = artifactId + "/" + version;
     if (!userAgents.contains(userAgent)) {
@@ -280,7 +286,8 @@ public final class CoreSocketFactory {
   }
 
   /**
-   * Sets the User-Agent header for requests made using the underlying SQLAdmin API client.
+   * Adds an external application name to the user agent string for tracking. This is known to be
+   * used by the spring-cloud-gcp project.
    *
    * @throws IllegalStateException if the SQLAdmin client has already been initialized
    */

--- a/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
@@ -54,6 +54,15 @@ import jnr.unixsocket.UnixSocketChannel;
 public final class CoreSocketFactory {
 
   public static final String CLOUD_SQL_INSTANCE_PROPERTY = "cloudSqlInstance";
+
+  /**
+   * Property used to set the application name for the underlying SQLAdmin client.
+   *
+   * @deprecated Use {@link #setApplicationName(String)} to set the application name
+   *     programmatically.
+   */
+  @Deprecated public static final String USER_TOKEN_PROPERTY_NAME = "_CLOUD_SQL_USER_TOKEN";
+
   public static final String DEFAULT_IP_TYPES = "PUBLIC,PRIVATE";
   private static final String UNIX_SOCKET_PROPERTY = "unixSocketPath";
   private static final Logger logger = Logger.getLogger(CoreSocketFactory.class.getName());
@@ -267,7 +276,20 @@ public final class CoreSocketFactory {
     if (coreSocketFactory != null) {
       return coreSocketFactory.adminApiService.getApplicationName();
     }
-    return "";
+    return System.getProperty(USER_TOKEN_PROPERTY_NAME, "");
+  }
+
+  /**
+   * Sets the User-Agent header for requests made using the underlying SQLAdmin API client.
+   *
+   * @throws IllegalStateException if the SQLAdmin client has already been initialized
+   */
+  public static void setApplicationName(String applicationName) {
+    if (coreSocketFactory != null) {
+      throw new IllegalStateException(
+          "Unable to set ApplicationName - SQLAdmin client already initialized.");
+    }
+    System.setProperty(USER_TOKEN_PROPERTY_NAME, applicationName);
   }
 
   /**

--- a/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
@@ -19,7 +19,6 @@ package com.google.cloud.sql.core;
 import com.google.api.client.http.HttpRequestInitializer;
 import com.google.cloud.sql.AuthType;
 import com.google.cloud.sql.CredentialFactory;
-import com.google.cloud.sql.SqlAdminApiFetcherFactory;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -55,14 +54,6 @@ import jnr.unixsocket.UnixSocketChannel;
 public final class CoreSocketFactory {
 
   public static final String CLOUD_SQL_INSTANCE_PROPERTY = "cloudSqlInstance";
-  /**
-   * Property used to set the application name for the underlying SQLAdmin client.
-   *
-   * @deprecated Use {@link #setApplicationName(String)} to set the application name
-   *     programmatically.
-   */
-  @Deprecated public static final String USER_TOKEN_PROPERTY_NAME = "_CLOUD_SQL_USER_TOKEN";
-
   public static final String DEFAULT_IP_TYPES = "PUBLIC,PRIVATE";
   private static final String UNIX_SOCKET_PROPERTY = "unixSocketPath";
   private static final Logger logger = Logger.getLogger(CoreSocketFactory.class.getName());
@@ -114,10 +105,6 @@ public final class CoreSocketFactory {
               executor);
     }
     return coreSocketFactory;
-  }
-
-  static int getDefaultServerProxyPort() {
-    return DEFAULT_SERVER_PROXY_PORT;
   }
 
   // TODO(kvg): Figure out better executor to use for testing
@@ -210,21 +197,6 @@ public final class CoreSocketFactory {
     return getInstance().getCloudSqlInstance(csqlInstanceName, AuthType.PASSWORD).getSslData();
   }
 
-  /** Returns data that can be used to establish Cloud SQL SSL connection. */
-  static SslData getSslData(String csqlInstanceName, AuthType authType) {
-    return getInstance().getCloudSqlInstance(csqlInstanceName, authType).getSslData();
-  }
-
-  /** Returns data that can be used to establish Cloud SQL SSL connection. */
-  public static SslData getSslData(String csqlInstanceName) throws IOException {
-    return getSslData(csqlInstanceName, false);
-  }
-
-  /** Returns default ip address that can be used to establish Cloud SQL connection. */
-  public static String getHostIp(String csqlInstanceName) {
-    return getInstance().getHostIp(csqlInstanceName, listIpTypes(DEFAULT_IP_TYPES));
-  }
-
   /** Returns preferred ip address that can be used to establish Cloud SQL connection. */
   public static String getHostIp(String csqlInstanceName, String ipTypes) throws IOException {
     return getInstance().getHostIp(csqlInstanceName, listIpTypes(ipTypes));
@@ -291,24 +263,11 @@ public final class CoreSocketFactory {
   }
 
   /** Returns the current User-Agent header set for the underlying SQLAdmin API client. */
-  public static String getApplicationName() {
+  private static String getApplicationName() {
     if (coreSocketFactory != null) {
       return coreSocketFactory.adminApiService.getApplicationName();
     }
-    return System.getProperty(USER_TOKEN_PROPERTY_NAME, "");
-  }
-
-  /**
-   * Sets the User-Agent header for requests made using the underlying SQLAdmin API client.
-   *
-   * @throws IllegalStateException if the SQLAdmin client has already been initialized
-   */
-  public static void setApplicationName(String applicationName) {
-    if (coreSocketFactory != null) {
-      throw new IllegalStateException(
-          "Unable to set ApplicationName - SQLAdmin client already initialized.");
-    }
-    System.setProperty(USER_TOKEN_PROPERTY_NAME, applicationName);
+    return "";
   }
 
   /**

--- a/core/src/main/java/com/google/cloud/sql/core/CredentialFactoryProvider.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CredentialFactoryProvider.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.sql.core;
 
-import com.google.cloud.sql.ApplicationDefaultCredentialFactory;
 import com.google.cloud.sql.CredentialFactory;
 
 /**

--- a/core/src/main/java/com/google/cloud/sql/core/SqlAdminApiFetcher.java
+++ b/core/src/main/java/com/google/cloud/sql/core/SqlAdminApiFetcher.java
@@ -60,12 +60,12 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManagerFactory;
 
 /** Class that encapsulates all logic for interacting with SQLAdmin API. */
-public class SqlAdminApiFetcher {
+class SqlAdminApiFetcher {
 
   private static final Logger logger = Logger.getLogger(SqlAdminApiFetcher.class.getName());
   private final SQLAdmin apiClient;
 
-  public SqlAdminApiFetcher(SQLAdmin apiClient) {
+  SqlAdminApiFetcher(SQLAdmin apiClient) {
     this.apiClient = apiClient;
   }
 
@@ -162,7 +162,7 @@ public class SqlAdminApiFetcher {
     return Optional.ofNullable(credentials.getAccessToken().getExpirationTime());
   }
 
-  public String getApplicationName() {
+  String getApplicationName() {
     return apiClient.getApplicationName();
   }
 

--- a/core/src/main/java/com/google/cloud/sql/core/SqlAdminApiFetcherFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/core/SqlAdminApiFetcherFactory.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.cloud.sql;
+package com.google.cloud.sql.core;
 
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpRequestInitializer;
@@ -22,7 +22,6 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.services.sqladmin.SQLAdmin;
-import com.google.cloud.sql.core.SqlAdminApiFetcher;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 

--- a/core/src/main/java/com/google/cloud/sql/core/package-info.java
+++ b/core/src/main/java/com/google/cloud/sql/core/package-info.java
@@ -1,5 +1,7 @@
 /*
- * Copyright 2023 Google LLC All Rights Reserved.
+ * Copyright 2023 Google LLC
+ *
+ * All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/com/google/cloud/sql/core/package-info.java
+++ b/core/src/main/java/com/google/cloud/sql/core/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google Inc. All Rights Reserved.
+ * Copyright 2023 Google LLC All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/com/google/cloud/sql/core/package-info.java
+++ b/core/src/main/java/com/google/cloud/sql/core/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Package com.google.cloud.sql.core holds internal shared packages that implement logic to create a
+ * socket to a Cloud SQL database. Classes in this package are considered internal and subject to
+ * change without notice.
+ */
+package com.google.cloud.sql.core;

--- a/core/src/main/java/com/google/cloud/sql/package-info.java
+++ b/core/src/main/java/com/google/cloud/sql/package-info.java
@@ -1,5 +1,7 @@
 /*
- * Copyright 2023 Google LLC All Rights Reserved.
+ * Copyright 2023 Google LLC
+ *
+ * All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/com/google/cloud/sql/package-info.java
+++ b/core/src/main/java/com/google/cloud/sql/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2023 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Package com.google.cloud.sql holds the stable public java API for creating sockets to Cloud SQL
+ * database.
+ */
+package com.google.cloud.sql;

--- a/core/src/main/java/com/google/cloud/sql/package-info.java
+++ b/core/src/main/java/com/google/cloud/sql/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google Inc. All Rights Reserved.
+ * Copyright 2023 Google LLC All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/com/google/cloud/sql/core/CredentialFactoryProviderTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/CredentialFactoryProviderTest.java
@@ -18,7 +18,6 @@ package com.google.cloud.sql.core;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import com.google.cloud.sql.ApplicationDefaultCredentialFactory;
 import com.google.cloud.sql.CredentialFactory;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/core/src/test/java/com/google/cloud/sql/core/StubApiFetcherFactory.java
+++ b/core/src/test/java/com/google/cloud/sql/core/StubApiFetcherFactory.java
@@ -22,7 +22,6 @@ import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.client.testing.http.MockHttpTransport;
 import com.google.api.services.sqladmin.SQLAdmin;
 import com.google.api.services.sqladmin.SQLAdmin.Builder;
-import com.google.cloud.sql.ApiFetcherFactory;
 
 public class StubApiFetcherFactory implements ApiFetcherFactory {
 


### PR DESCRIPTION
Removes public access from unused methods.  Moves non-public classes into the core package.  This should have no impact existing implementations using the connector. 