### PR TITLE
fix: Use guava rate limiter instead of dev.failsafe

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -130,12 +130,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>dev.failsafe</groupId>
-      <artifactId>failsafe</artifactId>
-      <version>3.3.2</version>
-    </dependency>
-
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.13.2</version>

--- a/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstance.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstance.java
@@ -23,9 +23,9 @@ import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
+import com.google.common.util.concurrent.RateLimiter;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
-import dev.failsafe.RateLimiter;
 import java.io.IOException;
 import java.security.KeyPair;
 import java.time.Instant;
@@ -56,7 +56,7 @@ class CloudSqlInstance {
   private final ListenableFuture<KeyPair> keyPair;
   private final Object instanceDataGuard = new Object();
   // Limit forced refreshes to 1 every minute.
-  private final RateLimiter<Object> forcedRenewRateLimiter;
+  private final RateLimiter forcedRenewRateLimiter;
 
   private final RefreshCalculator refreshCalculator = new RefreshCalculator();
 
@@ -84,7 +84,7 @@ class CloudSqlInstance {
       CredentialFactory tokenSourceFactory,
       ListeningScheduledExecutorService executor,
       ListenableFuture<KeyPair> keyPair,
-      RateLimiter<Object> forcedRenewRateLimiter) {
+      RateLimiter forcedRenewRateLimiter) {
     this.instanceName = new CloudSqlInstanceName(connectionName);
     this.instanceDataSupplier = instanceDataSupplier;
     this.authType = authType;
@@ -189,7 +189,7 @@ class CloudSqlInstance {
     logger.fine(
         String.format("[%s] Refresh Operation: Acquiring rate limiter permit.", instanceName));
     // To avoid unreasonable SQL Admin API usage, use a rate limit to throttle our usage.
-    forcedRenewRateLimiter.acquirePermit();
+    forcedRenewRateLimiter.acquire();
     logger.fine(
         String.format(
             "[%s] Refresh Operation: Acquired rate limiter permit. Starting refresh...",

--- a/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
@@ -24,7 +24,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
-import dev.failsafe.RateLimiter;
+import com.google.common.util.concurrent.RateLimiter;
 import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -32,7 +32,6 @@ import java.net.Socket;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
@@ -359,6 +358,6 @@ public final class CoreSocketFactory {
                 credentialFactory,
                 executor,
                 localKeyPair,
-                RateLimiter.burstyBuilder(2, Duration.ofSeconds(30)).build()));
+                RateLimiter.create(1.0 / 30.0))); // 1 refresh attempt every 30 seconds
   }
 }

--- a/core/src/test/java/com/google/cloud/sql/core/CloudSqlInstanceConcurrencyTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/CloudSqlInstanceConcurrencyTest.java
@@ -25,10 +25,9 @@ import com.google.cloud.sql.CredentialFactory;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
-import dev.failsafe.RateLimiter;
+import com.google.common.util.concurrent.RateLimiter;
 import java.io.IOException;
 import java.security.KeyPair;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -214,7 +213,7 @@ public class CloudSqlInstanceConcurrencyTest {
     return t;
   }
 
-  private RateLimiter<Object> newRateLimiter() {
-    return RateLimiter.burstyBuilder(2, Duration.ofMillis(50)).build();
+  private RateLimiter newRateLimiter() {
+    return RateLimiter.create(20.0); // 20/sec = every 50 ms
   }
 }

--- a/core/src/test/java/com/google/cloud/sql/core/CloudSqlInstanceTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/CloudSqlInstanceTest.java
@@ -23,10 +23,9 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
-import dev.failsafe.RateLimiter;
+import com.google.common.util.concurrent.RateLimiter;
 import java.security.KeyPair;
 import java.sql.Date;
-import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
@@ -77,7 +76,7 @@ public class CloudSqlInstanceTest {
             stubCredentialFactory,
             executorService,
             keyPairFuture,
-            RateLimiter.burstyBuilder(2, Duration.ofSeconds(30)).build());
+            RateLimiter.create(1.0 / 30.0));
 
     SslData gotSslData = instance.getSslData();
     assertThat(gotSslData).isSameInstanceAs(instanceDataSupplier.response.getSslData());
@@ -111,7 +110,7 @@ public class CloudSqlInstanceTest {
             stubCredentialFactory,
             executorService,
             keyPairFuture,
-            RateLimiter.burstyBuilder(2, Duration.ofSeconds(30)).build());
+            RateLimiter.create(1.0 / 30.0));
 
     RuntimeException ex = Assert.assertThrows(RuntimeException.class, instance::getSslData);
     assertThat(ex).hasMessageThat().contains("always fails");
@@ -139,7 +138,7 @@ public class CloudSqlInstanceTest {
             stubCredentialFactory,
             executorService,
             keyPairFuture,
-            RateLimiter.burstyBuilder(2, Duration.ofSeconds(30)).build());
+            RateLimiter.create(1.0 / 30.0));
 
     SslData gotSslData = instance.getSslData();
     assertThat(gotSslData).isSameInstanceAs(sslData);
@@ -179,7 +178,7 @@ public class CloudSqlInstanceTest {
             stubCredentialFactory,
             executorService,
             keyPairFuture,
-            RateLimiter.burstyBuilder(2, Duration.ofSeconds(30)).build());
+            RateLimiter.create(1.0 / 30.0));
 
     assertThat(instance.getPreferredIp(Arrays.asList("PUBLIC", "PRIVATE"))).isEqualTo("10.1.2.3");
     assertThat(instance.getPreferredIp(Arrays.asList("PUBLIC"))).isEqualTo("10.1.2.3");
@@ -216,7 +215,7 @@ public class CloudSqlInstanceTest {
             stubCredentialFactory,
             executorService,
             keyPairFuture,
-            RateLimiter.burstyBuilder(2, Duration.ofSeconds(30)).build());
+            RateLimiter.create(1.0 / 30.0));
     Assert.assertThrows(
         IllegalArgumentException.class, () -> instance.getPreferredIp(Arrays.asList("PRIVATE")));
   }


### PR DESCRIPTION
For simplicity, we are removing the library dev.failsafe and using a rate limiter already included in 
the Guava library instead.