### PR TITLE
feat: Add support for service account impersonation.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -100,6 +100,7 @@ jobs:
           SQLSERVER_USER:${{ secrets.GOOGLE_CLOUD_PROJECT }}/SQLSERVER_USER
           SQLSERVER_PASS:${{ secrets.GOOGLE_CLOUD_PROJECT }}/SQLSERVER_PASS
           SQLSERVER_DB:${{ secrets.GOOGLE_CLOUD_PROJECT }}/SQLSERVER_DB
+          IMPERSONATED_USER:${{ secrets.GOOGLE_CLOUD_PROJECT }}/IMPERSONATED_USER
     - name: Run tests
       env:
         MYSQL_CONNECTION_NAME: '${{ steps.secrets.outputs.MYSQL_CONNECTION_NAME }}'
@@ -118,6 +119,7 @@ jobs:
         SQLSERVER_USER: '${{ steps.secrets.outputs.SQLSERVER_USER }}'
         SQLSERVER_PASS: '${{ steps.secrets.outputs.SQLSERVER_PASS }}'
         SQLSERVER_DB: '${{ steps.secrets.outputs.SQLSERVER_DB }}'
+        IMPERSONATED_USER: '${{ steps.secrets.outputs.IMPERSONATED_USER }}'
       run: ./.github/scripts/run_tests.sh
       shell: bash
     - name: FlakyBot (Linux)
@@ -224,6 +226,7 @@ jobs:
           SQLSERVER_USER:${{ secrets.GOOGLE_CLOUD_PROJECT }}/SQLSERVER_USER
           SQLSERVER_PASS:${{ secrets.GOOGLE_CLOUD_PROJECT }}/SQLSERVER_PASS
           SQLSERVER_DB:${{ secrets.GOOGLE_CLOUD_PROJECT }}/SQLSERVER_DB
+          IMPERSONATED_USER:${{ secrets.GOOGLE_CLOUD_PROJECT }}/IMPERSONATED_USER
     - name: Run tests
       env:
         MYSQL_CONNECTION_NAME: '${{ steps.secrets.outputs.MYSQL_CONNECTION_NAME }}'
@@ -242,6 +245,7 @@ jobs:
         SQLSERVER_USER: '${{ steps.secrets.outputs.SQLSERVER_USER }}'
         SQLSERVER_PASS: '${{ steps.secrets.outputs.SQLSERVER_PASS }}'
         SQLSERVER_DB: '${{ steps.secrets.outputs.SQLSERVER_DB }}'
+        IMPERSONATED_USER: '${{ steps.secrets.outputs.IMPERSONATED_USER }}'
       run: ./.github/scripts/run_tests.sh
       shell: bash
     - name: FlakyBot (Linux)
@@ -334,6 +338,7 @@ jobs:
           SQLSERVER_USER:${{ secrets.GOOGLE_CLOUD_PROJECT }}/SQLSERVER_USER
           SQLSERVER_PASS:${{ secrets.GOOGLE_CLOUD_PROJECT }}/SQLSERVER_PASS
           SQLSERVER_DB:${{ secrets.GOOGLE_CLOUD_PROJECT }}/SQLSERVER_DB
+          IMPERSONATED_USER:${{ secrets.GOOGLE_CLOUD_PROJECT }}/IMPERSONATED_USER
 
     - name: Run tests
       env:
@@ -353,6 +358,7 @@ jobs:
         SQLSERVER_USER: '${{ steps.secrets.outputs.SQLSERVER_USER }}'
         SQLSERVER_PASS: '${{ steps.secrets.outputs.SQLSERVER_PASS }}'
         SQLSERVER_DB: '${{ steps.secrets.outputs.SQLSERVER_DB }}'
+        IMPERSONATED_USER: '${{ steps.secrets.outputs.IMPERSONATED_USER }}'
       run: ./.github/scripts/run_tests_graalvm_native.sh
       shell: bash
     - name: FlakyBot

--- a/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
@@ -34,6 +34,8 @@ import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
@@ -56,6 +58,7 @@ import jnr.unixsocket.UnixSocketChannel;
 public final class CoreSocketFactory {
 
   public static final String CLOUD_SQL_INSTANCE_PROPERTY = "cloudSqlInstance";
+  public static final String CLOUD_SQL_DELEGATES_PROPERTY = "delegates";
 
   /**
    * Property used to set the application name for the underlying SQLAdmin client.
@@ -173,6 +176,13 @@ public final class CoreSocketFactory {
     // Gather parameters
     final String csqlInstanceName = props.getProperty(CLOUD_SQL_INSTANCE_PROPERTY);
     final boolean enableIamAuth = Boolean.parseBoolean(props.getProperty("enableIamAuth"));
+    final String delegatesStr = props.getProperty(CLOUD_SQL_DELEGATES_PROPERTY);
+    final List<String> delegates;
+    if (delegatesStr != null && !delegatesStr.isEmpty()) {
+      delegates = Arrays.asList(delegatesStr.split(","));
+    } else {
+      delegates = Collections.emptyList();
+    }
 
     // Validate parameters
     Preconditions.checkArgument(
@@ -197,27 +207,32 @@ public final class CoreSocketFactory {
 
     final List<String> ipTypes = listIpTypes(props.getProperty("ipTypes", DEFAULT_IP_TYPES));
     if (enableIamAuth) {
-      return getInstance().createSslSocket(csqlInstanceName, ipTypes, AuthType.IAM);
+      return getInstance().createSslSocket(csqlInstanceName, ipTypes, AuthType.IAM, delegates);
     }
-    return getInstance().createSslSocket(csqlInstanceName, ipTypes, AuthType.PASSWORD);
+    return getInstance().createSslSocket(csqlInstanceName, ipTypes, AuthType.PASSWORD, delegates);
   }
 
   /** Returns data that can be used to establish Cloud SQL SSL connection. */
-  public static SslData getSslData(String csqlInstanceName, boolean enableIamAuth)
-      throws IOException {
+  public static SslData getSslData(
+      String csqlInstanceName, boolean enableIamAuth, List<String> delegates) throws IOException {
     if (enableIamAuth) {
-      return getInstance().getCloudSqlInstance(csqlInstanceName, AuthType.IAM).getSslData();
+      return getInstance()
+          .getCloudSqlInstance(csqlInstanceName, AuthType.IAM, delegates)
+          .getSslData();
     }
-    return getInstance().getCloudSqlInstance(csqlInstanceName, AuthType.PASSWORD).getSslData();
+    return getInstance()
+        .getCloudSqlInstance(csqlInstanceName, AuthType.PASSWORD, delegates)
+        .getSslData();
   }
 
   /** Returns preferred ip address that can be used to establish Cloud SQL connection. */
-  public static String getHostIp(String csqlInstanceName, String ipTypes) throws IOException {
-    return getInstance().getHostIp(csqlInstanceName, listIpTypes(ipTypes));
+  public static String getHostIp(String csqlInstanceName, String ipTypes, List<String> delegates)
+      throws IOException {
+    return getInstance().getHostIp(csqlInstanceName, listIpTypes(ipTypes), delegates);
   }
 
-  private String getHostIp(String instanceName, List<String> ipTypes) {
-    CloudSqlInstance instance = getCloudSqlInstance(instanceName, AuthType.PASSWORD);
+  private String getHostIp(String instanceName, List<String> ipTypes, List<String> delegates) {
+    CloudSqlInstance instance = getCloudSqlInstance(instanceName, AuthType.PASSWORD, delegates);
     return instance.getPreferredIp(ipTypes);
   }
 
@@ -324,9 +339,10 @@ public final class CoreSocketFactory {
    */
   // TODO(berezv): separate creating socket and performing connection to make it easier to test
   @VisibleForTesting
-  Socket createSslSocket(String instanceName, List<String> ipTypes, AuthType authType)
+  Socket createSslSocket(
+      String instanceName, List<String> ipTypes, AuthType authType, List<String> delegates)
       throws IOException, InterruptedException {
-    CloudSqlInstance instance = getCloudSqlInstance(instanceName, authType);
+    CloudSqlInstance instance = getCloudSqlInstance(instanceName, authType, delegates);
 
     try {
       SSLSocket socket = instance.createSslSocket();
@@ -349,20 +365,30 @@ public final class CoreSocketFactory {
     }
   }
 
-  private CloudSqlInstance getCloudSqlInstance(String instanceName, AuthType authType) {
-    return instances.computeIfAbsent(instanceName, k -> apiFetcher(k, authType));
+  private CloudSqlInstance getCloudSqlInstance(
+      String instanceName, AuthType authType, List<String> delegates) {
+    return instances.computeIfAbsent(instanceName, k -> apiFetcher(k, authType, delegates));
   }
 
-  private CloudSqlInstance apiFetcher(String instanceName, AuthType authType) {
+  private CloudSqlInstance apiFetcher(
+      String instanceName, AuthType authType, List<String> delegates) {
 
-    HttpRequestInitializer credential = credentialFactory.create();
+    final CredentialFactory instanceCredentialFactory;
+    if (delegates != null && !delegates.isEmpty()) {
+      instanceCredentialFactory =
+          new ServiceAccountImpersonatingCredentialFactory(credentialFactory, delegates);
+    } else {
+      instanceCredentialFactory = credentialFactory;
+    }
+
+    HttpRequestInitializer credential = instanceCredentialFactory.create();
     SqlAdminApiFetcher adminApi = apiFetcherFactory.create(credential);
 
     return new CloudSqlInstance(
         instanceName,
         adminApi,
         authType,
-        credentialFactory,
+        instanceCredentialFactory,
         executor,
         localKeyPair,
         RateLimiter.create(1.0 / 30.0)); // 1 refresh attempt every 30 seconds

--- a/core/src/test/java/com/google/cloud/sql/CredentialFactoryTest.java
+++ b/core/src/test/java/com/google/cloud/sql/CredentialFactoryTest.java
@@ -33,6 +33,7 @@ import com.google.auth.oauth2.GoogleCredentials;
 import com.google.auth.oauth2.OAuth2Credentials;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import org.junit.Test;
 
 public class CredentialFactoryTest {
@@ -82,8 +83,9 @@ public class CredentialFactoryTest {
                       @Override
                       public LowLevelHttpResponse execute() throws IOException {
                         MockLowLevelHttpResponse response = new MockLowLevelHttpResponse();
-                        response.setHeaderNames(Arrays.asList("WWW-Authenticate"));
-                        response.setHeaderValues(Arrays.asList("Bearer my-refreshed-token"));
+                        response.setHeaderNames(Collections.singletonList("WWW-Authenticate"));
+                        response.setHeaderValues(
+                            Collections.singletonList("Bearer my-refreshed-token"));
 
                         return response;
                       }

--- a/core/src/test/java/com/google/cloud/sql/CredentialFactoryTest.java
+++ b/core/src/test/java/com/google/cloud/sql/CredentialFactoryTest.java
@@ -32,7 +32,6 @@ import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.auth.oauth2.OAuth2Credentials;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collections;
 import org.junit.Test;
 

--- a/core/src/test/java/com/google/cloud/sql/core/CloudSqlInstanceTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/CloudSqlInstanceTest.java
@@ -185,7 +185,8 @@ public class CloudSqlInstanceTest {
     assertThat(instance.getPreferredIp(Collections.singletonList("PUBLIC"))).isEqualTo("10.1.2.3");
     assertThat(instance.getPreferredIp(Arrays.asList("PRIVATE", "PUBLIC")))
         .isEqualTo("10.10.10.10");
-    assertThat(instance.getPreferredIp(Collections.singletonList("PRIVATE"))).isEqualTo("10.10.10.10");
+    assertThat(instance.getPreferredIp(Collections.singletonList("PRIVATE")))
+        .isEqualTo("10.10.10.10");
     assertThat(instance.getPreferredIp(Collections.singletonList("PSC")))
         .isEqualTo("abcde.12345.us-central1.sql.goog");
   }
@@ -218,8 +219,8 @@ public class CloudSqlInstanceTest {
             keyPairFuture,
             RateLimiter.create(1.0 / 30.0));
     Assert.assertThrows(
-        IllegalArgumentException.class, () -> instance.getPreferredIp(
-            Collections.singletonList("PRIVATE")));
+        IllegalArgumentException.class,
+        () -> instance.getPreferredIp(Collections.singletonList("PRIVATE")));
   }
 
   private ListeningScheduledExecutorService newTestExecutor() {

--- a/core/src/test/java/com/google/cloud/sql/core/CloudSqlInstanceTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/CloudSqlInstanceTest.java
@@ -29,6 +29,7 @@ import java.sql.Date;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -45,7 +46,7 @@ public class CloudSqlInstanceTest {
   private ListeningScheduledExecutorService executorService;
   private ListenableFuture<KeyPair> keyPairFuture;
 
-  private StubCredentialFactory stubCredentialFactory =
+  private final StubCredentialFactory stubCredentialFactory =
       new StubCredentialFactory("my-token", System.currentTimeMillis() + 3600L);
 
   @Before
@@ -181,11 +182,11 @@ public class CloudSqlInstanceTest {
             RateLimiter.create(1.0 / 30.0));
 
     assertThat(instance.getPreferredIp(Arrays.asList("PUBLIC", "PRIVATE"))).isEqualTo("10.1.2.3");
-    assertThat(instance.getPreferredIp(Arrays.asList("PUBLIC"))).isEqualTo("10.1.2.3");
+    assertThat(instance.getPreferredIp(Collections.singletonList("PUBLIC"))).isEqualTo("10.1.2.3");
     assertThat(instance.getPreferredIp(Arrays.asList("PRIVATE", "PUBLIC")))
         .isEqualTo("10.10.10.10");
-    assertThat(instance.getPreferredIp(Arrays.asList("PRIVATE"))).isEqualTo("10.10.10.10");
-    assertThat(instance.getPreferredIp(Arrays.asList("PSC")))
+    assertThat(instance.getPreferredIp(Collections.singletonList("PRIVATE"))).isEqualTo("10.10.10.10");
+    assertThat(instance.getPreferredIp(Collections.singletonList("PSC")))
         .isEqualTo("abcde.12345.us-central1.sql.goog");
   }
 
@@ -217,7 +218,8 @@ public class CloudSqlInstanceTest {
             keyPairFuture,
             RateLimiter.create(1.0 / 30.0));
     Assert.assertThrows(
-        IllegalArgumentException.class, () -> instance.getPreferredIp(Arrays.asList("PRIVATE")));
+        IllegalArgumentException.class, () -> instance.getPreferredIp(
+            Collections.singletonList("PRIVATE")));
   }
 
   private ListeningScheduledExecutorService newTestExecutor() {

--- a/core/src/test/java/com/google/cloud/sql/core/CoreSocketFactoryTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/CoreSocketFactoryTest.java
@@ -64,7 +64,10 @@ public class CoreSocketFactoryTest extends CloudSqlCoreTestingBase {
         new CoreSocketFactory(clientKeyPair, factory, credentialFactory, 3307, defaultExecutor);
     try {
       coreSocketFactory.createSslSocket(
-          "myProject", Collections.singletonList("PRIMARY"), AuthType.PASSWORD);
+          "myProject",
+          Collections.singletonList("PRIMARY"),
+          AuthType.PASSWORD,
+          Collections.emptyList());
       fail();
     } catch (IllegalArgumentException | InterruptedException e) {
       assertThat(e).hasMessageThat().contains("Cloud SQL connection name is invalid");
@@ -72,7 +75,10 @@ public class CoreSocketFactoryTest extends CloudSqlCoreTestingBase {
 
     try {
       coreSocketFactory.createSslSocket(
-          "myProject:myRegion", Collections.singletonList("PRIMARY"), AuthType.PASSWORD);
+          "myProject:myRegion",
+          Collections.singletonList("PRIMARY"),
+          AuthType.PASSWORD,
+          Collections.emptyList());
       fail();
     } catch (IllegalArgumentException e) {
       assertThat(e).hasMessageThat().contains("Cloud SQL connection name is invalid");
@@ -91,7 +97,8 @@ public class CoreSocketFactoryTest extends CloudSqlCoreTestingBase {
       coreSocketFactory.createSslSocket(
           "myProject:notMyRegion:myInstance",
           Collections.singletonList("PRIMARY"),
-          AuthType.PASSWORD);
+          AuthType.PASSWORD,
+          Collections.emptyList());
       fail();
     } catch (RuntimeException e) {
       assertThat(e)
@@ -119,7 +126,8 @@ public class CoreSocketFactoryTest extends CloudSqlCoreTestingBase {
         coreSocketFactory.createSslSocket(
             "myProject:myRegion:myInstance",
             Collections.singletonList("PRIVATE"),
-            AuthType.PASSWORD);
+            AuthType.PASSWORD,
+            Collections.emptyList());
 
     assertThat(readLine(socket)).isEqualTo(SERVER_MESSAGE);
   }
@@ -137,7 +145,8 @@ public class CoreSocketFactoryTest extends CloudSqlCoreTestingBase {
         coreSocketFactory.createSslSocket(
             "myProject:myRegion:myInstance",
             Collections.singletonList("PRIMARY"),
-            AuthType.PASSWORD);
+            AuthType.PASSWORD,
+            Collections.emptyList());
 
     assertThat(readLine(socket)).isEqualTo(SERVER_MESSAGE);
   }
@@ -155,7 +164,8 @@ public class CoreSocketFactoryTest extends CloudSqlCoreTestingBase {
         coreSocketFactory.createSslSocket(
             "example.com:myProject:myRegion:myInstance",
             Collections.singletonList("PRIMARY"),
-            AuthType.PASSWORD);
+            AuthType.PASSWORD,
+            Collections.emptyList());
     assertThat(readLine(socket)).isEqualTo(SERVER_MESSAGE);
   }
 
@@ -169,7 +179,8 @@ public class CoreSocketFactoryTest extends CloudSqlCoreTestingBase {
       coreSocketFactory.createSslSocket(
           "NotMyProject:myRegion:myInstance",
           Collections.singletonList("PRIMARY"),
-          AuthType.PASSWORD);
+          AuthType.PASSWORD,
+          Collections.emptyList());
       fail("Expected RuntimeException");
     } catch (RuntimeException | InterruptedException e) {
       assertThat(e)
@@ -191,7 +202,8 @@ public class CoreSocketFactoryTest extends CloudSqlCoreTestingBase {
       coreSocketFactory.createSslSocket(
           "myProject:myRegion:NotMyInstance",
           Collections.singletonList("PRIMARY"),
-          AuthType.PASSWORD);
+          AuthType.PASSWORD,
+          Collections.emptyList());
       fail();
     } catch (RuntimeException e) {
       assertThat(e)
@@ -220,7 +232,10 @@ public class CoreSocketFactoryTest extends CloudSqlCoreTestingBase {
         new CoreSocketFactory(clientKeyPair, factory, stubCredentialFactory, port, defaultExecutor);
     Socket socket =
         coreSocketFactory.createSslSocket(
-            "myProject:myRegion:myInstance", Collections.singletonList("PRIMARY"), AuthType.IAM);
+            "myProject:myRegion:myInstance",
+            Collections.singletonList("PRIMARY"),
+            AuthType.IAM,
+            Collections.emptyList());
 
     assertThat(readLine(socket)).isEqualTo(SERVER_MESSAGE);
   }
@@ -239,7 +254,10 @@ public class CoreSocketFactoryTest extends CloudSqlCoreTestingBase {
         new CoreSocketFactory(clientKeyPair, factory, stubCredentialFactory, port, defaultExecutor);
     Socket socket =
         coreSocketFactory.createSslSocket(
-            "myProject:myRegion:myInstance", Collections.singletonList("PRIMARY"), AuthType.IAM);
+            "myProject:myRegion:myInstance",
+            Collections.singletonList("PRIMARY"),
+            AuthType.IAM,
+            Collections.emptyList());
 
     assertThat(readLine(socket)).isEqualTo(SERVER_MESSAGE);
   }
@@ -269,7 +287,8 @@ public class CoreSocketFactoryTest extends CloudSqlCoreTestingBase {
             coreSocketFactory.createSslSocket(
                 "myProject:myRegion:myInstance",
                 Collections.singletonList("PRIMARY"),
-                AuthType.IAM));
+                AuthType.IAM,
+                Collections.emptyList()));
   }
 
   @Test
@@ -280,7 +299,7 @@ public class CoreSocketFactoryTest extends CloudSqlCoreTestingBase {
     CoreSocketFactory.getInstance();
     assertThat(CoreSocketFactory.getUserAgents()).startsWith("unit-test/");
     assertThat(CoreSocketFactory.getUserAgents()).endsWith(" sample-app");
-  }
+  }git 
 
   @Test
   public void testGetApplicationNameFailsAfterInitialization() {

--- a/core/src/test/java/com/google/cloud/sql/core/CoreSocketFactoryTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/CoreSocketFactoryTest.java
@@ -299,7 +299,7 @@ public class CoreSocketFactoryTest extends CloudSqlCoreTestingBase {
     CoreSocketFactory.getInstance();
     assertThat(CoreSocketFactory.getUserAgents()).startsWith("unit-test/");
     assertThat(CoreSocketFactory.getUserAgents()).endsWith(" sample-app");
-  }git 
+  }
 
   @Test
   public void testGetApplicationNameFailsAfterInitialization() {

--- a/core/src/test/java/com/google/cloud/sql/core/DefaultAccessTokenSupplierTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/DefaultAccessTokenSupplierTest.java
@@ -39,7 +39,6 @@ import com.google.cloud.sql.CredentialFactory;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.Optional;

--- a/core/src/test/java/com/google/cloud/sql/core/DefaultAccessTokenSupplierTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/DefaultAccessTokenSupplierTest.java
@@ -40,6 +40,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.Optional;
 import org.junit.Before;
@@ -335,8 +336,9 @@ public class DefaultAccessTokenSupplierTest {
                       @Override
                       public LowLevelHttpResponse execute() throws IOException {
                         MockLowLevelHttpResponse response = new MockLowLevelHttpResponse();
-                        response.setHeaderNames(Arrays.asList("WWW-Authenticate"));
-                        response.setHeaderValues(Arrays.asList("Bearer my-refreshed-token"));
+                        response.setHeaderNames(Collections.singletonList("WWW-Authenticate"));
+                        response.setHeaderValues(
+                            Collections.singletonList("Bearer my-refreshed-token"));
 
                         return response;
                       }

--- a/core/src/test/java/com/google/cloud/sql/core/RefreshCalculatorTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/RefreshCalculatorTest.java
@@ -58,7 +58,7 @@ public class RefreshCalculatorTest {
   }
 
   private static final Instant NOW = Instant.now().truncatedTo(SECONDS);
-  private RefreshCalculator refreshCalculator;
+  private final RefreshCalculator refreshCalculator;
 
   @Test
   public void testDuration() {

--- a/jdbc/mysql-j-8/src/test/java/com/google/cloud/sql/mysql/JdbcMysqlJ8ServiceAccountImpersonationIntegrationTests.java
+++ b/jdbc/mysql-j-8/src/test/java/com/google/cloud/sql/mysql/JdbcMysqlJ8ServiceAccountImpersonationIntegrationTests.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.sql.mysql;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+
+import com.google.common.collect.ImmutableList;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class JdbcMysqlJ8ServiceAccountImpersonationIntegrationTests {
+
+  private static final String CONNECTION_NAME = System.getenv("MYSQL_CONNECTION_NAME");
+  private static final String DB_NAME = System.getenv("MYSQL_DB");
+  private static final String DB_USER = System.getenv("MYSQL_USER");
+  private static final String DB_PASSWORD = System.getenv("MYSQL_PASS");
+  private static final String IMPERSONATED_USER = System.getenv("IMPERSONATED_USER");
+  private static final ImmutableList<String> requiredEnvVars =
+      ImmutableList.of(
+          "MYSQL_USER", "MYSQL_PASS", "MYSQL_DB", "MYSQL_CONNECTION_NAME", "IMPERSONATED_USER");
+  @Rule public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
+  private HikariDataSource connectionPool;
+
+  @BeforeClass
+  public static void checkEnvVars() {
+    // Check that required env vars are set
+    requiredEnvVars.forEach(
+        (varName) ->
+            assertWithMessage(
+                    String.format(
+                        "Environment variable '%s' must be set to perform these tests.", varName))
+                .that(System.getenv(varName))
+                .isNotEmpty());
+  }
+
+  @Before
+  public void setUpPool() throws SQLException {
+    // Set up URL parameters
+    String jdbcURL = String.format("jdbc:mysql:///%s", DB_NAME);
+    Properties connProps = new Properties();
+    connProps.setProperty("user", DB_USER);
+    connProps.setProperty("password", DB_PASSWORD);
+    connProps.setProperty("delegates", IMPERSONATED_USER);
+    connProps.setProperty("socketFactory", "com.google.cloud.sql.mysql.SocketFactory");
+    connProps.setProperty("cloudSqlInstance", CONNECTION_NAME);
+
+    // Initialize connection pool
+    HikariConfig config = new HikariConfig();
+    config.setJdbcUrl(jdbcURL);
+    config.setDataSourceProperties(connProps);
+    config.setConnectionTimeout(10000); // 10s
+
+    this.connectionPool = new HikariDataSource(config);
+  }
+
+  @Test
+  public void pooledConnectionTest() throws SQLException {
+
+    List<Timestamp> rows = new ArrayList<>();
+    try (Connection conn = connectionPool.getConnection()) {
+      try (PreparedStatement selectStmt = conn.prepareStatement("SELECT NOW() as TS")) {
+        ResultSet rs = selectStmt.executeQuery();
+        while (rs.next()) {
+          rows.add(rs.getTimestamp("TS"));
+        }
+      }
+    }
+    assertThat(rows.size()).isEqualTo(1);
+  }
+}

--- a/jdbc/mysql-j-8/src/test/java/com/google/cloud/sql/mysql/JdbcMysqlJ8ServiceAccountImpersonationIntegrationTests.java
+++ b/jdbc/mysql-j-8/src/test/java/com/google/cloud/sql/mysql/JdbcMysqlJ8ServiceAccountImpersonationIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     https://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -72,7 +72,7 @@ public class JdbcMysqlJ8ServiceAccountImpersonationIntegrationTests {
     Properties connProps = new Properties();
     connProps.setProperty("user", DB_USER);
     connProps.setProperty("password", DB_PASSWORD);
-    connProps.setProperty("delegates", IMPERSONATED_USER);
+    connProps.setProperty("targetPrincipal", IMPERSONATED_USER);
     connProps.setProperty("socketFactory", "com.google.cloud.sql.mysql.SocketFactory");
     connProps.setProperty("cloudSqlInstance", CONNECTION_NAME);
 

--- a/r2dbc/core/src/main/java/com/google/cloud/sql/core/CloudSqlConnectionFactory.java
+++ b/r2dbc/core/src/main/java/com/google/cloud/sql/core/CloudSqlConnectionFactory.java
@@ -38,12 +38,14 @@ public class CloudSqlConnectionFactory implements ConnectionFactory {
   private final ConnectionFactoryOptions.Builder builder;
   private final String hostname;
   private final String ipTypes;
+  private final String targetPrincipal;
   private final List<String> delegates;
 
   /** Creates an instance of ConnectionFactory that pulls and sets host ip before delegating. */
   public CloudSqlConnectionFactory(
       Supplier<ConnectionFactoryProvider> supplier,
       String ipTypes,
+      String targetPrincipal,
       List<String> delegates,
       ConnectionFactoryOptions.Builder builder,
       String hostname) {
@@ -51,6 +53,7 @@ public class CloudSqlConnectionFactory implements ConnectionFactory {
     this.ipTypes = ipTypes;
     this.builder = builder;
     this.hostname = hostname;
+    this.targetPrincipal = targetPrincipal;
     this.delegates = delegates;
   }
 
@@ -58,7 +61,7 @@ public class CloudSqlConnectionFactory implements ConnectionFactory {
   @NonNull
   public Publisher<? extends Connection> create() {
     try {
-      String hostIp = CoreSocketFactory.getHostIp(hostname, ipTypes, delegates);
+      String hostIp = CoreSocketFactory.getHostIp(hostname, ipTypes, targetPrincipal, delegates);
       builder.option(HOST, hostIp).option(PORT, SERVER_PROXY_PORT);
       return supplier.get().create(builder.build()).create();
     } catch (IOException e) {
@@ -70,7 +73,7 @@ public class CloudSqlConnectionFactory implements ConnectionFactory {
   @NonNull
   public ConnectionFactoryMetadata getMetadata() {
     try {
-      String hostIp = CoreSocketFactory.getHostIp(hostname, ipTypes, delegates);
+      String hostIp = CoreSocketFactory.getHostIp(hostname, ipTypes, targetPrincipal, delegates);
       builder.option(HOST, hostIp).option(PORT, SERVER_PROXY_PORT);
       return supplier.get().create(builder.build()).getMetadata();
     } catch (IOException e) {

--- a/r2dbc/core/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProvider.java
+++ b/r2dbc/core/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProvider.java
@@ -27,6 +27,9 @@ import io.r2dbc.spi.ConnectionFactoryOptions;
 import io.r2dbc.spi.ConnectionFactoryProvider;
 import io.r2dbc.spi.Option;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.function.Function;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
@@ -38,6 +41,7 @@ public abstract class GcpConnectionFactoryProvider implements ConnectionFactoryP
   public static final Option<String> UNIX_SOCKET = Option.valueOf("UNIX_SOCKET");
   public static final Option<String> IP_TYPES = Option.valueOf("IP_TYPES");
   public static final Option<Boolean> ENABLE_IAM_AUTH = Option.valueOf("ENABLE_IAM_AUTH");
+  public static final Option<String> DELEGATES = Option.valueOf("DELEGATES");
 
   /**
    * Creates a ConnectionFactory that creates an SSL connection over a TCP socket, using
@@ -46,6 +50,7 @@ public abstract class GcpConnectionFactoryProvider implements ConnectionFactoryP
   abstract ConnectionFactory tcpSocketConnectionFactory(
       Builder optionBuilder,
       String ipTypes,
+      List<String> delegates,
       Function<SslContextBuilder, SslContextBuilder> customizer,
       String csqlHostName);
 
@@ -86,12 +91,21 @@ public abstract class GcpConnectionFactoryProvider implements ConnectionFactoryP
       enableIamAuth = false;
     }
 
+    final List<String> delegates;
+    Object delegatesObj = connectionFactoryOptions.getValue(DELEGATES);
+
+    if (delegatesObj instanceof String && !((String) delegatesObj).isEmpty()) {
+      delegates = Arrays.asList(((String) delegatesObj).split(","));
+    } else {
+      delegates = Collections.emptyList();
+    }
+
     Builder optionBuilder = createBuilder(connectionFactoryOptions);
     String connectionName = (String) connectionFactoryOptions.getRequiredValue(HOST);
     try {
       // Precompute SSL Data to trigger the initial refresh to happen immediately,
       // and ensure enableIAMAuth is set correctly.
-      CoreSocketFactory.getSslData(connectionName, enableIamAuth);
+      CoreSocketFactory.getSslData(connectionName, enableIamAuth, delegates);
 
       String socket = (String) connectionFactoryOptions.getValue(UNIX_SOCKET);
       if (socket != null) {
@@ -105,7 +119,8 @@ public abstract class GcpConnectionFactoryProvider implements ConnectionFactoryP
                 Mono.fromSupplier(
                         () -> {
                           try {
-                            return CoreSocketFactory.getSslData(connectionName, enableIamAuth);
+                            return CoreSocketFactory.getSslData(
+                                connectionName, enableIamAuth, delegates);
                           } catch (IOException e) {
                             throw new RuntimeException(e);
                           }
@@ -119,7 +134,8 @@ public abstract class GcpConnectionFactoryProvider implements ConnectionFactoryP
 
             return sslContextBuilder;
           };
-      return tcpSocketConnectionFactory(optionBuilder, ipTypes, sslFunction, connectionName);
+      return tcpSocketConnectionFactory(
+          optionBuilder, ipTypes, delegates, sslFunction, connectionName);
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/r2dbc/mysql/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderMysql.java
+++ b/r2dbc/mysql/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderMysql.java
@@ -47,6 +47,7 @@ public class GcpConnectionFactoryProviderMysql extends GcpConnectionFactoryProvi
   ConnectionFactory tcpSocketConnectionFactory(
       Builder builder,
       String ipTypes,
+      String targetPrincipal,
       List<String> delegates,
       Function<SslContextBuilder, SslContextBuilder> customizer,
       String hostname) {
@@ -57,7 +58,12 @@ public class GcpConnectionFactoryProviderMysql extends GcpConnectionFactoryProvi
         .option(MySqlConnectionFactoryProvider.TCP_KEEP_ALIVE, true);
 
     return new CloudSqlConnectionFactory(
-        MySqlConnectionFactoryProvider::new, ipTypes, delegates, builder, hostname);
+        MySqlConnectionFactoryProvider::new,
+        ipTypes,
+        targetPrincipal,
+        delegates,
+        builder,
+        hostname);
   }
 
   @Override

--- a/r2dbc/mysql/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderMysql.java
+++ b/r2dbc/mysql/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderMysql.java
@@ -25,6 +25,7 @@ import io.netty.handler.ssl.SslContextBuilder;
 import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.ConnectionFactoryOptions;
 import io.r2dbc.spi.ConnectionFactoryProvider;
+import java.util.List;
 import java.util.function.Function;
 
 /** {@link ConnectionFactoryProvider} for proxied access to GCP MySQL instances. */
@@ -46,6 +47,7 @@ public class GcpConnectionFactoryProviderMysql extends GcpConnectionFactoryProvi
   ConnectionFactory tcpSocketConnectionFactory(
       Builder builder,
       String ipTypes,
+      List<String> delegates,
       Function<SslContextBuilder, SslContextBuilder> customizer,
       String hostname) {
     builder
@@ -55,7 +57,7 @@ public class GcpConnectionFactoryProviderMysql extends GcpConnectionFactoryProvi
         .option(MySqlConnectionFactoryProvider.TCP_KEEP_ALIVE, true);
 
     return new CloudSqlConnectionFactory(
-        MySqlConnectionFactoryProvider::new, ipTypes, builder, hostname);
+        MySqlConnectionFactoryProvider::new, ipTypes, delegates, builder, hostname);
   }
 
   @Override

--- a/r2dbc/postgres/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderPostgres.java
+++ b/r2dbc/postgres/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderPostgres.java
@@ -49,6 +49,7 @@ public class GcpConnectionFactoryProviderPostgres extends GcpConnectionFactoryPr
   ConnectionFactory tcpSocketConnectionFactory(
       Builder builder,
       String ipTypes,
+      String targetPrincipal,
       List<String> delegates,
       Function<SslContextBuilder, SslContextBuilder> customizer,
       String hostname) {
@@ -59,7 +60,12 @@ public class GcpConnectionFactoryProviderPostgres extends GcpConnectionFactoryPr
         .option(PostgresqlConnectionFactoryProvider.TCP_KEEPALIVE, true);
 
     return new CloudSqlConnectionFactory(
-        PostgresqlConnectionFactoryProvider::new, ipTypes, delegates, builder, hostname);
+        PostgresqlConnectionFactoryProvider::new,
+        ipTypes,
+        targetPrincipal,
+        delegates,
+        builder,
+        hostname);
   }
 
   @Override

--- a/r2dbc/postgres/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderPostgres.java
+++ b/r2dbc/postgres/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderPostgres.java
@@ -25,6 +25,7 @@ import io.r2dbc.postgresql.client.SSLMode;
 import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.ConnectionFactoryOptions;
 import io.r2dbc.spi.ConnectionFactoryProvider;
+import java.util.List;
 import java.util.function.Function;
 
 /** {@link ConnectionFactoryProvider} for proxied access to GCP Postgres instances. */
@@ -48,6 +49,7 @@ public class GcpConnectionFactoryProviderPostgres extends GcpConnectionFactoryPr
   ConnectionFactory tcpSocketConnectionFactory(
       Builder builder,
       String ipTypes,
+      List<String> delegates,
       Function<SslContextBuilder, SslContextBuilder> customizer,
       String hostname) {
     builder
@@ -57,7 +59,7 @@ public class GcpConnectionFactoryProviderPostgres extends GcpConnectionFactoryPr
         .option(PostgresqlConnectionFactoryProvider.TCP_KEEPALIVE, true);
 
     return new CloudSqlConnectionFactory(
-        PostgresqlConnectionFactoryProvider::new, ipTypes, builder, hostname);
+        PostgresqlConnectionFactoryProvider::new, ipTypes, delegates, builder, hostname);
   }
 
   @Override

--- a/r2dbc/sqlserver/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderMssql.java
+++ b/r2dbc/sqlserver/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderMssql.java
@@ -24,6 +24,7 @@ import io.r2dbc.mssql.MssqlConnectionFactoryProvider;
 import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.ConnectionFactoryOptions;
 import io.r2dbc.spi.ConnectionFactoryProvider;
+import java.util.List;
 import java.util.function.Function;
 
 /** {@link ConnectionFactoryProvider} for proxied access to GCP MsSQL instances. */
@@ -45,6 +46,7 @@ public class GcpConnectionFactoryProviderMssql extends GcpConnectionFactoryProvi
   ConnectionFactory tcpSocketConnectionFactory(
       Builder builder,
       String ipTypes,
+      List<String> delegates,
       Function<SslContextBuilder, SslContextBuilder> customizer,
       String hostname) {
     builder
@@ -53,7 +55,7 @@ public class GcpConnectionFactoryProviderMssql extends GcpConnectionFactoryProvi
         .option(MssqlConnectionFactoryProvider.TCP_KEEPALIVE, true);
 
     return new CloudSqlConnectionFactory(
-        MssqlConnectionFactoryProvider::new, ipTypes, builder, hostname);
+        MssqlConnectionFactoryProvider::new, ipTypes, delegates, builder, hostname);
   }
 
   @Override

--- a/r2dbc/sqlserver/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderMssql.java
+++ b/r2dbc/sqlserver/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderMssql.java
@@ -46,6 +46,7 @@ public class GcpConnectionFactoryProviderMssql extends GcpConnectionFactoryProvi
   ConnectionFactory tcpSocketConnectionFactory(
       Builder builder,
       String ipTypes,
+      String targetPrincipal,
       List<String> delegates,
       Function<SslContextBuilder, SslContextBuilder> customizer,
       String hostname) {
@@ -55,7 +56,12 @@ public class GcpConnectionFactoryProviderMssql extends GcpConnectionFactoryProvi
         .option(MssqlConnectionFactoryProvider.TCP_KEEPALIVE, true);
 
     return new CloudSqlConnectionFactory(
-        MssqlConnectionFactoryProvider::new, ipTypes, delegates, builder, hostname);
+        MssqlConnectionFactoryProvider::new,
+        ipTypes,
+        targetPrincipal,
+        delegates,
+        builder,
+        hostname);
   }
 
   @Override


### PR DESCRIPTION
Adds new `delegates` JDBC connection property that will enable users to list the service account delegates
to use when connecting to a database instance. 

part of #1168 