### PR TITLE
chore: add AccessTokenSupplier

### DIFF
--- a/core/src/main/java/com/google/cloud/sql/core/AccessTokenSupplier.java
+++ b/core/src/main/java/com/google/cloud/sql/core/AccessTokenSupplier.java
@@ -1,9 +1,34 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.cloud.sql.core;
 
 import com.google.auth.oauth2.AccessToken;
 import java.io.IOException;
 import java.util.Optional;
 
+/** Supplies an AccessToken to use when authenticating with the Google API. */
+@FunctionalInterface
 interface AccessTokenSupplier {
+
+  /**
+   * Returns a valid access token or Optional.empty() when no token is available.
+   *
+   * @return the access token
+   * @throws IOException when an error occurs attempting to refresh the token.
+   */
   Optional<AccessToken> get() throws IOException;
 }

--- a/core/src/main/java/com/google/cloud/sql/core/AccessTokenSupplier.java
+++ b/core/src/main/java/com/google/cloud/sql/core/AccessTokenSupplier.java
@@ -1,0 +1,9 @@
+package com.google.cloud.sql.core;
+
+import com.google.auth.oauth2.AccessToken;
+import java.io.IOException;
+import java.util.Optional;
+
+interface AccessTokenSupplier {
+  Optional<AccessToken> get() throws IOException;
+}

--- a/core/src/main/java/com/google/cloud/sql/core/DefaultAccessTokenSupplier.java
+++ b/core/src/main/java/com/google/cloud/sql/core/DefaultAccessTokenSupplier.java
@@ -22,7 +22,6 @@ import com.google.auth.Credentials;
 import com.google.auth.http.HttpCredentialsAdapter;
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
-import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Date;

--- a/core/src/main/java/com/google/cloud/sql/core/DefaultAccessTokenSupplier.java
+++ b/core/src/main/java/com/google/cloud/sql/core/DefaultAccessTokenSupplier.java
@@ -33,6 +33,7 @@ import java.util.Optional;
  * configured HttpRequestInitializer.
  */
 class DefaultAccessTokenSupplier implements AccessTokenSupplier {
+
   private static final String SQL_LOGIN_SCOPE = "https://www.googleapis.com/auth/sqlservice.login";
 
   private final Optional<HttpRequestInitializer> tokenSource;
@@ -45,9 +46,7 @@ class DefaultAccessTokenSupplier implements AccessTokenSupplier {
    * @param tokenSource the token source that produces auth tokens.
    */
   DefaultAccessTokenSupplier(Optional<HttpRequestInitializer> tokenSource) {
-    this.tokenSource = tokenSource;
-    retryCount = 3;
-    retryDuration = Duration.ofSeconds(3);
+    this(tokenSource, 3, Duration.ofSeconds(3));
   }
 
   /**
@@ -57,7 +56,6 @@ class DefaultAccessTokenSupplier implements AccessTokenSupplier {
    * @param retryCount the number of attempts to refresh.
    * @param retryDuration the duration to wait between attempts.
    */
-  @VisibleForTesting
   DefaultAccessTokenSupplier(
       Optional<HttpRequestInitializer> tokenSource, int retryCount, Duration retryDuration) {
     this.tokenSource = tokenSource;

--- a/core/src/main/java/com/google/cloud/sql/core/DefaultAccessTokenSupplier.java
+++ b/core/src/main/java/com/google/cloud/sql/core/DefaultAccessTokenSupplier.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.sql.core;
+
+import com.google.api.client.auth.oauth2.Credential;
+import com.google.api.client.http.HttpRequestInitializer;
+import com.google.auth.Credentials;
+import com.google.auth.http.HttpCredentialsAdapter;
+import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.common.annotations.VisibleForTesting;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Date;
+import java.util.Optional;
+
+/**
+ * DefaultAccessTokenSupplier produces access tokens using credentials produced by this connector's
+ * configured HttpRequestInitializer.
+ */
+class DefaultAccessTokenSupplier implements AccessTokenSupplier {
+  private static final String SQL_LOGIN_SCOPE = "https://www.googleapis.com/auth/sqlservice.login";
+
+  private final Optional<HttpRequestInitializer> tokenSource;
+  private final int retryCount;
+  private final Duration retryDuration;
+
+  /**
+   * Creates an instance with default retry settings.
+   *
+   * @param tokenSource the token source that produces auth tokens.
+   */
+  DefaultAccessTokenSupplier(Optional<HttpRequestInitializer> tokenSource) {
+    this.tokenSource = tokenSource;
+    retryCount = 3;
+    retryDuration = Duration.ofSeconds(3);
+  }
+
+  /**
+   * Creates an instance with configurable retry settings.
+   *
+   * @param tokenSource the token source
+   * @param retryCount the number of attempts to refresh.
+   * @param retryDuration the duration to wait between attempts.
+   */
+  @VisibleForTesting
+  DefaultAccessTokenSupplier(
+      Optional<HttpRequestInitializer> tokenSource, int retryCount, Duration retryDuration) {
+    this.tokenSource = tokenSource;
+    this.retryCount = retryCount;
+    this.retryDuration = retryDuration;
+  }
+
+  /**
+   * Parses credentials out of the HttpRequestInitializer.
+   *
+   * @return the GoogleCredentials.
+   * @throws RuntimeException when the HttpRequestInitializer is unrecognized, or if it can't
+   *     produce a GoogleCredentials instance.
+   */
+  private GoogleCredentials parseCredentials() {
+    HttpRequestInitializer source = this.tokenSource.get();
+
+    if (source instanceof HttpCredentialsAdapter) {
+      HttpCredentialsAdapter adapter = (HttpCredentialsAdapter) source;
+      Credentials c = adapter.getCredentials();
+      if (c != null && c instanceof GoogleCredentials) {
+        return (GoogleCredentials) c;
+      }
+      throw new RuntimeException(
+          String.format(
+              "Unable to connect via automatic IAM authentication: "
+                  + "HttpCredentialsAdapter did not create valid credentials. %s, %s",
+              source.getClass().getName(), c));
+    }
+
+    if (source instanceof Credential) {
+      Credential credential = (Credential) source;
+      AccessToken accessToken =
+          new AccessToken(
+              credential.getAccessToken(), getTokenExpirationTime(credential).orElse(null));
+
+      return new GoogleCredentials(accessToken) {
+        @Override
+        public AccessToken refreshAccessToken() throws IOException {
+          credential.refreshToken();
+
+          return new AccessToken(
+              credential.getAccessToken(), getTokenExpirationTime(credential).orElse(null));
+        }
+      };
+    }
+    throw new RuntimeException(
+        String.format(
+            "Unable to connect via automatic IAM authentication: "
+                + "Unsupported credentials of type %s",
+            source.getClass().getName()));
+  }
+
+  /**
+   * Returns an access token, refreshing if the credentials are expired or nearly expired.
+   *
+   * @return the AccessToken or Optional.empty() if there is no tokenSource.
+   * @throws IOException if there is an error attempting to refresh the token
+   * @throws IllegalStateException if the token cannot be used to refresh.
+   */
+  @Override
+  public Optional<AccessToken> get() throws IOException {
+    if (tokenSource.isPresent()) {
+      RetryingCallable<Optional<AccessToken>> retries =
+          new RetryingCallable<>(
+              () -> {
+                final GoogleCredentials credentials;
+                credentials = parseCredentials();
+                try {
+                  credentials.refreshIfExpired();
+                } catch (IllegalStateException e) {
+                  throw new IllegalStateException("Error refreshing credentials " + credentials, e);
+                }
+                if (credentials.getAccessToken() == null
+                    || credentials.getAccessToken().equals("")) {
+                  throw new IllegalStateException("Credentials do not have an access token");
+                }
+                if (credentials.getAccessToken().getExpirationTime() != null
+                    && credentials.getAccessToken().getExpirationTime().before(new Date())) {
+                  throw new IllegalStateException(
+                      "Credentials were refreshed but expiration time is in the past");
+                }
+                GoogleCredentials downscoped = getDownscopedCredentials(credentials);
+                if (downscoped.getAccessToken() == null || downscoped.getAccessToken().equals("")) {
+                  throw new IllegalStateException(
+                      "Donwscoped credentials do not have an access token");
+                }
+                return Optional.of(downscoped.getAccessToken());
+              },
+              this.retryCount,
+              this.retryDuration);
+
+      try {
+        return retries.call();
+      } catch (IOException e) {
+        throw e;
+      } catch (RuntimeException e) {
+        throw e;
+      } catch (Exception e) {
+        throw new RuntimeException("Unexpected exception refreshing authentication token", e);
+      }
+    }
+    return Optional.empty();
+  }
+
+  /**
+   * Extracts the expiration time from an AccessToken.
+   *
+   * @param token the token
+   * @return the expiration time, if set.
+   */
+  static Optional<Date> getTokenExpirationTime(Optional<AccessToken> token) {
+    if (token.isPresent()) {
+      return Optional.ofNullable(token.get().getExpirationTime());
+    } else {
+      return Optional.empty();
+    }
+  }
+
+  /**
+   * Extracts the expiration time from a Credential.
+   *
+   * @param credentials the token
+   * @return the expiration time, if set.
+   */
+  private Optional<Date> getTokenExpirationTime(Credential credentials) {
+    return Optional.ofNullable(credentials.getExpirationTimeMilliseconds()).map(Date::new);
+  }
+
+  /**
+   * Produces a credential that only has sqlservice.login scope.
+   *
+   * @param credentials the credentials
+   * @return the downscoped credentials.
+   */
+  static GoogleCredentials getDownscopedCredentials(GoogleCredentials credentials) {
+    return credentials.createScoped(SQL_LOGIN_SCOPE);
+  }
+}

--- a/core/src/test/java/com/google/cloud/sql/core/DefaultAccessTokenSupplierTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/DefaultAccessTokenSupplierTest.java
@@ -1,0 +1,400 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.sql.core;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import com.google.api.client.auth.oauth2.Credential;
+import com.google.api.client.auth.oauth2.Credential.AccessMethod;
+import com.google.api.client.auth.oauth2.TokenResponse;
+import com.google.api.client.http.GenericUrl;
+import com.google.api.client.http.HttpExecuteInterceptor;
+import com.google.api.client.http.HttpRequest;
+import com.google.api.client.http.HttpRequestInitializer;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.http.LowLevelHttpRequest;
+import com.google.api.client.http.LowLevelHttpResponse;
+import com.google.api.client.json.gson.GsonFactory;
+import com.google.api.client.testing.http.MockLowLevelHttpResponse;
+import com.google.auth.http.HttpCredentialsAdapter;
+import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.auth.oauth2.OAuth2Credentials;
+import java.io.IOException;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class DefaultAccessTokenSupplierTest {
+
+  private final Date now = new Date();
+  private final Date past = Date.from(now.toInstant().plus(-1, ChronoUnit.HOURS));
+  private final Date future = Date.from(now.toInstant().plus(1, ChronoUnit.HOURS));
+
+  private GoogleCredentials scopedCredentials;
+  private volatile int refreshCounter = 0;
+  @Mock private OAuth2Credentials oAuth2Credentials;
+
+  @Before
+  public void setup() throws IOException {
+    refreshCounter = 0;
+
+    MockitoAnnotations.openMocks(this);
+    // Scoped credentials can't be refreshed.
+    scopedCredentials =
+        new GoogleCredentials(new AccessToken("my-scoped-token", null)) {
+          @Override
+          public AccessToken refreshAccessToken() throws IOException {
+            refreshCounter++;
+            throw new IllegalStateException("Refresh not supported");
+          }
+        };
+  }
+
+  @Test
+  public void testEmptyTokenOnEmptyCredentials() throws IOException {
+    DefaultAccessTokenSupplier supplier =
+        new DefaultAccessTokenSupplier(Optional.empty(), 1, Duration.ofMillis(10));
+    assertThat(supplier.get()).isEqualTo(Optional.empty());
+  }
+
+  @Test
+  public void testWithValidToken() throws Exception {
+    // Google credentials can be refreshed
+    GoogleCredentials googleCredentials =
+        new GoogleCredentials(new AccessToken("my-token", future)) {
+          @Override
+          public GoogleCredentials createScoped(String... scopes) {
+            return scopedCredentials;
+          }
+
+          @Override
+          public AccessToken refreshAccessToken() throws IOException {
+            refreshCounter++;
+            return super.refreshAccessToken();
+          }
+        };
+
+    DefaultAccessTokenSupplier supplier =
+        new DefaultAccessTokenSupplier(
+            Optional.of(new HttpCredentialsAdapter(googleCredentials)), 1, Duration.ofMillis(10));
+    Optional<AccessToken> token = supplier.get();
+
+    assertThat(token.isPresent()).isTrue();
+    assertThat(token.get().getTokenValue()).isEqualTo("my-scoped-token");
+    assertThat(refreshCounter).isEqualTo(0);
+  }
+
+  @Test
+  public void testInvalidWithUnknownRequestInitializer() throws Exception {
+    HttpRequestInitializer bad =
+        new HttpRequestInitializer() {
+          @Override
+          public void initialize(HttpRequest request) throws IOException {
+            // ignore
+          }
+        };
+
+    DefaultAccessTokenSupplier supplier =
+        new DefaultAccessTokenSupplier(Optional.of(bad), 1, Duration.ofMillis(10));
+    RuntimeException ex = assertThrows(RuntimeException.class, supplier::get);
+    assertThat(ex).hasMessageThat().contains("Unsupported credentials of type");
+  }
+
+  @Test
+  public void testThrowsOnExpiredTokenRefreshNotSupported() throws Exception {
+
+    GoogleCredentials expiredGoogleCredentials =
+        new GoogleCredentials(new AccessToken("my-expired-token", past)) {
+          @Override
+          public GoogleCredentials createScoped(String... scopes) {
+            return scopedCredentials;
+          }
+
+          @Override
+          public AccessToken refreshAccessToken() throws IOException {
+            refreshCounter++;
+            return super.refreshAccessToken();
+          }
+        };
+
+    DefaultAccessTokenSupplier supplier =
+        new DefaultAccessTokenSupplier(
+            Optional.of(new HttpCredentialsAdapter(expiredGoogleCredentials)),
+            1,
+            Duration.ofMillis(10));
+    IllegalStateException ex = assertThrows(IllegalStateException.class, supplier::get);
+    assertThat(ex).hasMessageThat().contains("Error refreshing credentials");
+    assertThat(refreshCounter).isEqualTo(1);
+  }
+
+  @Test
+  public void testThrowsOnExpiredTokenRefreshStillExpired() throws Exception {
+
+    GoogleCredentials refreshGetsExpiredToken =
+        new GoogleCredentials(new AccessToken("my-expired-token", past)) {
+          @Override
+          public GoogleCredentials createScoped(String... scopes) {
+            return scopedCredentials;
+          }
+
+          @Override
+          public AccessToken refreshAccessToken() throws IOException {
+            refreshCounter++;
+            return new AccessToken("my-still-expired-token", past);
+          }
+        };
+
+    DefaultAccessTokenSupplier supplier =
+        new DefaultAccessTokenSupplier(
+            Optional.of(new HttpCredentialsAdapter(refreshGetsExpiredToken)),
+            1,
+            Duration.ofMillis(10));
+    IllegalStateException ex = assertThrows(IllegalStateException.class, supplier::get);
+    assertThat(ex).hasMessageThat().contains("expiration time is in the past");
+    assertThat(refreshCounter).isEqualTo(1);
+  }
+
+  @Test
+  public void testValidOnRefreshSucceeded() throws Exception {
+    GoogleCredentials refreshableCredentials =
+        new GoogleCredentials(new AccessToken("my-expired-token", past)) {
+          @Override
+          public GoogleCredentials createScoped(String... scopes) {
+            return scopedCredentials;
+          }
+
+          @Override
+          public AccessToken refreshAccessToken() throws IOException {
+            refreshCounter++;
+            return new AccessToken("my-refreshed-token", future);
+          }
+        };
+
+    DefaultAccessTokenSupplier supplier =
+        new DefaultAccessTokenSupplier(
+            Optional.of(new HttpCredentialsAdapter(refreshableCredentials)),
+            1,
+            Duration.ofMillis(10));
+    Optional<AccessToken> token = supplier.get();
+
+    assertThat(token.isPresent()).isTrue();
+    assertThat(token.get().getTokenValue()).isEqualTo("my-scoped-token");
+
+    assertThat(refreshCounter).isEqualTo(1);
+  }
+
+  @Test
+  public void testValidOnRefreshFailsSometimes() throws Exception {
+    GoogleCredentials refreshableCredentials =
+        new GoogleCredentials(new AccessToken("my-expired-token", past)) {
+          @Override
+          public GoogleCredentials createScoped(String... scopes) {
+            return scopedCredentials;
+          }
+
+          @Override
+          public AccessToken refreshAccessToken() throws IOException {
+            refreshCounter++;
+            // fail the first request and every other request after it
+            if (refreshCounter % 2 == 1) {
+              throw new IOException("Fake Connect IOException");
+            }
+            return new AccessToken("my-refreshed-token", future);
+          }
+        };
+
+    DefaultAccessTokenSupplier supplier =
+        new DefaultAccessTokenSupplier(
+            Optional.of(new HttpCredentialsAdapter(refreshableCredentials)),
+            3,
+            Duration.ofMillis(10));
+    Optional<AccessToken> token = supplier.get();
+
+    assertThat(token.isPresent()).isTrue();
+    assertThat(token.get().getTokenValue()).isEqualTo("my-scoped-token");
+
+    assertThat(refreshCounter).isEqualTo(2);
+  }
+
+  @Test
+  public void downscopesGoogleCredentials() {
+    // Google credentials can be refreshed
+    GoogleCredentials googleCredentials =
+        new GoogleCredentials(new AccessToken("my-token", future)) {
+          @Override
+          public GoogleCredentials createScoped(String... scopes) {
+            return scopedCredentials;
+          }
+        };
+
+    GoogleCredentials downscoped =
+        DefaultAccessTokenSupplier.getDownscopedCredentials(googleCredentials);
+    assertThat(downscoped).isEqualTo(scopedCredentials);
+  }
+
+  @Test
+  public void throwsErrorForWrongCredentialType() {
+    DefaultAccessTokenSupplier supplier =
+        new DefaultAccessTokenSupplier(
+            Optional.of(new HttpCredentialsAdapter(oAuth2Credentials)), 1, Duration.ofMillis(10));
+    RuntimeException ex = assertThrows(RuntimeException.class, supplier::get);
+
+    assertThat(ex)
+        .hasMessageThat()
+        .contains("HttpCredentialsAdapter did not create valid credentials");
+  }
+
+  @Test
+  public void testWithCredential() throws Exception {
+    Credential credential =
+        new Credential.Builder(
+                new AccessMethod() {
+                  @Override
+                  public void intercept(HttpRequest request, String accessToken)
+                      throws IOException {
+                    // do nothing
+                  }
+
+                  @Override
+                  public String getAccessTokenFromRequest(HttpRequest request) {
+                    return "my-refreshed-token";
+                  }
+                })
+            .setTransport(
+                new HttpTransport() {
+                  @Override
+                  protected LowLevelHttpRequest buildRequest(String method, String url)
+                      throws IOException {
+                    return new LowLevelHttpRequest() {
+                      @Override
+                      public void addHeader(String name, String value) throws IOException {
+                        // do nothing
+                      }
+
+                      @Override
+                      public LowLevelHttpResponse execute() throws IOException {
+                        MockLowLevelHttpResponse response = new MockLowLevelHttpResponse();
+                        response.setHeaderNames(Arrays.asList("WWW-Authenticate"));
+                        response.setHeaderValues(Arrays.asList("Bearer my-refreshed-token"));
+
+                        return response;
+                      }
+                    };
+                  }
+                })
+            .build();
+    credential.setAccessToken("my-token");
+    credential.setExpirationTimeMilliseconds(future.getTime());
+
+    DefaultAccessTokenSupplier supplier =
+        new DefaultAccessTokenSupplier(Optional.of(credential), 1, Duration.ofMillis(10));
+    Optional<AccessToken> token = supplier.get();
+
+    assertThat(token.isPresent()).isTrue();
+    assertThat(token.get().getTokenValue()).isEqualTo("my-token");
+    assertThat(refreshCounter).isEqualTo(0);
+  }
+
+  @Test
+  public void testWithRefreshableCredential() throws Exception {
+    Credential credential =
+        new Credential.Builder(
+                new AccessMethod() {
+                  @Override
+                  public void intercept(HttpRequest request, String accessToken)
+                      throws IOException {
+                    // do nothing
+                  }
+
+                  @Override
+                  public String getAccessTokenFromRequest(HttpRequest request) {
+                    return "my-refreshed-token";
+                  }
+                })
+            .setTransport(
+                new HttpTransport() {
+                  @Override
+                  protected LowLevelHttpRequest buildRequest(String method, String url)
+                      throws IOException {
+                    return new LowLevelHttpRequest() {
+                      @Override
+                      public void addHeader(String name, String value) throws IOException {
+                        // do nothing
+                      }
+
+                      @Override
+                      public LowLevelHttpResponse execute() throws IOException {
+                        MockLowLevelHttpResponse response = new MockLowLevelHttpResponse();
+
+                        TokenResponse tr = new TokenResponse();
+                        tr.setAccessToken("my-refreshed-token");
+                        tr.setTokenType("access");
+                        tr.setExpiresInSeconds(3600L);
+                        tr.setScope("https://www.googleapis.com/auth/sqlservice.login");
+                        String content = GsonFactory.getDefaultInstance().toString(tr);
+                        response.setContent(content);
+
+                        refreshCounter++;
+
+                        return response;
+                      }
+                    };
+                  }
+                })
+            .setJsonFactory(GsonFactory.getDefaultInstance())
+            .setClientAuthentication(
+                new HttpExecuteInterceptor() {
+                  @Override
+                  public void intercept(HttpRequest request) throws IOException {
+                    // todo nothing
+                  }
+                })
+            .setTokenServerUrl(new GenericUrl("https://example.com/"))
+            .build();
+    credential.setAccessToken("my-token");
+    credential.setRefreshToken("refresh-token");
+    credential.setExpirationTimeMilliseconds(past.getTime());
+
+    DefaultAccessTokenSupplier supplier =
+        new DefaultAccessTokenSupplier(Optional.of(credential), 1, Duration.ofMillis(10));
+    Optional<AccessToken> token = supplier.get();
+
+    assertThat(token.isPresent()).isTrue();
+    assertThat(token.get().getTokenValue()).isEqualTo("my-refreshed-token");
+    assertThat(refreshCounter).isEqualTo(1);
+  }
+
+  @Test
+  public void testGetTokenExpiration() {
+    assertThat(DefaultAccessTokenSupplier.getTokenExpirationTime(Optional.empty()))
+        .isEqualTo(Optional.empty());
+    assertThat(
+            DefaultAccessTokenSupplier.getTokenExpirationTime(Optional.of(new AccessToken("", null))))
+        .isEqualTo(Optional.empty());
+    assertThat(
+            DefaultAccessTokenSupplier.getTokenExpirationTime(Optional.of(new AccessToken("", past))))
+        .isEqualTo(Optional.of(past));
+  }
+}

--- a/core/src/test/java/com/google/cloud/sql/core/DefaultAccessTokenSupplierTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/DefaultAccessTokenSupplierTest.java
@@ -391,10 +391,12 @@ public class DefaultAccessTokenSupplierTest {
     assertThat(DefaultAccessTokenSupplier.getTokenExpirationTime(Optional.empty()))
         .isEqualTo(Optional.empty());
     assertThat(
-            DefaultAccessTokenSupplier.getTokenExpirationTime(Optional.of(new AccessToken("", null))))
+            DefaultAccessTokenSupplier.getTokenExpirationTime(
+                Optional.of(new AccessToken("", null))))
         .isEqualTo(Optional.empty());
     assertThat(
-            DefaultAccessTokenSupplier.getTokenExpirationTime(Optional.of(new AccessToken("", past))))
+            DefaultAccessTokenSupplier.getTokenExpirationTime(
+                Optional.of(new AccessToken("", past))))
         .isEqualTo(Optional.of(past));
   }
 }

--- a/core/src/test/java/com/google/cloud/sql/core/DefaultAccessTokenSupplierTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/DefaultAccessTokenSupplierTest.java
@@ -43,8 +43,6 @@ import java.util.Date;
 import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 
 public class DefaultAccessTokenSupplierTest {
 
@@ -54,13 +52,11 @@ public class DefaultAccessTokenSupplierTest {
 
   private GoogleCredentials scopedCredentials;
   private volatile int refreshCounter = 0;
-  @Mock private OAuth2Credentials oAuth2Credentials;
 
   @Before
   public void setup() throws IOException {
     refreshCounter = 0;
 
-    MockitoAnnotations.openMocks(this);
     // Scoped credentials can't be refreshed.
     scopedCredentials =
         new GoogleCredentials(new AccessToken("my-scoped-token", null)) {
@@ -256,9 +252,10 @@ public class DefaultAccessTokenSupplierTest {
 
   @Test
   public void throwsErrorForWrongCredentialType() {
+    OAuth2Credentials creds = OAuth2Credentials.create(new AccessToken("abc", null));
     DefaultAccessTokenSupplier supplier =
         new DefaultAccessTokenSupplier(
-            Optional.of(new HttpCredentialsAdapter(oAuth2Credentials)), 1, Duration.ofMillis(10));
+            Optional.of(new HttpCredentialsAdapter(creds)), 1, Duration.ofMillis(10));
     RuntimeException ex = assertThrows(RuntimeException.class, supplier::get);
 
     assertThat(ex)


### PR DESCRIPTION
Between version v1.13 and v1.14 of google-auth-library-oauth2, a bug was fixed that changed the behavior of how downscope tokens are refreshed. Prior to the fix, the code could downscope an oauth2 token, then the refresh the downscoped token. After the fix, the code must first refresh the original oauth2 token, then downscope it again.

In order to incorporate this new behavior into our code, we needed to encapsulate the operation of refreshing and 
downscoping a token. This change became too big for one PR, so I split the implementation into 3 PRs.

This PR introduces a new class and interface `AccessTokenSupplier` and `DefaultAccessTokenSupplier` along with extensive unit tests. This new class encapsulates the logic to refresh a token, duplicating the logic in `CloudSqlInstance`

PR #1330 refactors `CloudSqlInstance` and `SqlAdminApiFetcher` and tests to use the new `DefaultAccessTokenSupplier`, removing the duplicate refresh token code. 

PR #1331 upgrades google-auth-library-oauth2 to the latest version.

Related to issue: #1294