### PR TITLE
fix: Use explicit project version in distributionManagement section

### DIFF
--- a/jdbc/mysql-j-5/pom.xml
+++ b/jdbc/mysql-j-5/pom.xml
@@ -41,7 +41,7 @@
     <relocation>
       <groupId>com.google.cloud.sql</groupId>
       <artifactId>mysql-socket-factory-connector-j-8</artifactId>
-      <version>${project.version}</version>
+      <version>1.12.1-SNAPSHOT</version>
       <message>
        MySQL Connector/J 5.0.x is no longer under development and has significant security vulnerabilities.
        Please update to 8.0.x instead. See the following GitHub issue for more details: 


### PR DESCRIPTION
This rolls back PR #1290, which tried to use ${project.version} instead. Unfortunately the expansion doesn't work when you use gradle to pull the dependencies. 

Fixes #1333 
See also [GoogleCloudPlatform/spring-cloud-gcp #1982](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/1982)
