### PR TITLE
chore: fix mysql 5 distribution management.

### DIFF
--- a/jdbc/mysql-j-5/pom.xml
+++ b/jdbc/mysql-j-5/pom.xml
@@ -41,7 +41,7 @@
     <relocation>
       <groupId>com.google.cloud.sql</groupId>
       <artifactId>mysql-socket-factory-connector-j-8</artifactId>
-      <version>1.12.1-SNAPSHOT</version>
+      <version>1.13.1-SNAPSHOT</version>
       <message>
        MySQL Connector/J 5.0.x is no longer under development and has significant security vulnerabilities.
        Please update to 8.0.x instead. See the following GitHub issue for more details: 


### PR DESCRIPTION
Update the version number on the mysql-5 distributionManagement. It does not get updated automatically by ReleasePlease.