### PR TITLE
chore: add debug logging aroud refresh operation

### DIFF
--- a/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstance.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstance.java
@@ -196,7 +196,6 @@ class CloudSqlInstance {
           String.format(
               "Refresh Operation: Completed refresh with new certificate expiration at %s.",
               data.getExpiration().toInstant().toString()));
-      // schedule a replacement before the SSLContext expires;
       long secondsToRefresh =
           refreshCalculator.calculateSecondsUntilNextRefresh(
               Instant.now(), data.getExpiration().toInstant());


### PR DESCRIPTION
In addition to helping customers to understand failed connections, this logging will also help debug why a refresh operation failed.