### PR TITLE
ci: disable auto running tests.

### DIFF
--- a/.github/trusted-contribution.yml
+++ b/.github/trusted-contribution.yml
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-annotations:
-  - type: label
-    text: "tests: run"
-trustedContributors: ['renovate-bot', 'gcf-merge-on-green[bot]']
+# Temporarily disable automatic running of renovate tests in order to
+# manage to control the number of tests running simultaneously.
+#annotations:
+#  - type: label
+#    text: "tests: run"
+#trustedContributors: ['renovate-bot', 'gcf-merge-on-green[bot]']


### PR DESCRIPTION
We have way to many Renovate PRs open right now and need to stop the tests from running on every branch change
for every PR. 

This PR will temporarily stop the branches from running. We will revert it once the backlog of renovate PRs is done.