### PR TITLE
fix: Eliminate busy wait inside of the CloudSqlInstance.performRefresh().

### DIFF
--- a/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
@@ -32,6 +32,7 @@ import java.net.Socket;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
@@ -218,7 +219,7 @@ public final class CoreSocketFactory {
     return getInstance().getHostIp(csqlInstanceName, listIpTypes(ipTypes));
   }
 
-  private String getHostIp(String instanceName, List<String> ipTypes) {
+  private String getHostIp(String instanceName, List<String> ipTypes) throws IOException {
     CloudSqlInstance instance = getCloudSqlInstance(instanceName, AuthType.PASSWORD);
     return instance.getPreferredIp(ipTypes);
   }
@@ -358,6 +359,7 @@ public final class CoreSocketFactory {
                 credentialFactory,
                 executor,
                 localKeyPair,
-                RateLimiter.create(1.0 / 30.0))); // 1 refresh attempt every 30 seconds
+                RateLimiter.create(1.0 / 30.0),
+                Duration.ofSeconds(30)));
   }
 }

--- a/core/src/main/java/com/google/cloud/sql/core/InstanceDataSupplier.java
+++ b/core/src/main/java/com/google/cloud/sql/core/InstanceDataSupplier.java
@@ -30,11 +30,10 @@ interface InstanceDataSupplier {
    * @throws ExecutionException if an exception is thrown during execution.
    * @throws InterruptedException if the executor is interrupted.
    */
-  InstanceData getInstanceData(
+  ListenableFuture<InstanceData> getInstanceData(
       CloudSqlInstanceName instanceName,
       AccessTokenSupplier accessTokenSupplier,
       AuthType authType,
       ListeningScheduledExecutorService executor,
-      ListenableFuture<KeyPair> keyPair)
-      throws ExecutionException, InterruptedException;
+      ListenableFuture<KeyPair> keyPair);
 }

--- a/core/src/main/java/com/google/cloud/sql/core/InstanceDataTimeoutException.java
+++ b/core/src/main/java/com/google/cloud/sql/core/InstanceDataTimeoutException.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 Google LLC. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.sql.core;
+
+import java.io.IOException;
+
+/**
+ * Thrown when the InstanceData refresh operation does not complete within the configured timeout
+ * period.
+ */
+public class InstanceDataTimeoutException extends IOException {
+
+  public InstanceDataTimeoutException(String message) {
+    super(message);
+  }
+
+  public InstanceDataTimeoutException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/core/src/main/java/com/google/cloud/sql/core/SqlAdminApiFetcher.java
+++ b/core/src/main/java/com/google/cloud/sql/core/SqlAdminApiFetcher.java
@@ -95,13 +95,12 @@ class SqlAdminApiFetcher implements InstanceDataSupplier {
    * @throws InterruptedException if the executor is interrupted.
    */
   @Override
-  public InstanceData getInstanceData(
+  public ListenableFuture<InstanceData> getInstanceData(
       CloudSqlInstanceName instanceName,
       AccessTokenSupplier accessTokenSupplier,
       AuthType authType,
       ListeningScheduledExecutorService executor,
-      ListenableFuture<KeyPair> keyPair)
-      throws ExecutionException, InterruptedException {
+      ListenableFuture<KeyPair> keyPair) {
 
     ListenableFuture<Optional<AccessToken>> token = executor.submit(accessTokenSupplier::get);
 
@@ -160,9 +159,10 @@ class SqlAdminApiFetcher implements InstanceDataSupplier {
                 },
                 executor);
 
-    InstanceData instanceData = done.get();
-    logger.fine(String.format("[%s] ALL FUTURES DONE", instanceName));
-    return instanceData;
+    done.addListener(
+        () -> logger.fine(String.format("[%s] ALL FUTURES DONE", instanceName)), executor);
+
+    return done;
   }
 
   String getApplicationName() {

--- a/core/src/test/java/com/google/cloud/sql/core/SqlAdminApiFetcherTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/SqlAdminApiFetcherTest.java
@@ -54,12 +54,14 @@ public class SqlAdminApiFetcherTest {
             .create(new StubCredentialFactory().create());
 
     InstanceData instanceData =
-        fetcher.getInstanceData(
-            new CloudSqlInstanceName(INSTANCE_CONNECTION_NAME),
-            () -> Optional.empty(),
-            AuthType.PASSWORD,
-            newTestExecutor(),
-            Futures.immediateFuture(mockAdminApi.getClientKeyPair()));
+        fetcher
+            .getInstanceData(
+                new CloudSqlInstanceName(INSTANCE_CONNECTION_NAME),
+                () -> Optional.empty(),
+                AuthType.PASSWORD,
+                newTestExecutor(),
+                Futures.immediateFuture(mockAdminApi.getClientKeyPair()))
+            .get();
     assertThat(instanceData.getSslContext()).isInstanceOf(SSLContext.class);
 
     Map<String, String> ipAddrs = instanceData.getIpAddrs();
@@ -83,12 +85,14 @@ public class SqlAdminApiFetcherTest {
             .create(new StubCredentialFactory().create());
 
     InstanceData instanceData =
-        fetcher.getInstanceData(
-            new CloudSqlInstanceName(INSTANCE_CONNECTION_NAME),
-            () -> Optional.empty(),
-            AuthType.PASSWORD,
-            newTestExecutor(),
-            Futures.immediateFuture(mockAdminApi.getClientKeyPair()));
+        fetcher
+            .getInstanceData(
+                new CloudSqlInstanceName(INSTANCE_CONNECTION_NAME),
+                () -> Optional.empty(),
+                AuthType.PASSWORD,
+                newTestExecutor(),
+                Futures.immediateFuture(mockAdminApi.getClientKeyPair()))
+            .get();
     assertThat(instanceData.getSslContext()).isInstanceOf(SSLContext.class);
 
     Map<String, String> ipAddrs = instanceData.getIpAddrs();

--- a/core/src/test/java/com/google/cloud/sql/core/TestDataSupplier.java
+++ b/core/src/test/java/com/google/cloud/sql/core/TestDataSupplier.java
@@ -49,13 +49,12 @@ class TestDataSupplier implements InstanceDataSupplier {
   }
 
   @Override
-  public InstanceData getInstanceData(
+  public ListenableFuture<InstanceData> getInstanceData(
       CloudSqlInstanceName instanceName,
       AccessTokenSupplier accessTokenSupplier,
       AuthType authType,
       ListeningScheduledExecutorService executor,
-      ListenableFuture<KeyPair> keyPair)
-      throws ExecutionException, InterruptedException {
+      ListenableFuture<KeyPair> keyPair) {
 
     // This method mimics the behavior of SqlAdminApiFetcher under flaky network conditions.
     // It schedules a future on the executor to produces the result InstanceData.
@@ -74,6 +73,6 @@ class TestDataSupplier implements InstanceDataSupplier {
               return response;
             });
 
-    return f.get();
+    return f;
   }
 }


### PR DESCRIPTION
Instead of blocking until SqlAdminApiFetcher.getInstance() completes, CloudSqlInstance.performRefresh() will
listen for completion of the future and then update its internal state. This uses the threads in the
thread pool more efficiently, so that fewer threads are needed for the process to run smoothly.
