### PR TITLE
chore: Remove coupling in user agent logic to SqlAdminApiFetcher 

### DIFF
--- a/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
@@ -280,13 +280,14 @@ public final class CoreSocketFactory {
     }
   }
 
-  /** Resets the values of User Agent fields */
+  /** Resets the values of User Agent fields. */
   @VisibleForTesting
   static void resetUserAgent() {
     coreSocketFactory = null;
     userAgents.clear();
     setApplicationName("");
   }
+
   /** Returns the default string which is appended to the SQLAdmin API client User-Agent header. */
   static String getUserAgents() {
     String ua = String.join(" ", userAgents);

--- a/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
@@ -21,6 +21,7 @@ import com.google.cloud.sql.AuthType;
 import com.google.cloud.sql.CredentialFactory;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
@@ -279,16 +280,25 @@ public final class CoreSocketFactory {
     }
   }
 
+  /** Resets the values of User Agent fields */
+  @VisibleForTesting
+  static void resetUserAgent() {
+    coreSocketFactory = null;
+    userAgents.clear();
+    setApplicationName("");
+  }
   /** Returns the default string which is appended to the SQLAdmin API client User-Agent header. */
-  private static String getUserAgents() {
-    return String.join(" ", userAgents) + " " + getApplicationName();
+  static String getUserAgents() {
+    String ua = String.join(" ", userAgents);
+    String appName = getApplicationName();
+    if (!Strings.isNullOrEmpty(appName)) {
+      ua = ua + " " + appName;
+    }
+    return ua;
   }
 
   /** Returns the current User-Agent header set for the underlying SQLAdmin API client. */
   private static String getApplicationName() {
-    if (coreSocketFactory != null) {
-      return coreSocketFactory.adminApiService.getApplicationName();
-    }
     return System.getProperty(USER_TOKEN_PROPERTY_NAME, "");
   }
 

--- a/core/src/test/java/com/google/cloud/sql/core/CoreSocketFactoryTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/CoreSocketFactoryTest.java
@@ -270,6 +270,24 @@ public class CoreSocketFactoryTest extends CloudSqlCoreTestingBase {
                 AuthType.IAM));
   }
 
+  @Test
+  public void testGetApplicationNameWithApplicationName() {
+    CoreSocketFactory.resetUserAgent();
+    CoreSocketFactory.setApplicationName("sample-app");
+    CoreSocketFactory.addArtifactId("unit-test");
+    CoreSocketFactory.getInstance();
+    assertThat(CoreSocketFactory.getUserAgents()).startsWith("unit-test/");
+    assertThat(CoreSocketFactory.getUserAgents()).endsWith(" sample-app");
+  }
+
+  @Test
+  public void testGetApplicationNameFailsAfterInitialization() {
+    CoreSocketFactory.resetUserAgent();
+    CoreSocketFactory.getInstance();
+    assertThrows(
+        IllegalStateException.class, () -> CoreSocketFactory.setApplicationName("sample-app"));
+  }
+
   private String readLine(Socket socket) throws IOException {
     BufferedReader bufferedReader =
         new BufferedReader(new InputStreamReader(socket.getInputStream(), UTF_8));


### PR DESCRIPTION
This removes circular dependencies between the user agent calculation and the SqlAdminApiFetcher. This is necessary 
because to implement of #1168, CoreSocketFactory must change from using a single instance of SqlAdminApiFetcher 
for all Cloud SQL instances to having an instance of SqlAdminApiFetcher per Cloud SQL instance. 

Related to #1168