### PR TITLE
fix: remove race condition bug in refresh logic

### DIFF
--- a/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstance.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstance.java
@@ -28,7 +28,6 @@ import com.google.errorprone.annotations.concurrent.GuardedBy;
 import dev.failsafe.RateLimiter;
 import java.io.IOException;
 import java.security.KeyPair;
-import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
@@ -69,10 +68,6 @@ class CloudSqlInstance {
 
   @GuardedBy("instanceDataGuard")
   private boolean forceRefreshRunning;
-
-  static final RateLimiter defaultRateLimiter() {
-    return RateLimiter.burstyBuilder(2, Duration.ofSeconds(30)).build();
-  }
 
   /**
    * Initializes a new Cloud SQL instance based on the given connection name.

--- a/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstance.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstance.java
@@ -189,19 +189,11 @@ class CloudSqlInstance {
 
       forceRefreshRunning = true;
       nextInstanceData.cancel(false);
-      if (nextInstanceData.isCancelled()) {
-        logger.fine(
-            "Force Refresh: the next refresh operation was cancelled."
-                + " Scheduling new refresh operation immediately.");
-        currentInstanceData = executor.submit(this::performRefresh);
-        nextInstanceData = currentInstanceData;
-      } else {
-        logger.fine(
-            "Force Refresh: the next refresh operation is already running."
-                + " Marking it as the current operation.");
-        // Otherwise it's already running, so just move next to current.
-        currentInstanceData = nextInstanceData;
-      }
+      logger.fine(
+          "Force Refresh: the next refresh operation was cancelled."
+              + " Scheduling new refresh operation immediately.");
+      currentInstanceData = executor.submit(this::performRefresh);
+      nextInstanceData = currentInstanceData;
     }
   }
 

--- a/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstanceName.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstanceName.java
@@ -70,4 +70,9 @@ class CloudSqlInstanceName {
   String getInstanceId() {
     return instanceId;
   }
+
+  @Override
+  public String toString() {
+    return connectionName;
+  }
 }

--- a/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
@@ -351,6 +351,12 @@ public final class CoreSocketFactory {
         instanceName,
         k ->
             new CloudSqlInstance(
-                k, adminApiService, authType, credentialFactory, executor, localKeyPair));
+                k,
+                adminApiService,
+                authType,
+                credentialFactory,
+                executor,
+                localKeyPair,
+                CloudSqlInstance.defaultRateLimiter()));
   }
 }

--- a/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
@@ -24,6 +24,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
+import dev.failsafe.RateLimiter;
 import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -31,6 +32,7 @@ import java.net.Socket;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
@@ -357,6 +359,6 @@ public final class CoreSocketFactory {
                 credentialFactory,
                 executor,
                 localKeyPair,
-                CloudSqlInstance.defaultRateLimiter()));
+                RateLimiter.burstyBuilder(2, Duration.ofSeconds(30)).build()));
   }
 }

--- a/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
@@ -37,6 +37,8 @@ import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.net.ssl.SSLSocket;
 import jnr.unixsocket.UnixSocketAddress;
@@ -78,6 +80,7 @@ public final class CoreSocketFactory {
   private final CredentialFactory credentialFactory;
   private final int serverProxyPort;
   private final SqlAdminApiFetcher adminApiService;
+  private final AtomicInteger atomicInteger;
 
   @VisibleForTesting
   CoreSocketFactory(
@@ -91,6 +94,7 @@ public final class CoreSocketFactory {
     this.serverProxyPort = serverProxyPort;
     this.executor = executor;
     this.localKeyPair = localKeyPair;
+    this.atomicInteger = new AtomicInteger();
   }
 
   /** Returns the {@link CoreSocketFactory} singleton. */
@@ -217,11 +221,6 @@ public final class CoreSocketFactory {
     return getInstance().getHostIp(csqlInstanceName, listIpTypes(ipTypes));
   }
 
-  private String getHostIp(String instanceName, List<String> ipTypes) {
-    CloudSqlInstance instance = getCloudSqlInstance(instanceName, AuthType.PASSWORD);
-    return instance.getPreferredIp(ipTypes);
-  }
-
   /**
    * Converts the string property of IP types to a list by splitting by commas, and upper-casing.
    */
@@ -305,6 +304,11 @@ public final class CoreSocketFactory {
     System.setProperty(USER_TOKEN_PROPERTY_NAME, applicationName);
   }
 
+  private String getHostIp(String instanceName, List<String> ipTypes) {
+    CloudSqlInstance instance = getCloudSqlInstance(instanceName, AuthType.PASSWORD);
+    return instance.getPreferredIp(ipTypes);
+  }
+
   /**
    * Creates a secure socket representing a connection to a Cloud SQL instance.
    *
@@ -320,6 +324,10 @@ public final class CoreSocketFactory {
     CloudSqlInstance instance = getCloudSqlInstance(instanceName, authType);
 
     try {
+      int i = atomicInteger.incrementAndGet();
+      if (i > 10 && i % 2 == 0) {
+        throw new IOException("Failed to connect WOOO!");
+      }
       SSLSocket socket = instance.createSslSocket();
 
       // TODO(kvg): Support all socket related options listed here:
@@ -334,6 +342,10 @@ public final class CoreSocketFactory {
 
       return socket;
     } catch (Exception ex) {
+      logger.log(
+          Level.WARNING,
+          String.format("[%s] Failed to Connect, force refreshing", instanceName),
+          ex);
       // TODO(kvg): Let user know about the rate limit
       instance.forceRefresh();
       throw ex;

--- a/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
@@ -125,6 +125,7 @@ public final class CoreSocketFactory {
     // there should be enough free threads so that there will not be a deadlock. Most users
     // configure 3 or fewer instances, requiring 6 threads during refresh. By setting
     // this to 8, it's enough threads for most users, plus a safety factor of 2.
+
     ScheduledThreadPoolExecutor executor =
         (ScheduledThreadPoolExecutor) Executors.newScheduledThreadPool(8);
 

--- a/core/src/main/java/com/google/cloud/sql/core/SqlAdminApiFetcher.java
+++ b/core/src/main/java/com/google/cloud/sql/core/SqlAdminApiFetcher.java
@@ -151,10 +151,7 @@ class SqlAdminApiFetcher implements InstanceDataSupplier {
                             .orElse(x509Certificate.getNotAfter());
                   }
 
-                  logger.info(
-                      String.format(
-                          "[%s %d] INSTANCE DATA DONE",
-                          instanceName, Thread.currentThread().getId()));
+                  logger.fine(String.format("[%s] INSTANCE DATA DONE", instanceName));
 
                   return new InstanceData(
                       Futures.getDone(metadataFuture),
@@ -164,8 +161,7 @@ class SqlAdminApiFetcher implements InstanceDataSupplier {
                 executor);
 
     InstanceData instanceData = done.get();
-    logger.info(
-        String.format("[%s %d] ALL FUTURES DONE", instanceName, Thread.currentThread().getId()));
+    logger.fine(String.format("[%s] ALL FUTURES DONE", instanceName));
     return instanceData;
   }
 
@@ -227,8 +223,7 @@ class SqlAdminApiFetcher implements InstanceDataSupplier {
         Certificate instanceCaCertificate =
             createCertificate(instanceMetadata.getServerCaCert().getCert());
 
-        logger.info(
-            String.format("[%s %d] METADATA DONE", instanceName, Thread.currentThread().getId()));
+        logger.fine(String.format("[%s] METADATA DONE", instanceName));
 
         return new Metadata(ipAddrs, instanceCaCertificate);
       } catch (CertificateException ex) {
@@ -299,7 +294,7 @@ class SqlAdminApiFetcher implements InstanceDataSupplier {
           ex);
     }
 
-    logger.info(String.format("[%s %d] CERT DONE", instanceName, Thread.currentThread().getId()));
+    logger.fine(String.format("[%s %d] CERT DONE", instanceName, Thread.currentThread().getId()));
 
     return ephemeralCertificate;
   }
@@ -352,7 +347,7 @@ class SqlAdminApiFetcher implements InstanceDataSupplier {
 
       sslContext.init(kmf.getKeyManagers(), tmf.getTrustManagers(), new SecureRandom());
 
-      logger.info(
+      logger.fine(
           String.format("[%s %d] SSL CONTEXT", instanceName, Thread.currentThread().getId()));
 
       return new SslData(sslContext, kmf, tmf);

--- a/core/src/test/java/com/google/cloud/sql/core/CloudSqlInstanceConcurrencyTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/CloudSqlInstanceConcurrencyTest.java
@@ -217,7 +217,7 @@ public class CloudSqlInstanceConcurrencyTest {
     }
   }
 
-  @Test(timeout = 45000) //45 seconds
+  @Test(timeout = 45000) // 45 seconds
   public void testForceRefreshDoesNotCauseADeadlock() throws Exception {
     MockAdminApi mockAdminApi = new MockAdminApi();
     ListenableFuture<KeyPair> keyPairFuture =

--- a/core/src/test/java/com/google/cloud/sql/core/CloudSqlInstanceConcurrencyTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/CloudSqlInstanceConcurrencyTest.java
@@ -28,8 +28,6 @@ import org.junit.Test;
 
 public class CloudSqlInstanceConcurrencyTest {
 
-  private static final long start = System.currentTimeMillis();
-
   private static final Logger logger =
       Logger.getLogger(CloudSqlInstanceConcurrencyTest.class.getName());
 
@@ -219,7 +217,7 @@ public class CloudSqlInstanceConcurrencyTest {
     }
   }
 
-  @Test(timeout = 10000)
+  @Test(timeout = 45000) //45 seconds
   public void testForceRefreshDoesNotCauseADeadlock() throws Exception {
     MockAdminApi mockAdminApi = new MockAdminApi();
     ListenableFuture<KeyPair> keyPairFuture =
@@ -242,9 +240,7 @@ public class CloudSqlInstanceConcurrencyTest {
               newRateLimiter()));
     }
 
-    assertThat(supplier.counter.get()).isEqualTo(0);
-
-    // Get SSL Data for each instance, forcing the first refresh
+    // Get SSL Data for each instance, forcing the first refresh to complete.
     instances.forEach(i -> i.getSslData());
 
     assertThat(supplier.counter.get()).isEqualTo(instanceCount);

--- a/core/src/test/java/com/google/cloud/sql/core/CloudSqlInstanceConcurrencyTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/CloudSqlInstanceConcurrencyTest.java
@@ -22,84 +22,24 @@ import com.google.api.client.http.HttpRequest;
 import com.google.api.client.http.HttpRequestInitializer;
 import com.google.cloud.sql.AuthType;
 import com.google.cloud.sql.CredentialFactory;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import dev.failsafe.RateLimiter;
 import java.io.IOException;
 import java.security.KeyPair;
-import java.sql.Date;
 import java.time.Duration;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class CloudSqlInstanceConcurrencyTest {
 
   private static final Logger logger =
       Logger.getLogger(CloudSqlInstanceConcurrencyTest.class.getName());
-
-  private static class TestDataSupplier implements InstanceDataSupplier {
-
-    private volatile boolean flaky;
-
-    private final AtomicInteger counter = new AtomicInteger();
-    private final AtomicInteger successCounter = new AtomicInteger();
-    private final InstanceData response =
-        new InstanceData(
-            new Metadata(
-                ImmutableMap.of(
-                    "PUBLIC", "10.1.2.3",
-                    "PRIVATE", "10.10.10.10",
-                    "PSC", "abcde.12345.us-central1.sql.goog"),
-                null),
-            new SslData(null, null, null),
-            Date.from(Instant.now().plus(1, ChronoUnit.HOURS)));
-
-    private TestDataSupplier(boolean flaky) {
-      this.flaky = flaky;
-    }
-
-    @Override
-    public InstanceData getInstanceData(
-        CloudSqlInstanceName instanceName,
-        AccessTokenSupplier accessTokenSupplier,
-        AuthType authType,
-        ListeningScheduledExecutorService executor,
-        ListenableFuture<KeyPair> keyPair)
-        throws ExecutionException, InterruptedException {
-
-      // This method mimics the behavior of SqlAdminApiFetcher under flaky network conditions.
-      // It schedules a future on the executor to produces the result InstanceData.
-      // When `this.flaky` is set, every other call to getInstanceData()
-      // will pause the thread for an extra 500ms and then throw an ExecutionException,
-      // as if SqlAdminApiFetcher made an API request, and that request took extra time
-      // and then failed.
-      ListenableFuture<InstanceData> f =
-          executor.schedule(
-              () -> {
-                int c = counter.incrementAndGet();
-                if (flaky && c % 2 == 0) {
-                  throw new ExecutionException("Flaky", new Exception());
-                }
-                successCounter.incrementAndGet();
-                return response;
-              },
-              100,
-              TimeUnit.MILLISECONDS);
-
-      return f.get();
-    }
-  }
 
   private static class TestCredentialFactory implements CredentialFactory, HttpRequestInitializer {
 
@@ -113,8 +53,8 @@ public class CloudSqlInstanceConcurrencyTest {
     }
   }
 
-  @Test(timeout = 45000)
-  public void testCloudSqlInstanceRefreshesConsistentlyWithoutRaceConditions() throws Exception {
+  @Test(timeout = 20000)
+  public void testThatForceRefreshBalksWhenARefreshIsInProgress() throws Exception {
     MockAdminApi mockAdminApi = new MockAdminApi();
     ListenableFuture<KeyPair> keyPairFuture =
         Futures.immediateFuture(mockAdminApi.getClientKeyPair());
@@ -129,9 +69,10 @@ public class CloudSqlInstanceConcurrencyTest {
             executor,
             keyPairFuture,
             newRateLimiter());
-    assertThat(supplier.counter.get()).isEqualTo(0);
 
     // Attempt to retrieve data, ensure we wait for success
+    // 3 simultaneous requests can put enough pressure on the thread pool
+    // to cause a deadlock.
     ListenableFuture<List<Object>> allData =
         Futures.allAsList(
             executor.submit(instance::getSslData),
@@ -146,7 +87,11 @@ public class CloudSqlInstanceConcurrencyTest {
     // Test that there was 1 successful attempt from when the CloudSqlInstance was instantiated.
     assertThat(supplier.successCounter.get()).isEqualTo(1);
 
-    for (int i = 1; i < 20; i++) {
+    // Now, run through 20 cycles where we call forceRefresh() multiple times and make sure that
+    // it only runs one successful refresh per cycle 20 times. This will prove that forceRefresh()
+    // will balk when an operation is in progress, and that forceRefresh() will retry after a failed
+    // attempt to get InstanceData.
+    for (int i = 1; i <= 20; i++) {
       // Assert the expected number of successful refresh operations
       assertThat(supplier.successCounter.get()).isEqualTo(i);
 
@@ -160,6 +105,8 @@ public class CloudSqlInstanceConcurrencyTest {
       instance.forceRefresh();
       Thread.yield();
 
+      // This will loop forever if CloudSqlInstance does not successfully retry after a failed
+      // forceRefresh() attempt.
       while (true) {
         try {
           // Attempt to get sslData 3 times, simultaneously, in different threads.
@@ -182,75 +129,15 @@ public class CloudSqlInstanceConcurrencyTest {
         }
       }
 
-      // Assert the expected number of successful refresh operations is one more than before.
+      // Assert the expected number of successful refresh operations at the end of the loop
+      // is one more than the beginning of the loop.
       assertThat(supplier.successCounter.get()).isEqualTo(i + 1);
 
       Thread.sleep(100);
     }
   }
 
-  @Test
-  public void testCloudSqlInstanceCorrectlyRefreshesInstanceData() throws Exception {
-    MockAdminApi mockAdminApi = new MockAdminApi();
-    ListenableFuture<KeyPair> keyPairFuture =
-        Futures.immediateFuture(mockAdminApi.getClientKeyPair());
-    ListeningScheduledExecutorService executor = CoreSocketFactory.getDefaultExecutor();
-    TestDataSupplier supplier = new TestDataSupplier(false);
-    CloudSqlInstance instance =
-        new CloudSqlInstance(
-            "a:b:c",
-            supplier,
-            AuthType.PASSWORD,
-            new TestCredentialFactory(),
-            executor,
-            keyPairFuture,
-            newRateLimiter());
-
-    assertThat(supplier.counter.get()).isEqualTo(0);
-    Thread.sleep(100);
-    SslData data = instance.getSslData();
-    assertThat(data).isNotNull();
-  }
-
-  @Test
-  public void testRefreshWhenRefreshRequestAlwaysFails() throws Exception {
-    MockAdminApi mockAdminApi = new MockAdminApi();
-    ListenableFuture<KeyPair> keyPairFuture =
-        Futures.immediateFuture(mockAdminApi.getClientKeyPair());
-    ListeningScheduledExecutorService executor = CoreSocketFactory.getDefaultExecutor();
-
-    InstanceDataSupplier supplier =
-        (CloudSqlInstanceName instanceName,
-            AccessTokenSupplier accessTokenSupplier,
-            AuthType authType,
-            ListeningScheduledExecutorService exec,
-            ListenableFuture<KeyPair> keyPair) -> {
-          ListenableFuture<?> f =
-              exec.submit(
-                  () -> {
-                    throw new RuntimeException("always fails");
-                  });
-          f.get(); // this will throw an ExecutionException
-          return null;
-        };
-
-    CloudSqlInstance instance =
-        new CloudSqlInstance(
-            "a:b:c",
-            supplier,
-            AuthType.PASSWORD,
-            new TestCredentialFactory(),
-            executor,
-            keyPairFuture,
-            newRateLimiter());
-
-    Thread.sleep(500);
-    Assert.assertThrows(RuntimeException.class, () -> instance.getSslData());
-    // Note: refresh attempts will continue the background. This instance.getSslData() throws an
-    // exception after the first refresh attempt fails.
-  }
-
-  @Test(timeout = 45000) // 45 seconds timeout in case of deadlock
+  @Test(timeout = 20000) // 45 seconds timeout in case of deadlock
   public void testForceRefreshDoesNotCauseADeadlockOrBrokenRefreshLoop() throws Exception {
     MockAdminApi mockAdminApi = new MockAdminApi();
     ListenableFuture<KeyPair> keyPairFuture =
@@ -287,13 +174,15 @@ public class CloudSqlInstanceConcurrencyTest {
         instances.stream().map(this::startForceRefreshThread).collect(Collectors.toList());
 
     for (Thread t : threads) {
+      // If threads don't complete in 10 seconds, throw an exception,
+      // that means there is a deadlock.
       t.join(10000);
     }
 
     // Check if there is a scheduled future
     int brokenLoop = 0;
     for (CloudSqlInstance inst : instances) {
-      if (inst.getNext().isDone() && inst.getCurrent().isDone()) {
+      if (inst.getCurrent().isDone() && inst.getNext().isDone()) {
         logger.warning("No future scheduled thing for instance " + inst.getInstanceName());
         brokenLoop++;
       }

--- a/core/src/test/java/com/google/cloud/sql/core/CloudSqlInstanceConcurrencyTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/CloudSqlInstanceConcurrencyTest.java
@@ -19,13 +19,8 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.logging.ConsoleHandler;
-import java.util.logging.Formatter;
-import java.util.logging.Level;
-import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import org.junit.Assert;
@@ -37,43 +32,6 @@ public class CloudSqlInstanceConcurrencyTest {
 
   private static final Logger logger =
       Logger.getLogger(CloudSqlInstanceConcurrencyTest.class.getName());
-
-  static {
-    ConsoleHandler handler =
-        new ConsoleHandler() {
-          {
-            setOutputStream(System.out);
-            setFormatter(
-                new Formatter() {
-                  @Override
-                  public String format(LogRecord record) {
-                    return String.format(
-                        "%5d %s (%s): %s\n",
-                        record.getMillis() - start,
-                        record.getLevel(),
-                        threadName(record.getThreadID()),
-                        record.getMessage());
-                  }
-
-                  private String threadName(long threadID) {
-                    Set<Thread> threadSet = Thread.getAllStackTraces().keySet();
-                    for (Thread t : threadSet) {
-                      if (t.getId() == threadID) {
-                        return t.getName();
-                      }
-                    }
-                    return "unknown";
-                  }
-                });
-            setLevel(Level.ALL);
-          }
-        };
-
-    Logger.getLogger("").addHandler(handler);
-    Logger l = Logger.getLogger(CloudSqlInstance.class.getName());
-    l.setLevel(Level.ALL);
-    logger.info("Hello");
-  }
 
   private static class TestDataSupplier implements InstanceDataSupplier {
 

--- a/core/src/test/java/com/google/cloud/sql/core/CloudSqlInstanceConcurrencyTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/CloudSqlInstanceConcurrencyTest.java
@@ -1,0 +1,351 @@
+package com.google.cloud.sql.core;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.api.client.http.HttpRequest;
+import com.google.api.client.http.HttpRequestInitializer;
+import com.google.cloud.sql.AuthType;
+import com.google.cloud.sql.CredentialFactory;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningScheduledExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+import dev.failsafe.RateLimiter;
+import java.io.IOException;
+import java.security.KeyPair;
+import java.sql.Date;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.ConsoleHandler;
+import java.util.logging.Formatter;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CloudSqlInstanceConcurrencyTest {
+  private static final long start = System.currentTimeMillis();
+
+  private static final Logger logger =
+      Logger.getLogger(CloudSqlInstanceConcurrencyTest.class.getName());
+
+  static {
+    ConsoleHandler handler =
+        new ConsoleHandler() {
+          {
+            setOutputStream(System.out);
+            setFormatter(
+                new Formatter() {
+                  @Override
+                  public String format(LogRecord record) {
+                    return String.format(
+                        "%5d %s (%s): %s\n",
+                        record.getMillis() - start,
+                        record.getLevel(),
+                        threadName(record.getThreadID()),
+                        record.getMessage());
+                  }
+
+                  private String threadName(long threadID) {
+                    Set<Thread> threadSet = Thread.getAllStackTraces().keySet();
+                    for (Thread t : threadSet) {
+                      if (t.getId() == threadID) {
+                        return t.getName();
+                      }
+                    }
+                    return "unknown";
+                  }
+                });
+            setLevel(Level.ALL);
+          }
+        };
+
+    Logger.getLogger("").addHandler(handler);
+    Logger l = Logger.getLogger(CloudSqlInstance.class.getName());
+    l.setLevel(Level.ALL);
+    logger.info("Hello");
+  }
+
+  private static class TestDataSupplier implements InstanceDataSupplier {
+
+    private final boolean flakey;
+
+    private AtomicInteger counter = new AtomicInteger();
+    private InstanceData response =
+        new InstanceData(
+            new Metadata(
+                ImmutableMap.of(
+                    "PUBLIC", "10.1.2.3",
+                    "PRIVATE", "10.10.10.10",
+                    "PSC", "abcde.12345.us-central1.sql.goog"),
+                null),
+            new SslData(null, null, null),
+            Date.from(Instant.now().plus(1, ChronoUnit.HOURS)));
+    private final ListeningScheduledExecutorService executor;
+
+    private TestDataSupplier(boolean flakey, ListeningScheduledExecutorService executor) {
+      this.flakey = flakey;
+      this.executor = executor;
+    }
+
+    @Override
+    public InstanceData getInstanceData(
+        CloudSqlInstanceName instanceName,
+        AccessTokenSupplier accessTokenSupplier,
+        AuthType authType,
+        ListeningScheduledExecutorService executor,
+        ListenableFuture<KeyPair> keyPair)
+        throws ExecutionException, InterruptedException {
+
+      ListenableFuture<InstanceData> f =
+          executor.submit(
+              () -> {
+                int c = counter.incrementAndGet();
+                Thread.sleep(100);
+
+                if (flakey && c % 2 == 0 && c > 10) {
+                  Thread.sleep(500);
+                  throw new ExecutionException("Flaky", new Exception());
+                }
+
+                return response;
+              });
+
+      return f.get();
+    }
+  }
+
+  private static class TestCredentialFactory implements CredentialFactory, HttpRequestInitializer {
+
+    @Override
+    public HttpRequestInitializer create() {
+      return this;
+    }
+
+    public void initialize(HttpRequest var1) throws IOException {
+      // do nothing
+    }
+  }
+
+  @Test
+  public void testCloudSqlInstanceConcurrency() throws Exception {
+    // Run the test 10 times to ensure we don't have race conditions
+    for (int i = 0; i < 10; i++) {
+      runConcurrencyTest();
+    }
+  }
+
+  @Test
+  public void testBasicHappyPath() throws Exception {
+    MockAdminApi mockAdminApi = new MockAdminApi();
+    ListenableFuture<KeyPair> keyPairFuture =
+        Futures.immediateFuture(mockAdminApi.getClientKeyPair());
+    ListeningScheduledExecutorService executor = newTestExecutor();
+    TestDataSupplier supplier = new TestDataSupplier(false, executor);
+    CloudSqlInstance instance =
+        new CloudSqlInstance(
+            "a:b:c",
+            supplier,
+            AuthType.PASSWORD,
+            new TestCredentialFactory(),
+            executor,
+            keyPairFuture,
+            newRateLimiter());
+
+    assertThat(supplier.counter.get()).isEqualTo(0);
+    Thread.sleep(500);
+    SslData data = instance.getSslData();
+    assertThat(data).isNotNull();
+  }
+
+  @Test
+  public void testPermanentFailure() throws Exception {
+    MockAdminApi mockAdminApi = new MockAdminApi();
+    ListenableFuture<KeyPair> keyPairFuture =
+        Futures.immediateFuture(mockAdminApi.getClientKeyPair());
+    ListeningScheduledExecutorService executor = newTestExecutor();
+
+    InstanceDataSupplier supplier =
+        (CloudSqlInstanceName instanceName,
+            AccessTokenSupplier accessTokenSupplier,
+            AuthType authType,
+            ListeningScheduledExecutorService exec,
+            ListenableFuture<KeyPair> keyPair) -> {
+          ListenableFuture<?> f =
+              exec.submit(
+                  () -> {
+                    throw new RuntimeException("always fails");
+                  });
+          f.get(); // this will throw an ExecutionException
+          return null;
+        };
+
+    CloudSqlInstance instance =
+        new CloudSqlInstance(
+            "a:b:c",
+            supplier,
+            AuthType.PASSWORD,
+            new TestCredentialFactory(),
+            executor,
+            keyPairFuture,
+            newRateLimiter());
+
+    Thread.sleep(500);
+    Assert.assertThrows(RuntimeException.class, () -> instance.getSslData());
+    // Note: refresh attempts will continue the background. This instance.getSslData() throws an
+    // exception after the first refresh attempt fails.
+  }
+
+  public void runConcurrencyTest() throws Exception {
+    MockAdminApi mockAdminApi = new MockAdminApi();
+    ListenableFuture<KeyPair> keyPairFuture =
+        Futures.immediateFuture(mockAdminApi.getClientKeyPair());
+    ListeningScheduledExecutorService executor = newTestExecutor();
+    TestDataSupplier supplier = new TestDataSupplier(true, executor);
+    CloudSqlInstance instance =
+        new CloudSqlInstance(
+            "a:b:c",
+            supplier,
+            AuthType.PASSWORD,
+            new TestCredentialFactory(),
+            executor,
+            keyPairFuture,
+            newRateLimiter());
+    assertThat(supplier.counter.get()).isEqualTo(0);
+
+    // Attempt to retrieve data, ensure we wait for success
+    ListenableFuture<List<Object>> allData =
+        Futures.allAsList(
+            executor.submit(instance::getSslData),
+            executor.submit(instance::getSslData),
+            executor.submit(instance::getSslData));
+
+    List<Object> d = allData.get();
+    assertThat(d.get(0)).isNotNull();
+    assertThat(d.get(1)).isNotNull();
+    assertThat(d.get(2)).isNotNull();
+    assertThat(supplier.counter.get()).isEqualTo(1);
+
+    for (int i = 0; i < 10; i++) {
+      // Call forceRefresh simultaneously
+      ListenableFuture<List<Object>> all =
+          Futures.allAsList(
+              executor.submit(instance::forceRefresh),
+              executor.submit(instance::forceRefresh),
+              executor.submit(instance::forceRefresh));
+      try {
+        all.get();
+      } catch (Exception e) {
+      }
+
+      ListenableFuture<List<Object>> allData2 =
+          Futures.allAsList(
+              executor.submit(instance::getSslData),
+              executor.submit(instance::getSslData),
+              executor.submit(instance::getSslData));
+      try {
+        allData2.get();
+      } catch (Exception e) {
+      }
+      assertThat(supplier.counter.get()).isEqualTo(2 + i);
+      Thread.sleep(100);
+    }
+  }
+
+  @Test
+  public void testForceRefreshDeadlock() throws Exception {
+    MockAdminApi mockAdminApi = new MockAdminApi();
+    ListenableFuture<KeyPair> keyPairFuture =
+        Futures.immediateFuture(mockAdminApi.getClientKeyPair());
+    ListeningScheduledExecutorService executor = newTestExecutor();
+    TestDataSupplier supplier = new TestDataSupplier(true, executor);
+    List<CloudSqlInstance> instances = new ArrayList<>();
+
+    final int instanceCount = 5;
+
+    for (int i = 0; i < instanceCount; i++) {
+      instances.add(
+          new CloudSqlInstance(
+              "a:b:instance" + i,
+              supplier,
+              AuthType.PASSWORD,
+              new TestCredentialFactory(),
+              executor,
+              keyPairFuture,
+              newRateLimiter()));
+    }
+
+    assertThat(supplier.counter.get()).isEqualTo(0);
+
+    // Get SSL Data for each instance, forcing the first refresh
+    instances.forEach(i -> i.getSslData());
+
+    assertThat(supplier.counter.get()).isEqualTo(instanceCount);
+
+    List<Thread> threads =
+        instances.stream()
+            .map(
+                (inst) -> {
+                  Thread t =
+                      new Thread(
+                          () -> {
+                            for (int i = 0; i < 50; i++) {
+                              try {
+                                inst.forceRefresh();
+                                inst.forceRefresh();
+                                Thread.yield();
+                                inst.forceRefresh();
+                                inst.getSslData();
+                                Thread.sleep(10);
+                              } catch (Exception e) {
+                                logger.info("Exception in force refresh loop.");
+                              }
+                            }
+                            logger.info("Done spamming");
+                          });
+                  t.setName("test-" + inst.getInstanceName());
+                  t.start();
+                  return t;
+                })
+            .collect(Collectors.toList());
+
+    for (Thread t : threads) {
+      t.join();
+    }
+
+    // Check if there is a scheduled future
+    int brokenLoop = 0;
+    for (CloudSqlInstance inst : instances) {
+      if (inst.getNext().isDone() && inst.getCurrent().isDone()) {
+        logger.warning("No future scheduled thing for instance " + inst.getInstanceName());
+        brokenLoop++;
+      }
+    }
+    assertThat(brokenLoop).isEqualTo(0);
+  }
+
+  private ListeningScheduledExecutorService newTestExecutor() {
+    ScheduledThreadPoolExecutor executor =
+        (ScheduledThreadPoolExecutor) Executors.newScheduledThreadPool(8);
+    executor.setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
+
+    //noinspection UnstableApiUsage
+    return MoreExecutors.listeningDecorator(
+        MoreExecutors.getExitingScheduledExecutorService(executor));
+  }
+
+  private RateLimiter<Object> newRateLimiter() {
+    return RateLimiter.burstyBuilder(2, Duration.ofMillis(50)).build();
+  }
+}

--- a/core/src/test/java/com/google/cloud/sql/core/CloudSqlInstanceConcurrencyTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/CloudSqlInstanceConcurrencyTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 Google LLC. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.cloud.sql.core;
 
 import static com.google.common.truth.Truth.assertThat;

--- a/core/src/test/java/com/google/cloud/sql/core/CloudSqlInstanceTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/CloudSqlInstanceTest.java
@@ -82,7 +82,8 @@ public class CloudSqlInstanceTest {
             AuthType.PASSWORD,
             stubCredentialFactory,
             executorService,
-            keyPairFuture);
+            keyPairFuture,
+            CloudSqlInstance.defaultRateLimiter());
 
     SslData gotSslData = instance.getSslData();
     assertThat(gotSslData).isSameInstanceAs(sslData);
@@ -105,7 +106,8 @@ public class CloudSqlInstanceTest {
             AuthType.PASSWORD,
             stubCredentialFactory,
             executorService,
-            keyPairFuture);
+            keyPairFuture,
+            CloudSqlInstance.defaultRateLimiter());
 
     RuntimeException ex = Assert.assertThrows(RuntimeException.class, instance::getSslData);
     assertThat(ex).hasMessageThat().contains("Fake connection error");
@@ -132,7 +134,8 @@ public class CloudSqlInstanceTest {
             AuthType.PASSWORD,
             stubCredentialFactory,
             executorService,
-            keyPairFuture);
+            keyPairFuture,
+            CloudSqlInstance.defaultRateLimiter());
 
     SslData gotSslData = instance.getSslData();
     assertThat(gotSslData).isSameInstanceAs(sslData);
@@ -171,7 +174,8 @@ public class CloudSqlInstanceTest {
             AuthType.PASSWORD,
             stubCredentialFactory,
             executorService,
-            keyPairFuture);
+            keyPairFuture,
+            CloudSqlInstance.defaultRateLimiter());
 
     assertThat(instance.getPreferredIp(Arrays.asList("PUBLIC", "PRIVATE"))).isEqualTo("10.1.2.3");
     assertThat(instance.getPreferredIp(Arrays.asList("PUBLIC"))).isEqualTo("10.1.2.3");
@@ -207,7 +211,8 @@ public class CloudSqlInstanceTest {
             AuthType.PASSWORD,
             stubCredentialFactory,
             executorService,
-            keyPairFuture);
+            keyPairFuture,
+            CloudSqlInstance.defaultRateLimiter());
     Assert.assertThrows(
         IllegalArgumentException.class, () -> instance.getPreferredIp(Arrays.asList("PRIVATE")));
   }

--- a/core/src/test/java/com/google/cloud/sql/core/CloudSqlInstanceTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/CloudSqlInstanceTest.java
@@ -23,9 +23,11 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
+import dev.failsafe.RateLimiter;
 import java.io.IOException;
 import java.security.KeyPair;
 import java.sql.Date;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
@@ -83,7 +85,7 @@ public class CloudSqlInstanceTest {
             stubCredentialFactory,
             executorService,
             keyPairFuture,
-            CloudSqlInstance.defaultRateLimiter());
+            RateLimiter.burstyBuilder(2, Duration.ofSeconds(30)).build());
 
     SslData gotSslData = instance.getSslData();
     assertThat(gotSslData).isSameInstanceAs(sslData);
@@ -107,7 +109,7 @@ public class CloudSqlInstanceTest {
             stubCredentialFactory,
             executorService,
             keyPairFuture,
-            CloudSqlInstance.defaultRateLimiter());
+            RateLimiter.burstyBuilder(2, Duration.ofSeconds(30)).build());
 
     RuntimeException ex = Assert.assertThrows(RuntimeException.class, instance::getSslData);
     assertThat(ex).hasMessageThat().contains("Fake connection error");
@@ -135,7 +137,7 @@ public class CloudSqlInstanceTest {
             stubCredentialFactory,
             executorService,
             keyPairFuture,
-            CloudSqlInstance.defaultRateLimiter());
+            RateLimiter.burstyBuilder(2, Duration.ofSeconds(30)).build());
 
     SslData gotSslData = instance.getSslData();
     assertThat(gotSslData).isSameInstanceAs(sslData);
@@ -175,7 +177,7 @@ public class CloudSqlInstanceTest {
             stubCredentialFactory,
             executorService,
             keyPairFuture,
-            CloudSqlInstance.defaultRateLimiter());
+            RateLimiter.burstyBuilder(2, Duration.ofSeconds(30)).build());
 
     assertThat(instance.getPreferredIp(Arrays.asList("PUBLIC", "PRIVATE"))).isEqualTo("10.1.2.3");
     assertThat(instance.getPreferredIp(Arrays.asList("PUBLIC"))).isEqualTo("10.1.2.3");
@@ -212,7 +214,7 @@ public class CloudSqlInstanceTest {
             stubCredentialFactory,
             executorService,
             keyPairFuture,
-            CloudSqlInstance.defaultRateLimiter());
+            RateLimiter.burstyBuilder(2, Duration.ofSeconds(30)).build());
     Assert.assertThrows(
         IllegalArgumentException.class, () -> instance.getPreferredIp(Arrays.asList("PRIVATE")));
   }

--- a/core/src/test/java/com/google/cloud/sql/core/CloudSqlInstanceTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/CloudSqlInstanceTest.java
@@ -24,14 +24,12 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import dev.failsafe.RateLimiter;
-import java.io.IOException;
 import java.security.KeyPair;
 import java.sql.Date;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -68,14 +66,8 @@ public class CloudSqlInstanceTest {
     SslData sslData = new SslData(null, null, null);
     InstanceData data =
         new InstanceData(null, sslData, Date.from(Instant.now().plus(1, ChronoUnit.HOURS)));
-    AtomicInteger refreshCount = new AtomicInteger();
 
-    InstanceDataSupplier instanceDataSupplier =
-        (instanceName, accessTokenSupplier, authType, executor, keyPair) -> {
-          Thread.sleep(100);
-          refreshCount.incrementAndGet();
-          return data;
-        };
+    TestDataSupplier instanceDataSupplier = new TestDataSupplier(false);
     // initialize instance after mocks are set up
     CloudSqlInstance instance =
         new CloudSqlInstance(
@@ -88,16 +80,26 @@ public class CloudSqlInstanceTest {
             RateLimiter.burstyBuilder(2, Duration.ofSeconds(30)).build());
 
     SslData gotSslData = instance.getSslData();
-    assertThat(gotSslData).isSameInstanceAs(sslData);
-    assertThat(refreshCount.get()).isEqualTo(1);
+    assertThat(gotSslData).isSameInstanceAs(instanceDataSupplier.response.getSslData());
+    assertThat(instanceDataSupplier.counter.get()).isEqualTo(1);
   }
 
   @Test
   public void testInstanceFailsOnConnectionError() throws Exception {
 
     InstanceDataSupplier instanceDataSupplier =
-        (instanceName, accessTokenSupplier, authType, executor, keyPair) -> {
-          throw new ExecutionException(new IOException("Fake connection error"));
+        (CloudSqlInstanceName instanceName,
+            AccessTokenSupplier accessTokenSupplier,
+            AuthType authType,
+            ListeningScheduledExecutorService exec,
+            ListenableFuture<KeyPair> keyPair) -> {
+          ListenableFuture<?> f =
+              exec.submit(
+                  () -> {
+                    throw new RuntimeException("always fails");
+                  });
+          f.get(); // this will throw an ExecutionException
+          return null;
         };
 
     // initialize instance after mocks are set up
@@ -112,7 +114,7 @@ public class CloudSqlInstanceTest {
             RateLimiter.burstyBuilder(2, Duration.ofSeconds(30)).build());
 
     RuntimeException ex = Assert.assertThrows(RuntimeException.class, instance::getSslData);
-    assertThat(ex).hasMessageThat().contains("Fake connection error");
+    assertThat(ex).hasMessageThat().contains("always fails");
   }
 
   @Test

--- a/core/src/test/java/com/google/cloud/sql/core/TestDataSupplier.java
+++ b/core/src/test/java/com/google/cloud/sql/core/TestDataSupplier.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 Google LLC. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.cloud.sql.core;
 
 import com.google.cloud.sql.AuthType;

--- a/core/src/test/java/com/google/cloud/sql/core/TestDataSupplier.java
+++ b/core/src/test/java/com/google/cloud/sql/core/TestDataSupplier.java
@@ -1,0 +1,63 @@
+package com.google.cloud.sql.core;
+
+import com.google.cloud.sql.AuthType;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningScheduledExecutorService;
+import java.security.KeyPair;
+import java.sql.Date;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+class TestDataSupplier implements InstanceDataSupplier {
+
+  volatile boolean flaky;
+
+  final AtomicInteger counter = new AtomicInteger();
+  final AtomicInteger successCounter = new AtomicInteger();
+  final InstanceData response =
+      new InstanceData(
+          new Metadata(
+              ImmutableMap.of(
+                  "PUBLIC", "10.1.2.3",
+                  "PRIVATE", "10.10.10.10",
+                  "PSC", "abcde.12345.us-central1.sql.goog"),
+              null),
+          new SslData(null, null, null),
+          Date.from(Instant.now().plus(1, ChronoUnit.HOURS)));
+
+  TestDataSupplier(boolean flaky) {
+    this.flaky = flaky;
+  }
+
+  @Override
+  public InstanceData getInstanceData(
+      CloudSqlInstanceName instanceName,
+      AccessTokenSupplier accessTokenSupplier,
+      AuthType authType,
+      ListeningScheduledExecutorService executor,
+      ListenableFuture<KeyPair> keyPair)
+      throws ExecutionException, InterruptedException {
+
+    // This method mimics the behavior of SqlAdminApiFetcher under flaky network conditions.
+    // It schedules a future on the executor to produces the result InstanceData.
+    // When `this.flaky` is set, every other call to getInstanceData()
+    // throw an ExecutionException, as if SqlAdminApiFetcher made an API request,
+    // and then failed.
+    ListenableFuture<InstanceData> f =
+        executor.submit(
+            () -> {
+              Thread.sleep(100);
+              int c = counter.incrementAndGet();
+              if (flaky && c % 2 == 0) {
+                throw new ExecutionException("Flaky", new Exception());
+              }
+              successCounter.incrementAndGet();
+              return response;
+            });
+
+    return f.get();
+  }
+}


### PR DESCRIPTION
Update the logic in forceRefresh() to reduce the churn on the thread pool when the certificate refresh API calls are failing. 

New forceRefresh() logic ensures that:

- Only 1 refresh cycle may run at a time. 
- If a refresh cycle is in progress, then it will not be canceled until it succeeds.

Add new test cases to validate race conditions, deadlocks, and concurrency.

Add additional logging to help diagnose production problems with certificate refresh.

Related to #1314

Fixes #1209 
Fixes #1159 