### PR TITLE
chore: Use AccessTokenSupplier, remove duplicate code from CloudSqlInstance.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -283,13 +283,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <version>4.11.0</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk15on</artifactId>
       <version>1.70</version>

--- a/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstance.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstance.java
@@ -48,7 +48,7 @@ class CloudSqlInstance {
   private static final Logger logger = Logger.getLogger(CloudSqlInstance.class.getName());
 
   private final ListeningScheduledExecutorService executor;
-  private final InstanceDataSupplier apiFetcher;
+  private final InstanceDataSupplier instanceDataSupplier;
   private final AuthType authType;
   private final AccessTokenSupplier accessTokenSupplier;
   private final CloudSqlInstanceName instanceName;
@@ -70,19 +70,19 @@ class CloudSqlInstance {
    * Initializes a new Cloud SQL instance based on the given connection name.
    *
    * @param connectionName instance connection name in the format "PROJECT_ID:REGION_ID:INSTANCE_ID"
-   * @param apiFetcher Service class for interacting with the Cloud SQL Admin API
+   * @param instanceDataSupplier Service class for interacting with the Cloud SQL Admin API
    * @param executor executor used to schedule asynchronous tasks
    * @param keyPair public/private key pair used to authenticate connections
    */
   CloudSqlInstance(
       String connectionName,
-      InstanceDataSupplier apiFetcher,
+      InstanceDataSupplier instanceDataSupplier,
       AuthType authType,
       CredentialFactory tokenSourceFactory,
       ListeningScheduledExecutorService executor,
       ListenableFuture<KeyPair> keyPair) {
     this.instanceName = new CloudSqlInstanceName(connectionName);
-    this.apiFetcher = apiFetcher;
+    this.instanceDataSupplier = instanceDataSupplier;
     this.authType = authType;
     this.executor = executor;
     this.keyPair = keyPair;
@@ -180,7 +180,7 @@ class CloudSqlInstance {
 
     try {
       InstanceData data =
-          apiFetcher.getInstanceData(
+          instanceDataSupplier.getInstanceData(
               this.instanceName, this.accessTokenSupplier, this.authType, executor, keyPair);
 
       synchronized (instanceDataGuard) {

--- a/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstance.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstance.java
@@ -48,10 +48,9 @@ class CloudSqlInstance {
   private static final Logger logger = Logger.getLogger(CloudSqlInstance.class.getName());
 
   private final ListeningScheduledExecutorService executor;
-  private final SqlAdminApiFetcher apiFetcher;
+  private final InstanceDataSupplier apiFetcher;
   private final AuthType authType;
   private final AccessTokenSupplier accessTokenSupplier;
-  private final Optional<HttpRequestInitializer> tokenSource;
   private final CloudSqlInstanceName instanceName;
   private final ListenableFuture<KeyPair> keyPair;
   private final Object instanceDataGuard = new Object();
@@ -77,7 +76,7 @@ class CloudSqlInstance {
    */
   CloudSqlInstance(
       String connectionName,
-      SqlAdminApiFetcher apiFetcher,
+      InstanceDataSupplier apiFetcher,
       AuthType authType,
       CredentialFactory tokenSourceFactory,
       ListeningScheduledExecutorService executor,
@@ -90,11 +89,9 @@ class CloudSqlInstance {
 
     if (authType == AuthType.IAM) {
       HttpRequestInitializer source = tokenSourceFactory.create();
-      this.tokenSource = Optional.ofNullable(source);
-      this.accessTokenSupplier = new DefaultAccessTokenSupplier(tokenSource);
+      this.accessTokenSupplier = new DefaultAccessTokenSupplier(Optional.ofNullable(source));
     } else {
-      this.tokenSource = Optional.empty();
-      this.accessTokenSupplier = new DefaultAccessTokenSupplier(Optional.empty());
+      this.accessTokenSupplier = () -> Optional.empty();
     }
 
     synchronized (instanceDataGuard) {

--- a/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstance.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstance.java
@@ -89,7 +89,7 @@ class CloudSqlInstance {
 
     if (authType == AuthType.IAM) {
       HttpRequestInitializer source = tokenSourceFactory.create();
-      this.accessTokenSupplier = new DefaultAccessTokenSupplier(Optional.ofNullable(source));
+      this.accessTokenSupplier = new DefaultAccessTokenSupplier(source);
     } else {
       this.accessTokenSupplier = () -> Optional.empty();
     }

--- a/core/src/main/java/com/google/cloud/sql/core/DefaultAccessTokenSupplier.java
+++ b/core/src/main/java/com/google/cloud/sql/core/DefaultAccessTokenSupplier.java
@@ -129,7 +129,7 @@ class DefaultAccessTokenSupplier implements AccessTokenSupplier {
                   throw new IllegalStateException("Error refreshing credentials " + credentials, e);
                 }
                 if (credentials.getAccessToken() == null
-                    || credentials.getAccessToken().equals("")) {
+                    || credentials.getAccessToken().getTokenValue().equals("")) {
                   throw new IllegalStateException("Credentials do not have an access token");
                 }
                 if (credentials.getAccessToken().getExpirationTime() != null
@@ -140,15 +140,16 @@ class DefaultAccessTokenSupplier implements AccessTokenSupplier {
 
                 // Now, attempt to downscope the credentials and refresh again
                 GoogleCredentials downscoped = getDownscopedCredentials(credentials);
-                if (downscoped.getAccessToken() == null || downscoped.getAccessToken().equals("")) {
+                if (downscoped.getAccessToken() == null
+                    || downscoped.getAccessToken().getTokenValue().equals("")) {
                   try {
                     downscoped.refreshIfExpired();
-                  } catch (IllegalStateException e) {
+                  } catch (Exception e) {
                     throw new IllegalStateException(
-                        "Error refreshing credentials " + credentials, e);
+                        "Error refreshing downscoped credentials " + credentials, e);
                   }
                   if (downscoped.getAccessToken() == null
-                      || downscoped.getAccessToken().equals("")) {
+                      || downscoped.getAccessToken().getTokenValue().equals("")) {
                     throw new IllegalStateException(
                         "Downscoped credentials do not have an access token: "
                             + downscoped.getClass().getName()

--- a/core/src/main/java/com/google/cloud/sql/core/DefaultAccessTokenSupplier.java
+++ b/core/src/main/java/com/google/cloud/sql/core/DefaultAccessTokenSupplier.java
@@ -129,7 +129,7 @@ class DefaultAccessTokenSupplier implements AccessTokenSupplier {
                   throw new IllegalStateException("Error refreshing credentials " + credentials, e);
                 }
                 if (credentials.getAccessToken() == null
-                    || credentials.getAccessToken().getTokenValue().equals("")) {
+                    || "".equals(credentials.getAccessToken().getTokenValue())) {
                   throw new IllegalStateException("Credentials do not have an access token");
                 }
                 if (credentials.getAccessToken().getExpirationTime() != null
@@ -141,7 +141,7 @@ class DefaultAccessTokenSupplier implements AccessTokenSupplier {
                 // Now, attempt to downscope the credentials and refresh again
                 GoogleCredentials downscoped = getDownscopedCredentials(credentials);
                 if (downscoped.getAccessToken() == null
-                    || downscoped.getAccessToken().getTokenValue().equals("")) {
+                    || "".equals(downscoped.getAccessToken().getTokenValue())) {
                   try {
                     downscoped.refreshIfExpired();
                   } catch (Exception e) {
@@ -149,7 +149,7 @@ class DefaultAccessTokenSupplier implements AccessTokenSupplier {
                         "Error refreshing downscoped credentials " + credentials, e);
                   }
                   if (downscoped.getAccessToken() == null
-                      || downscoped.getAccessToken().getTokenValue().equals("")) {
+                      || "".equals(downscoped.getAccessToken().getTokenValue())) {
                     throw new IllegalStateException(
                         "Downscoped credentials do not have an access token: "
                             + downscoped.getClass().getName()

--- a/core/src/main/java/com/google/cloud/sql/core/DefaultAccessTokenSupplier.java
+++ b/core/src/main/java/com/google/cloud/sql/core/DefaultAccessTokenSupplier.java
@@ -36,11 +36,12 @@ import java.util.logging.Logger;
  * configured HttpRequestInitializer.
  */
 class DefaultAccessTokenSupplier implements AccessTokenSupplier {
+
   private static final Logger logger = Logger.getLogger(DefaultAccessTokenSupplier.class.getName());
 
   private static final String SQL_LOGIN_SCOPE = "https://www.googleapis.com/auth/sqlservice.login";
 
-  private final Optional<HttpRequestInitializer> tokenSource;
+  private final HttpRequestInitializer requestInitializer;
   private final int retryCount;
   private final Duration retryDuration;
 
@@ -49,7 +50,7 @@ class DefaultAccessTokenSupplier implements AccessTokenSupplier {
    *
    * @param tokenSource the token source that produces auth tokens.
    */
-  DefaultAccessTokenSupplier(Optional<HttpRequestInitializer> tokenSource) {
+  DefaultAccessTokenSupplier(HttpRequestInitializer tokenSource) {
     this(tokenSource, 3, Duration.ofSeconds(3));
   }
 
@@ -61,8 +62,8 @@ class DefaultAccessTokenSupplier implements AccessTokenSupplier {
    * @param retryDuration the duration to wait between attempts.
    */
   DefaultAccessTokenSupplier(
-      Optional<HttpRequestInitializer> tokenSource, int retryCount, Duration retryDuration) {
-    this.tokenSource = tokenSource;
+      HttpRequestInitializer tokenSource, int retryCount, Duration retryDuration) {
+    this.requestInitializer = tokenSource;
     this.retryCount = retryCount;
     this.retryDuration = retryDuration;
   }
@@ -75,23 +76,22 @@ class DefaultAccessTokenSupplier implements AccessTokenSupplier {
    *     produce a GoogleCredentials instance.
    */
   private GoogleCredentials parseCredentials() {
-    HttpRequestInitializer source = this.tokenSource.get();
 
-    if (source instanceof HttpCredentialsAdapter) {
-      HttpCredentialsAdapter adapter = (HttpCredentialsAdapter) source;
+    if (this.requestInitializer instanceof HttpCredentialsAdapter) {
+      HttpCredentialsAdapter adapter = (HttpCredentialsAdapter) this.requestInitializer;
       Credentials c = adapter.getCredentials();
-      if (c != null && c instanceof GoogleCredentials) {
+      if (c instanceof GoogleCredentials) {
         return (GoogleCredentials) c;
       }
       throw new RuntimeException(
           String.format(
               "Unable to connect via automatic IAM authentication: "
                   + "HttpCredentialsAdapter did not create valid credentials. %s, %s",
-              source.getClass().getName(), c));
+              this.requestInitializer.getClass().getName(), c));
     }
 
-    if (source instanceof Credential) {
-      Credential credential = (Credential) source;
+    if (this.requestInitializer instanceof Credential) {
+      Credential credential = (Credential) this.requestInitializer;
       AccessToken accessToken =
           new AccessToken(
               credential.getAccessToken(), getTokenExpirationTime(credential).orElse(null));
@@ -110,7 +110,7 @@ class DefaultAccessTokenSupplier implements AccessTokenSupplier {
         String.format(
             "Unable to connect via automatic IAM authentication: "
                 + "Unsupported credentials of type %s",
-            source.getClass().getName()));
+            this.requestInitializer.getClass().getName()));
   }
 
   /**
@@ -122,69 +122,75 @@ class DefaultAccessTokenSupplier implements AccessTokenSupplier {
    */
   @Override
   public Optional<AccessToken> get() throws IOException {
-    if (tokenSource.isPresent()) {
-      RetryingCallable<Optional<AccessToken>> retries =
-          new RetryingCallable<>(
-              () -> {
-                final GoogleCredentials credentials;
-                credentials = parseCredentials();
+    if (requestInitializer == null) {
+      return Optional.empty();
+    }
+
+    RetryingCallable<Optional<AccessToken>> retries =
+        new RetryingCallable<>(
+            () -> {
+              final GoogleCredentials credentials;
+              credentials = parseCredentials();
+              try {
+                credentials.refreshIfExpired();
+              } catch (IllegalStateException e) {
+                throw new IllegalStateException("Error refreshing credentials " + credentials, e);
+              }
+              if (credentials.getAccessToken() == null
+                  || "".equals(credentials.getAccessToken().getTokenValue())) {
+
+                String errorMessage = "Access Token has length of zero";
+                logger.warning(errorMessage);
+
+                throw new IllegalStateException(errorMessage);
+              }
+
+              validateAccessTokenExpiration(credentials.getAccessToken());
+
+              // Now, attempt to down-scope and refresh credentials
+              GoogleCredentials downscoped = getDownscopedCredentials(credentials);
+
+              // For some implementations of GoogleCredentials, particularly
+              // ImpersonatedCredentials, down-scoped credentials are not
+              // initialized with a token and need to be explicitly refreshed.
+              if (downscoped.getAccessToken() == null
+                  || "".equals(downscoped.getAccessToken().getTokenValue())) {
                 try {
-                  credentials.refreshIfExpired();
-                } catch (IllegalStateException e) {
-                  throw new IllegalStateException("Error refreshing credentials " + credentials, e);
-                }
-                if (credentials.getAccessToken() == null
-                    || "".equals(credentials.getAccessToken().getTokenValue())) {
-
-                  String errorMessage = "Access Token has length of zero";
-                  logger.warning(errorMessage);
-
-                  throw new IllegalStateException(errorMessage);
+                  downscoped.refreshIfExpired();
+                } catch (Exception e) {
+                  throw new IllegalStateException(
+                      "Error refreshing downscoped credentials " + credentials, e);
                 }
 
-                validateAccessTokenExpiration(credentials.getAccessToken());
-
-                // Now, attempt to downscope the credentials and refresh again
-                GoogleCredentials downscoped = getDownscopedCredentials(credentials);
+                // After attempting to refresh once, if the downscoped credentials do not have
+                // an access token after attempting to refresh, then throw an IllegalStateException
                 if (downscoped.getAccessToken() == null
                     || "".equals(downscoped.getAccessToken().getTokenValue())) {
-                  try {
-                    downscoped.refreshIfExpired();
-                  } catch (Exception e) {
-                    throw new IllegalStateException(
-                        "Error refreshing downscoped credentials " + credentials, e);
-                  }
-                  if (downscoped.getAccessToken() == null
-                      || "".equals(downscoped.getAccessToken().getTokenValue())) {
-                    String errorMessage = "Downscoped access token has length of zero";
-                    logger.warning(errorMessage);
+                  String errorMessage = "Downscoped access token has length of zero";
+                  logger.warning(errorMessage);
 
-                    throw new IllegalStateException(
-                        errorMessage
-                            + ": "
-                            + downscoped.getClass().getName()
-                            + " from "
-                            + credentials.getClass().getName());
-                  }
-                  validateAccessTokenExpiration(downscoped.getAccessToken());
+                  throw new IllegalStateException(
+                      errorMessage
+                          + ": "
+                          + downscoped.getClass().getName()
+                          + " from "
+                          + credentials.getClass().getName());
                 }
+                validateAccessTokenExpiration(downscoped.getAccessToken());
+              }
 
-                return Optional.of(downscoped.getAccessToken());
-              },
-              this.retryCount,
-              this.retryDuration);
+              return Optional.of(downscoped.getAccessToken());
+            },
+            this.retryCount,
+            this.retryDuration);
 
-      try {
-        return retries.call();
-      } catch (IOException e) {
-        throw e;
-      } catch (RuntimeException e) {
-        throw e;
-      } catch (Exception e) {
-        throw new RuntimeException("Unexpected exception refreshing authentication token", e);
-      }
+    try {
+      return retries.call();
+    } catch (IOException | RuntimeException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new RuntimeException("Unexpected exception refreshing authentication token", e);
     }
-    return Optional.empty();
   }
 
   private void validateAccessTokenExpiration(AccessToken accessToken) {
@@ -217,11 +223,7 @@ class DefaultAccessTokenSupplier implements AccessTokenSupplier {
    * @return the expiration time, if set.
    */
   static Optional<Date> getTokenExpirationTime(Optional<AccessToken> token) {
-    if (token.isPresent()) {
-      return Optional.ofNullable(token.get().getExpirationTime());
-    } else {
-      return Optional.empty();
-    }
+    return token.flatMap((at) -> Optional.ofNullable(at.getExpirationTime()));
   }
 
   /**

--- a/core/src/main/java/com/google/cloud/sql/core/InstanceDataSupplier.java
+++ b/core/src/main/java/com/google/cloud/sql/core/InstanceDataSupplier.java
@@ -27,12 +27,6 @@ interface InstanceDataSupplier {
   /**
    * Internal Use Only: Gets the instance data for the CloudSqlInstance from the API.
    *
-   * @param instanceName the name of the instance
-   * @param accessTokenSupplier the token supplier
-   * @param authType the auth type
-   * @param executor the executor to use
-   * @param keyPair the client-side key pair
-   * @return an InstanceData
    * @throws ExecutionException if an exception is thrown during execution.
    * @throws InterruptedException if the executor is interrupted.
    */

--- a/core/src/main/java/com/google/cloud/sql/core/InstanceDataSupplier.java
+++ b/core/src/main/java/com/google/cloud/sql/core/InstanceDataSupplier.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.cloud.sql.core;
 
 import com.google.cloud.sql.AuthType;

--- a/core/src/main/java/com/google/cloud/sql/core/InstanceDataSupplier.java
+++ b/core/src/main/java/com/google/cloud/sql/core/InstanceDataSupplier.java
@@ -1,0 +1,17 @@
+package com.google.cloud.sql.core;
+
+import com.google.cloud.sql.AuthType;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningScheduledExecutorService;
+import java.security.KeyPair;
+import java.util.concurrent.ExecutionException;
+
+interface InstanceDataSupplier {
+  InstanceData getInstanceData(
+      CloudSqlInstanceName instanceName,
+      AccessTokenSupplier accessTokenSupplier,
+      AuthType authType,
+      ListeningScheduledExecutorService executor,
+      ListenableFuture<KeyPair> keyPair)
+      throws ExecutionException, InterruptedException;
+}

--- a/core/src/main/java/com/google/cloud/sql/core/InstanceDataSupplier.java
+++ b/core/src/main/java/com/google/cloud/sql/core/InstanceDataSupplier.java
@@ -22,7 +22,20 @@ import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import java.security.KeyPair;
 import java.util.concurrent.ExecutionException;
 
+/** Internal Use Only: Gets the instance data for the CloudSqlInstance from the API. */
 interface InstanceDataSupplier {
+  /**
+   * Internal Use Only: Gets the instance data for the CloudSqlInstance from the API.
+   *
+   * @param instanceName the name of the instance
+   * @param accessTokenSupplier the token supplier
+   * @param authType the auth type
+   * @param executor the executor to use
+   * @param keyPair the client-side key pair
+   * @return an InstanceData
+   * @throws ExecutionException if an exception is thrown during execution.
+   * @throws InterruptedException if the executor is interrupted.
+   */
   InstanceData getInstanceData(
       CloudSqlInstanceName instanceName,
       AccessTokenSupplier accessTokenSupplier,

--- a/core/src/main/java/com/google/cloud/sql/core/SqlAdminApiFetcher.java
+++ b/core/src/main/java/com/google/cloud/sql/core/SqlAdminApiFetcher.java
@@ -57,7 +57,7 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManagerFactory;
 
 /** Class that encapsulates all logic for interacting with SQLAdmin API. */
-class SqlAdminApiFetcher {
+class SqlAdminApiFetcher implements InstanceDataSupplier {
 
   private static final Logger logger = Logger.getLogger(SqlAdminApiFetcher.class.getName());
   private final SQLAdmin apiClient;
@@ -91,7 +91,20 @@ class SqlAdminApiFetcher {
         + "-----END RSA PUBLIC KEY-----\n";
   }
 
-  InstanceData getInstanceData(
+  /**
+   * Internal Use Only: Gets the instance data for the CloudSqlInstance from the API.
+   *
+   * @param instanceName the name of the instance
+   * @param accessTokenSupplier the token supplier
+   * @param authType the auth type
+   * @param executor the executor to use
+   * @param keyPair the client-side key pair
+   * @return an InstanceData
+   * @throws ExecutionException if an exception is thrown during execution.
+   * @throws InterruptedException if the executor is interrupted.
+   */
+  @Override
+  public InstanceData getInstanceData(
       CloudSqlInstanceName instanceName,
       AccessTokenSupplier accessTokenSupplier,
       AuthType authType,
@@ -100,8 +113,7 @@ class SqlAdminApiFetcher {
       throws ExecutionException, InterruptedException {
 
     ListenableFuture<Optional<AccessToken>> token =
-        executor.submit(
-            () -> accessTokenSupplier != null ? accessTokenSupplier.get() : Optional.empty());
+        executor.submit(() -> accessTokenSupplier.get());
 
     // Fetch the metadata
     ListenableFuture<Metadata> metadataFuture =

--- a/core/src/main/java/com/google/cloud/sql/core/SqlAdminApiFetcher.java
+++ b/core/src/main/java/com/google/cloud/sql/core/SqlAdminApiFetcher.java
@@ -142,7 +142,7 @@ class SqlAdminApiFetcher {
 
                   if (authType == AuthType.IAM) {
                     expiration =
-                        RealAccessTokenSupplier.getTokenExpirationTime(Futures.getDone(token))
+                        DefaultAccessTokenSupplier.getTokenExpirationTime(Futures.getDone(token))
                             .filter(
                                 tokenExpiration ->
                                     x509Certificate.getNotAfter().after(tokenExpiration))

--- a/core/src/main/java/com/google/cloud/sql/core/SqlAdminApiFetcher.java
+++ b/core/src/main/java/com/google/cloud/sql/core/SqlAdminApiFetcher.java
@@ -94,12 +94,6 @@ class SqlAdminApiFetcher implements InstanceDataSupplier {
   /**
    * Internal Use Only: Gets the instance data for the CloudSqlInstance from the API.
    *
-   * @param instanceName the name of the instance
-   * @param accessTokenSupplier the token supplier
-   * @param authType the auth type
-   * @param executor the executor to use
-   * @param keyPair the client-side key pair
-   * @return an InstanceData
    * @throws ExecutionException if an exception is thrown during execution.
    * @throws InterruptedException if the executor is interrupted.
    */

--- a/core/src/test/java/com/google/cloud/sql/core/CloudSqlInstanceTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/CloudSqlInstanceTest.java
@@ -15,9 +15,10 @@
  */
 package com.google.cloud.sql.core;
 
+import static com.google.common.truth.Truth.*;
+
 import com.google.cloud.sql.AuthType;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.truth.Truth;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
@@ -31,6 +32,7 @@ import java.util.Arrays;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -41,27 +43,17 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class CloudSqlInstanceTest {
 
-  private InstanceDataSupplier instanceDataSupplier;
-  private InstanceData data;
-  private SslData sslData;
-
-  private int refreshCount;
   private ListeningScheduledExecutorService executorService;
   private ListenableFuture<KeyPair> keyPairFuture;
 
   private StubCredentialFactory stubCredentialFactory =
       new StubCredentialFactory("my-token", System.currentTimeMillis() + 3600L);
 
-  private CloudSqlInstance instance;
-
   @Before
   public void setup() throws Exception {
     MockAdminApi mockAdminApi = new MockAdminApi();
     this.keyPairFuture = Futures.immediateFuture(mockAdminApi.getClientKeyPair());
     executorService = newTestExecutor();
-    refreshCount = 0;
-    sslData = new SslData(null, null, null);
-    data = new InstanceData(null, sslData, null);
   }
 
   @After
@@ -71,118 +63,157 @@ public class CloudSqlInstanceTest {
 
   @Test
   public void testCloudSqlInstanceDataRetrievedSuccessfully() throws Exception {
-    instanceDataSupplier =
+    SslData sslData = new SslData(null, null, null);
+    InstanceData data =
+        new InstanceData(null, sslData, Date.from(Instant.now().plus(1, ChronoUnit.HOURS)));
+    AtomicInteger refreshCount = new AtomicInteger();
+
+    InstanceDataSupplier instanceDataSupplier =
         (instanceName, accessTokenSupplier, authType, executor, keyPair) -> {
           Thread.sleep(100);
-          refreshCount++;
-          this.data =
-              new InstanceData(null, sslData, Date.from(Instant.now().plus(1, ChronoUnit.HOURS)));
+          refreshCount.incrementAndGet();
           return data;
         };
     // initialize instance after mocks are set up
-    instance = newCloudSqlInstance();
+    CloudSqlInstance instance =
+        new CloudSqlInstance(
+            "project:region:instance",
+            instanceDataSupplier,
+            AuthType.PASSWORD,
+            stubCredentialFactory,
+            executorService,
+            keyPairFuture);
 
     SslData gotSslData = instance.getSslData();
-    Truth.assertThat(gotSslData).isSameInstanceAs(this.sslData);
-    Truth.assertThat(refreshCount).isEqualTo(1);
+    assertThat(gotSslData).isSameInstanceAs(sslData);
+    assertThat(refreshCount.get()).isEqualTo(1);
   }
 
   @Test
   public void testInstanceFailsOnConnectionError() throws Exception {
-    instanceDataSupplier =
+
+    InstanceDataSupplier instanceDataSupplier =
         (instanceName, accessTokenSupplier, authType, executor, keyPair) -> {
           throw new ExecutionException(new IOException("Fake connection error"));
         };
 
     // initialize instance after mocks are set up
-    instance = newCloudSqlInstance();
+    CloudSqlInstance instance =
+        new CloudSqlInstance(
+            "project:region:instance",
+            instanceDataSupplier,
+            AuthType.PASSWORD,
+            stubCredentialFactory,
+            executorService,
+            keyPairFuture);
 
     RuntimeException ex = Assert.assertThrows(RuntimeException.class, instance::getSslData);
-    Truth.assertThat(ex).hasMessageThat().contains("Fake connection error");
+    assertThat(ex).hasMessageThat().contains("Fake connection error");
   }
 
   @Test
   public void testCloudSqlInstanceForcesRefresh() throws Exception {
-    instanceDataSupplier =
+    SslData sslData = new SslData(null, null, null);
+    InstanceData data =
+        new InstanceData(null, sslData, Date.from(Instant.now().plus(1, ChronoUnit.HOURS)));
+    AtomicInteger refreshCount = new AtomicInteger();
+
+    InstanceDataSupplier instanceDataSupplier =
         (instanceName, accessTokenSupplier, authType, executor, keyPair) -> {
           Thread.sleep(100);
-          refreshCount++;
-          this.data =
-              new InstanceData(null, sslData, Date.from(Instant.now().plus(1, ChronoUnit.HOURS)));
+          refreshCount.incrementAndGet();
           return data;
         };
 
-    instance = newCloudSqlInstance();
+    CloudSqlInstance instance =
+        new CloudSqlInstance(
+            "project:region:instance",
+            instanceDataSupplier,
+            AuthType.PASSWORD,
+            stubCredentialFactory,
+            executorService,
+            keyPairFuture);
 
     SslData gotSslData = instance.getSslData();
-    Truth.assertThat(gotSslData).isSameInstanceAs(this.sslData);
+    assertThat(gotSslData).isSameInstanceAs(sslData);
     instance.forceRefresh();
     instance.getSslData();
-    Truth.assertThat(refreshCount).isEqualTo(2);
+    assertThat(refreshCount.get()).isEqualTo(2);
   }
 
   @Test
   public void testGetPreferredIpTypes() throws Exception {
-    instanceDataSupplier =
+    SslData sslData = new SslData(null, null, null);
+    InstanceData data =
+        new InstanceData(
+            new Metadata(
+                ImmutableMap.of(
+                    "PUBLIC", "10.1.2.3",
+                    "PRIVATE", "10.10.10.10"),
+                null),
+            sslData,
+            Date.from(Instant.now().plus(1, ChronoUnit.HOURS)));
+    AtomicInteger refreshCount = new AtomicInteger();
+
+    InstanceDataSupplier instanceDataSupplier =
         (instanceName, accessTokenSupplier, authType, executor, keyPair) -> {
           Thread.sleep(100);
-          refreshCount++;
-          this.data =
-              new InstanceData(
-                  new Metadata(
-                      ImmutableMap.of(
-                          "PUBLIC", "10.1.2.3",
-                          "PRIVATE", "10.10.10.10"),
-                      null),
-                  sslData,
-                  Date.from(Instant.now().plus(1, ChronoUnit.HOURS)));
+          refreshCount.incrementAndGet();
           return data;
         };
 
     // initialize instance after mocks are set up
-    instance = newCloudSqlInstance();
-    Truth.assertThat(instance.getPreferredIp(Arrays.asList("PUBLIC", "PRIVATE")))
-        .isEqualTo("10.1.2.3");
-    Truth.assertThat(instance.getPreferredIp(Arrays.asList("PUBLIC"))).isEqualTo("10.1.2.3");
-    Truth.assertThat(instance.getPreferredIp(Arrays.asList("PRIVATE", "PUBLIC")))
+    CloudSqlInstance instance =
+        new CloudSqlInstance(
+            "project:region:instance",
+            instanceDataSupplier,
+            AuthType.PASSWORD,
+            stubCredentialFactory,
+            executorService,
+            keyPairFuture);
+
+    assertThat(instance.getPreferredIp(Arrays.asList("PUBLIC", "PRIVATE"))).isEqualTo("10.1.2.3");
+    assertThat(instance.getPreferredIp(Arrays.asList("PUBLIC"))).isEqualTo("10.1.2.3");
+    assertThat(instance.getPreferredIp(Arrays.asList("PRIVATE", "PUBLIC")))
         .isEqualTo("10.10.10.10");
-    Truth.assertThat(instance.getPreferredIp(Arrays.asList("PRIVATE"))).isEqualTo("10.10.10.10");
+    assertThat(instance.getPreferredIp(Arrays.asList("PRIVATE"))).isEqualTo("10.10.10.10");
   }
 
   @Test
   public void testGetPreferredIpTypesThrowsException() throws Exception {
-    instanceDataSupplier =
+    SslData sslData = new SslData(null, null, null);
+    InstanceData data =
+        new InstanceData(
+            new Metadata(ImmutableMap.of("PUBLIC", "10.1.2.3"), null),
+            sslData,
+            Date.from(Instant.now().plus(1, ChronoUnit.HOURS)));
+    AtomicInteger refreshCount = new AtomicInteger();
+
+    InstanceDataSupplier instanceDataSupplier =
         (instanceName, accessTokenSupplier, authType, executor, keyPair) -> {
           Thread.sleep(100);
-          refreshCount++;
-          this.data =
-              new InstanceData(
-                  new Metadata(ImmutableMap.of("PUBLIC", "10.1.2.3"), null),
-                  sslData,
-                  Date.from(Instant.now().plus(1, ChronoUnit.HOURS)));
+          refreshCount.incrementAndGet();
           return data;
         };
 
     // initialize instance after mocks are set up
-    instance = newCloudSqlInstance();
+    CloudSqlInstance instance =
+        new CloudSqlInstance(
+            "project:region:instance",
+            instanceDataSupplier,
+            AuthType.PASSWORD,
+            stubCredentialFactory,
+            executorService,
+            keyPairFuture);
     Assert.assertThrows(
         IllegalArgumentException.class, () -> instance.getPreferredIp(Arrays.asList("PRIVATE")));
-  }
-
-  private CloudSqlInstance newCloudSqlInstance() {
-    return new CloudSqlInstance(
-        "project:region:instance",
-        instanceDataSupplier,
-        AuthType.PASSWORD,
-        stubCredentialFactory,
-        executorService,
-        keyPairFuture);
   }
 
   private ListeningScheduledExecutorService newTestExecutor() {
     ScheduledThreadPoolExecutor executor =
         (ScheduledThreadPoolExecutor) Executors.newScheduledThreadPool(2);
     executor.setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
+
     //noinspection UnstableApiUsage
     return MoreExecutors.listeningDecorator(
         MoreExecutors.getExitingScheduledExecutorService(executor));

--- a/core/src/test/java/com/google/cloud/sql/core/CloudSqlInstanceTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/CloudSqlInstanceTest.java
@@ -41,7 +41,7 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class CloudSqlInstanceTest {
 
-  private InstanceDataSupplier fetcher;
+  private InstanceDataSupplier instanceDataSupplier;
   private InstanceData data;
   private SslData sslData;
 
@@ -71,7 +71,7 @@ public class CloudSqlInstanceTest {
 
   @Test
   public void testCloudSqlInstanceDataRetrievedSuccessfully() throws Exception {
-    fetcher =
+    instanceDataSupplier =
         (instanceName, accessTokenSupplier, authType, executor, keyPair) -> {
           Thread.sleep(100);
           refreshCount++;
@@ -89,7 +89,7 @@ public class CloudSqlInstanceTest {
 
   @Test
   public void testInstanceFailsOnConnectionError() throws Exception {
-    fetcher =
+    instanceDataSupplier =
         (instanceName, accessTokenSupplier, authType, executor, keyPair) -> {
           throw new ExecutionException(new IOException("Fake connection error"));
         };
@@ -103,7 +103,7 @@ public class CloudSqlInstanceTest {
 
   @Test
   public void testCloudSqlInstanceForcesRefresh() throws Exception {
-    fetcher =
+    instanceDataSupplier =
         (instanceName, accessTokenSupplier, authType, executor, keyPair) -> {
           Thread.sleep(100);
           refreshCount++;
@@ -123,7 +123,7 @@ public class CloudSqlInstanceTest {
 
   @Test
   public void testGetPreferredIpTypes() throws Exception {
-    fetcher =
+    instanceDataSupplier =
         (instanceName, accessTokenSupplier, authType, executor, keyPair) -> {
           Thread.sleep(100);
           refreshCount++;
@@ -151,7 +151,7 @@ public class CloudSqlInstanceTest {
 
   @Test
   public void testGetPreferredIpTypesThrowsException() throws Exception {
-    fetcher =
+    instanceDataSupplier =
         (instanceName, accessTokenSupplier, authType, executor, keyPair) -> {
           Thread.sleep(100);
           refreshCount++;
@@ -172,7 +172,7 @@ public class CloudSqlInstanceTest {
   private CloudSqlInstance newCloudSqlInstance() {
     return new CloudSqlInstance(
         "project:region:instance",
-        fetcher,
+        instanceDataSupplier,
         AuthType.PASSWORD,
         stubCredentialFactory,
         executorService,

--- a/core/src/test/java/com/google/cloud/sql/core/CloudSqlInstanceTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/CloudSqlInstanceTest.java
@@ -19,7 +19,6 @@ import static org.mockito.Mockito.when;
 
 import com.google.cloud.sql.AuthType;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 import com.google.common.truth.Truth;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -31,7 +30,6 @@ import java.sql.Date;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
-import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import org.junit.After;
@@ -49,19 +47,16 @@ import org.mockito.stubbing.Answer;
 @RunWith(JUnit4.class)
 public class CloudSqlInstanceTest {
 
-  @Mock
-  private SqlAdminApiFetcher fetcher;
-  @Mock
-  private InstanceData data;
-  @Mock
-  private SslData sslData;
+  @Mock private SqlAdminApiFetcher fetcher;
+  @Mock private InstanceData data;
+  @Mock private SslData sslData;
 
   private int refreshCount;
   private ListeningScheduledExecutorService executorService;
   private ListenableFuture<KeyPair> keyPairFuture;
 
-  private StubCredentialFactory stubCredentialFactory = new StubCredentialFactory("my-token",
-      System.currentTimeMillis() + 3600L);
+  private StubCredentialFactory stubCredentialFactory =
+      new StubCredentialFactory("my-token", System.currentTimeMillis() + 3600L);
 
   private CloudSqlInstance instance;
 
@@ -82,18 +77,19 @@ public class CloudSqlInstanceTest {
 
   @Test
   public void testCloudSqlInstance() throws Exception {
-    when(fetcher.getInstanceData(Mockito.any(), Mockito.any(), Mockito.any(),Mockito.any(),
-        Mockito.any()))
-        .then(new Answer<InstanceData>() {
+    when(fetcher.getInstanceData(
+            Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
+        .then(
+            new Answer<InstanceData>() {
 
-          @Override
-          public InstanceData answer(InvocationOnMock invocationOnMock) throws Throwable {
-            // sleep for a moment, then return data
-            Thread.sleep(100);
-            refreshCount++;
-            return data;
-          }
-        });
+              @Override
+              public InstanceData answer(InvocationOnMock invocationOnMock) throws Throwable {
+                // sleep for a moment, then return data
+                Thread.sleep(100);
+                refreshCount++;
+                return data;
+              }
+            });
     when(data.getExpiration()).thenReturn(Date.from(Instant.now().plus(1, ChronoUnit.HOURS)));
 
     // initialize instance after mocks are set up
@@ -106,15 +102,16 @@ public class CloudSqlInstanceTest {
 
   @Test
   public void testInstanceFails() throws Exception {
-    when(fetcher.getInstanceData(Mockito.any(), Mockito.any(), Mockito.any(),Mockito.any(),
-        Mockito.any()))
-        .then(new Answer<InstanceData>() {
+    when(fetcher.getInstanceData(
+            Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
+        .then(
+            new Answer<InstanceData>() {
 
-          @Override
-          public InstanceData answer(InvocationOnMock invocationOnMock) throws Throwable {
-            throw new IOException("Fake connection error");
-          }
-        });
+              @Override
+              public InstanceData answer(InvocationOnMock invocationOnMock) throws Throwable {
+                throw new IOException("Fake connection error");
+              }
+            });
     when(data.getExpiration()).thenReturn(Date.from(Instant.now().plus(1, ChronoUnit.HOURS)));
 
     // initialize instance after mocks are set up
@@ -122,22 +119,23 @@ public class CloudSqlInstanceTest {
 
     RuntimeException ex = Assert.assertThrows(RuntimeException.class, instance::getSslData);
     Truth.assertThat(ex).hasMessageThat().contains("Fake connection error");
-
   }
+
   @Test
   public void testCloudSqlInstanceForcesRefresh() throws Exception {
-    when(fetcher.getInstanceData(Mockito.any(), Mockito.any(), Mockito.any(),Mockito.any(),
-        Mockito.any()))
-        .then(new Answer<InstanceData>() {
+    when(fetcher.getInstanceData(
+            Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
+        .then(
+            new Answer<InstanceData>() {
 
-          @Override
-          public InstanceData answer(InvocationOnMock invocationOnMock) throws Throwable {
-            // sleep for a moment, then return data
-            Thread.sleep(100);
-            refreshCount++;
-            return data;
-          }
-        });
+              @Override
+              public InstanceData answer(InvocationOnMock invocationOnMock) throws Throwable {
+                // sleep for a moment, then return data
+                Thread.sleep(100);
+                refreshCount++;
+                return data;
+              }
+            });
     when(data.getExpiration()).thenReturn(Date.from(Instant.now().plus(1, ChronoUnit.HOURS)));
 
     // initialize instance after mocks are set up
@@ -152,54 +150,64 @@ public class CloudSqlInstanceTest {
 
   @Test
   public void testGetPreferredIpTypes() throws Exception {
-    when(fetcher.getInstanceData(Mockito.any(), Mockito.any(), Mockito.any(),Mockito.any(),
-        Mockito.any()))
-        .then(new Answer<InstanceData>() {
+    when(fetcher.getInstanceData(
+            Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
+        .then(
+            new Answer<InstanceData>() {
 
-          @Override
-          public InstanceData answer(InvocationOnMock invocationOnMock) throws Throwable {
-            refreshCount++;
-            return data;
-          }
-        });
+              @Override
+              public InstanceData answer(InvocationOnMock invocationOnMock) throws Throwable {
+                refreshCount++;
+                return data;
+              }
+            });
     when(data.getExpiration()).thenReturn(Date.from(Instant.now().plus(1, ChronoUnit.HOURS)));
-    when(data.getIpAddrs()).thenReturn(ImmutableMap.of(
-        "PUBLIC", "10.1.2.3",
-        "PRIVATE", "10.10.10.10"));
+    when(data.getIpAddrs())
+        .thenReturn(
+            ImmutableMap.of(
+                "PUBLIC", "10.1.2.3",
+                "PRIVATE", "10.10.10.10"));
 
     // initialize instance after mocks are set up
     instance = newCloudSqlInstance();
-    Truth.assertThat(instance.getPreferredIp(Arrays.asList("PUBLIC", "PRIVATE"))).isEqualTo("10.1.2.3");
+    Truth.assertThat(instance.getPreferredIp(Arrays.asList("PUBLIC", "PRIVATE")))
+        .isEqualTo("10.1.2.3");
     Truth.assertThat(instance.getPreferredIp(Arrays.asList("PUBLIC"))).isEqualTo("10.1.2.3");
-    Truth.assertThat(instance.getPreferredIp(Arrays.asList("PRIVATE", "PUBLIC"))).isEqualTo("10.10.10.10");
+    Truth.assertThat(instance.getPreferredIp(Arrays.asList("PRIVATE", "PUBLIC")))
+        .isEqualTo("10.10.10.10");
     Truth.assertThat(instance.getPreferredIp(Arrays.asList("PRIVATE"))).isEqualTo("10.10.10.10");
   }
+
   @Test
   public void testGetPreferredIpTypesThrowsException() throws Exception {
-    when(fetcher.getInstanceData(Mockito.any(), Mockito.any(), Mockito.any(),Mockito.any(),
-        Mockito.any()))
-        .then(new Answer<InstanceData>() {
+    when(fetcher.getInstanceData(
+            Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
+        .then(
+            new Answer<InstanceData>() {
 
-          @Override
-          public InstanceData answer(InvocationOnMock invocationOnMock) throws Throwable {
-            refreshCount++;
-            return data;
-          }
-        });
+              @Override
+              public InstanceData answer(InvocationOnMock invocationOnMock) throws Throwable {
+                refreshCount++;
+                return data;
+              }
+            });
     when(data.getExpiration()).thenReturn(Date.from(Instant.now().plus(1, ChronoUnit.HOURS)));
-    when(data.getIpAddrs()).thenReturn(ImmutableMap.of(
-        "PUBLIC", "10.1.2.3"));
+    when(data.getIpAddrs()).thenReturn(ImmutableMap.of("PUBLIC", "10.1.2.3"));
 
     // initialize instance after mocks are set up
     instance = newCloudSqlInstance();
-    Assert.assertThrows(IllegalArgumentException.class, () -> instance.getPreferredIp(Arrays.asList("PRIVATE")));
+    Assert.assertThrows(
+        IllegalArgumentException.class, () -> instance.getPreferredIp(Arrays.asList("PRIVATE")));
   }
 
-
   private CloudSqlInstance newCloudSqlInstance() {
-    return new CloudSqlInstance("project:region:instance", fetcher, AuthType.PASSWORD,
+    return new CloudSqlInstance(
+        "project:region:instance",
+        fetcher,
+        AuthType.PASSWORD,
         stubCredentialFactory,
-        executorService, keyPairFuture);
+        executorService,
+        keyPairFuture);
   }
 
   private ListeningScheduledExecutorService newTestExecutor() {
@@ -210,5 +218,4 @@ public class CloudSqlInstanceTest {
     return MoreExecutors.listeningDecorator(
         MoreExecutors.getExitingScheduledExecutorService(executor));
   }
-
 }

--- a/core/src/test/java/com/google/cloud/sql/core/DefaultAccessTokenSupplierTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/DefaultAccessTokenSupplierTest.java
@@ -71,7 +71,7 @@ public class DefaultAccessTokenSupplierTest {
   @Test
   public void testEmptyTokenOnEmptyCredentials() throws IOException {
     DefaultAccessTokenSupplier supplier =
-        new DefaultAccessTokenSupplier(Optional.empty(), 1, Duration.ofMillis(10));
+        new DefaultAccessTokenSupplier(null, 1, Duration.ofMillis(10));
     assertThat(supplier.get()).isEqualTo(Optional.empty());
   }
 
@@ -94,7 +94,7 @@ public class DefaultAccessTokenSupplierTest {
 
     DefaultAccessTokenSupplier supplier =
         new DefaultAccessTokenSupplier(
-            Optional.of(new HttpCredentialsAdapter(googleCredentials)), 1, Duration.ofMillis(10));
+            new HttpCredentialsAdapter(googleCredentials), 1, Duration.ofMillis(10));
     Optional<AccessToken> token = supplier.get();
 
     assertThat(token.isPresent()).isTrue();
@@ -113,7 +113,7 @@ public class DefaultAccessTokenSupplierTest {
         };
 
     DefaultAccessTokenSupplier supplier =
-        new DefaultAccessTokenSupplier(Optional.of(bad), 1, Duration.ofMillis(10));
+        new DefaultAccessTokenSupplier(bad, 1, Duration.ofMillis(10));
     RuntimeException ex = assertThrows(RuntimeException.class, supplier::get);
     assertThat(ex).hasMessageThat().contains("Unsupported credentials of type");
   }
@@ -137,9 +137,7 @@ public class DefaultAccessTokenSupplierTest {
 
     DefaultAccessTokenSupplier supplier =
         new DefaultAccessTokenSupplier(
-            Optional.of(new HttpCredentialsAdapter(expiredGoogleCredentials)),
-            1,
-            Duration.ofMillis(10));
+            new HttpCredentialsAdapter(expiredGoogleCredentials), 1, Duration.ofMillis(10));
     IllegalStateException ex = assertThrows(IllegalStateException.class, supplier::get);
     assertThat(ex).hasMessageThat().contains("Error refreshing credentials");
     assertThat(refreshCounter).isEqualTo(1);
@@ -164,9 +162,7 @@ public class DefaultAccessTokenSupplierTest {
 
     DefaultAccessTokenSupplier supplier =
         new DefaultAccessTokenSupplier(
-            Optional.of(new HttpCredentialsAdapter(refreshGetsExpiredToken)),
-            1,
-            Duration.ofMillis(10));
+            new HttpCredentialsAdapter(refreshGetsExpiredToken), 1, Duration.ofMillis(10));
     IllegalStateException ex = assertThrows(IllegalStateException.class, supplier::get);
     assertThat(ex).hasMessageThat().contains("expiration time is in the past");
     assertThat(refreshCounter).isEqualTo(1);
@@ -190,9 +186,7 @@ public class DefaultAccessTokenSupplierTest {
 
     DefaultAccessTokenSupplier supplier =
         new DefaultAccessTokenSupplier(
-            Optional.of(new HttpCredentialsAdapter(refreshableCredentials)),
-            1,
-            Duration.ofMillis(10));
+            new HttpCredentialsAdapter(refreshableCredentials), 1, Duration.ofMillis(10));
     Optional<AccessToken> token = supplier.get();
 
     assertThat(token.isPresent()).isTrue();
@@ -223,9 +217,7 @@ public class DefaultAccessTokenSupplierTest {
 
     DefaultAccessTokenSupplier supplier =
         new DefaultAccessTokenSupplier(
-            Optional.of(new HttpCredentialsAdapter(refreshableCredentials)),
-            3,
-            Duration.ofMillis(10));
+            new HttpCredentialsAdapter(refreshableCredentials), 3, Duration.ofMillis(10));
     Optional<AccessToken> token = supplier.get();
 
     assertThat(token.isPresent()).isTrue();
@@ -254,8 +246,7 @@ public class DefaultAccessTokenSupplierTest {
   public void throwsErrorForWrongCredentialType() {
     OAuth2Credentials creds = OAuth2Credentials.create(new AccessToken("abc", null));
     DefaultAccessTokenSupplier supplier =
-        new DefaultAccessTokenSupplier(
-            Optional.of(new HttpCredentialsAdapter(creds)), 1, Duration.ofMillis(10));
+        new DefaultAccessTokenSupplier(new HttpCredentialsAdapter(creds), 1, Duration.ofMillis(10));
     RuntimeException ex = assertThrows(RuntimeException.class, supplier::get);
 
     assertThat(ex)
@@ -273,8 +264,7 @@ public class DefaultAccessTokenSupplierTest {
           }
         };
     DefaultAccessTokenSupplier supplier =
-        new DefaultAccessTokenSupplier(
-            Optional.of(new HttpCredentialsAdapter(creds)), 1, Duration.ofMillis(10));
+        new DefaultAccessTokenSupplier(new HttpCredentialsAdapter(creds), 1, Duration.ofMillis(10));
     RuntimeException ex = assertThrows(RuntimeException.class, supplier::get);
 
     assertThat(ex).hasMessageThat().contains("Access Token has length of zero");
@@ -298,9 +288,7 @@ public class DefaultAccessTokenSupplierTest {
 
     DefaultAccessTokenSupplier supplier =
         new DefaultAccessTokenSupplier(
-            Optional.of(new HttpCredentialsAdapter(refreshableCredentials)),
-            1,
-            Duration.ofMillis(10));
+            new HttpCredentialsAdapter(refreshableCredentials), 1, Duration.ofMillis(10));
     RuntimeException ex = assertThrows(RuntimeException.class, supplier::get);
 
     assertThat(ex).hasMessageThat().contains("Access Token expiration time is in the past");
@@ -349,7 +337,7 @@ public class DefaultAccessTokenSupplierTest {
     credential.setExpirationTimeMilliseconds(future.getTime());
 
     DefaultAccessTokenSupplier supplier =
-        new DefaultAccessTokenSupplier(Optional.of(credential), 1, Duration.ofMillis(10));
+        new DefaultAccessTokenSupplier(credential, 1, Duration.ofMillis(10));
     Optional<AccessToken> token = supplier.get();
 
     assertThat(token.isPresent()).isTrue();
@@ -418,7 +406,7 @@ public class DefaultAccessTokenSupplierTest {
     credential.setExpirationTimeMilliseconds(past.getTime());
 
     DefaultAccessTokenSupplier supplier =
-        new DefaultAccessTokenSupplier(Optional.of(credential), 1, Duration.ofMillis(10));
+        new DefaultAccessTokenSupplier(credential, 1, Duration.ofMillis(10));
     Optional<AccessToken> token = supplier.get();
 
     assertThat(token.isPresent()).isTrue();

--- a/core/src/test/java/com/google/cloud/sql/core/SqlAdminApiFetcherTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/SqlAdminApiFetcherTest.java
@@ -57,7 +57,7 @@ public class SqlAdminApiFetcherTest {
     InstanceData instanceData =
         fetcher.getInstanceData(
             new CloudSqlInstanceName(INSTANCE_CONNECTION_NAME),
-            null,
+            () -> Optional.empty(),
             AuthType.PASSWORD,
             newTestExecutor(),
             Futures.immediateFuture(mockAdminApi.getClientKeyPair()));

--- a/core/src/test/java/com/google/cloud/sql/core/SqlAdminApiFetcherTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/SqlAdminApiFetcherTest.java
@@ -19,7 +19,6 @@ package com.google.cloud.sql.core;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
-import com.google.auth.oauth2.AccessToken;
 import com.google.cloud.sql.AuthType;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
@@ -27,8 +26,6 @@ import com.google.common.util.concurrent.MoreExecutors;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.time.Duration;
-import java.time.Instant;
-import java.util.Date;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
@@ -100,52 +97,6 @@ public class SqlAdminApiFetcherTest {
     assertThat(ex)
         .hasMessageThat()
         .contains("[p:r:i] IAM Authentication is not supported for SQL Server instances");
-  }
-
-  @Test
-  public void testFetchInstanceData_throwsException_whenTokenIsEmpty()
-      throws GeneralSecurityException, OperatorCreationException {
-    MockAdminApi mockAdminApi = buildMockAdminApi(INSTANCE_CONNECTION_NAME, DATABASE_VERSION);
-    SqlAdminApiFetcher fetcher =
-        new StubApiFetcherFactory(mockAdminApi.getHttpTransport())
-            .create(new StubCredentialFactory().create());
-
-    ExecutionException ex =
-        assertThrows(
-            ExecutionException.class,
-            () -> {
-              fetcher.getInstanceData(
-                  new CloudSqlInstanceName(INSTANCE_CONNECTION_NAME),
-                  () -> Optional.of(new AccessToken("" /* ignored */, null)),
-                  AuthType.IAM,
-                  newTestExecutor(),
-                  Futures.immediateFuture(mockAdminApi.getClientKeyPair()));
-            });
-
-    assertThat(ex).hasMessageThat().contains("Access Token has length of zero");
-  }
-
-  @Test
-  public void testFetchInstanceData_throwsException_whenTokenIsExpired()
-      throws GeneralSecurityException, OperatorCreationException {
-    MockAdminApi mockAdminApi = buildMockAdminApi(INSTANCE_CONNECTION_NAME, DATABASE_VERSION);
-    SqlAdminApiFetcher fetcher =
-        new StubApiFetcherFactory(mockAdminApi.getHttpTransport())
-            .create(new StubCredentialFactory().create());
-
-    ExecutionException ex =
-        assertThrows(
-            ExecutionException.class,
-            () -> {
-              fetcher.getInstanceData(
-                  new CloudSqlInstanceName(INSTANCE_CONNECTION_NAME),
-                  () -> Optional.of(new AccessToken("original-token", Date.from(Instant.now()))),
-                  AuthType.IAM,
-                  newTestExecutor(),
-                  Futures.immediateFuture(mockAdminApi.getClientKeyPair()));
-            });
-
-    assertThat(ex).hasMessageThat().contains("Access Token expiration time is in the past");
   }
 
   @Test


### PR DESCRIPTION
Refactors `CloudSqlInstance` and `SqlAdminApiFetcher` and tests to use the new `DefaultAccessTokenSupplier`, removing the duplicate refresh token code. Add unit tests to
cover CloudSqlInstance behavior.

This PR follows #1329
Related to issue #1294 

