### PR TITLE
fix: Increase threadpool count to avoid deadlocks

### DIFF
--- a/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
@@ -122,7 +122,9 @@ public final class CoreSocketFactory {
   static ListeningScheduledExecutorService getDefaultExecutor() {
 
     // During refresh, each instance consumes 2 threads from the thread pool. By using 8 threads,
-    // there should be enough free threads so that there will not be a deadlock.
+    // there should be enough free threads so that there will not be a deadlock. Most users
+    // configure 3 or fewer instances, requiring 6 threads during refresh. By setting
+    // this to 8, it's enough threads for most users, plus a safety factor of 2.
     ScheduledThreadPoolExecutor executor =
         (ScheduledThreadPoolExecutor) Executors.newScheduledThreadPool(8);
 

--- a/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
@@ -122,7 +122,7 @@ public final class CoreSocketFactory {
   static ListeningScheduledExecutorService getDefaultExecutor() {
     // TODO(kvg): Figure out correct way to determine number of threads
     ScheduledThreadPoolExecutor executor =
-        (ScheduledThreadPoolExecutor) Executors.newScheduledThreadPool(2);
+        (ScheduledThreadPoolExecutor) Executors.newScheduledThreadPool(8);
     executor.setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
     return MoreExecutors.listeningDecorator(
         MoreExecutors.getExitingScheduledExecutorService(executor));

--- a/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
@@ -120,9 +120,12 @@ public final class CoreSocketFactory {
   @VisibleForTesting
   // Returns a listenable, scheduled executor that exits upon shutdown.
   static ListeningScheduledExecutorService getDefaultExecutor() {
-    // TODO(kvg): Figure out correct way to determine number of threads
+
+    // During refresh, each instance consumes 2 threads from the thread pool. By using 8 threads,
+    // there should be enough free threads so that there will not be a deadlock.
     ScheduledThreadPoolExecutor executor =
         (ScheduledThreadPoolExecutor) Executors.newScheduledThreadPool(8);
+
     executor.setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
     return MoreExecutors.listeningDecorator(
         MoreExecutors.getExitingScheduledExecutorService(executor));


### PR DESCRIPTION
To refresh a Cloud SQL Instance's certificates, the current algorithm uses 2 threads from the thread pool for each
instance. Because the thread pool is fixed size, if a user configures 2 or more instances, they were at risk of a causing
thread starvation and a deadlock. 

This increases the thread count to a safe level so that most users will never experience a deadlock.

Fixes #1314 