### PR TITLE
docs: Add documentation for Service Account Impersonation feature.

### DIFF
--- a/docs/jdbc-mariadb.md
+++ b/docs/jdbc-mariadb.md
@@ -146,7 +146,7 @@ For example:
 ```
 
 In this example, the environment's application default principal impersonates
-SERVICE_ACCOUNT_2 which impersonates SERVICE_ACCOUNT_3 which then
+SERVICE_ACCOUNT_1 which impersonates SERVICE_ACCOUNT_2 which then
 impersonates the TARGET_SERVICE_ACCOUNT.
 
 ## Examples

--- a/docs/jdbc-mariadb.md
+++ b/docs/jdbc-mariadb.md
@@ -96,6 +96,52 @@ Note: a non-empty string value for the `password` property must be set. While th
 be ignored when connecting with the Cloud SQL Connector using IAM auth, leaving it empty will cause
 driver-level validations to fail.
 
+### Service Account Impersonation
+
+The Java Connector supports service account impersonation with the
+`delegates` JDBC connection property. When enabled,
+all API requests are made impersonating the supplied service account. The
+IAM principal must have the iam.serviceAccounts.getAccessToken permission or
+the role roles/iam.serviceAccounts.serviceAccountTokenCreator.
+
+Example:
+```java
+    // Set up URL parameters
+    String jdbcURL = String.format("jdbc:mariadb://ignoreme:123/%s", DB_NAME);
+    Properties connProps = new Properties();
+    connProps.setProperty("user", "mysql-iam-user@gmail.com");
+    connProps.setProperty("password", "password");
+    connProps.setProperty("sslmode", "disable");
+    connProps.setProperty("socketFactory", "com.google.cloud.sql.mariadb.SocketFactory");
+    connProps.setProperty("cloudSqlInstance", "project:region:instance");
+    connProps.setProperty("enableIamAuth", "true");
+    connProps.setProperty("delegates", "mysql-iam-user@gmail.com");
+
+    // Initialize connection pool
+    HikariConfig config = new HikariConfig();
+    config.setJdbcUrl(jdbcURL);
+    config.setDataSourceProperties(connProps);
+    config.setConnectionTimeout(10000); // 10s
+
+    HikariDataSource connectionPool = new HikariDataSource(config);
+```
+
+In addition, the `delegates` property supports an impersonation delegation chain
+where the value is a comma-separated list of service accounts. The first service
+account in the list is the impersonation target. Each subsequent service
+account is a delegate to the previous service account. When delegation is
+used, each delegate must have the permissions named above on the service
+account it is delegating to.
+
+For example:
+```java
+    connProps.setProperty("delegates", "SERVICE_ACCOUNT_1,SERVICE_ACCOUNT_2,SERVICE_ACCOUNT_3");
+```
+
+In this example, the environment's IAM principal impersonates
+SERVICE_ACCOUNT_3 which impersonates SERVICE_ACCOUNT_2 which then
+impersonates the target SERVICE_ACCOUNT_1.
+
 ## Examples
 
 Examples for using the Cloud SQL JDBC Connector for MySQL/MariaDB can be found by looking at the integration tests in this repository.

--- a/docs/jdbc-mariadb.md
+++ b/docs/jdbc-mariadb.md
@@ -99,34 +99,34 @@ driver-level validations to fail.
 ### Service Account Impersonation
 
 The Java Connector supports service account impersonation with the
-`targetPrincipal` JDBC connection property. When enabled,
+`cloudSqlTargetPrincipal` JDBC connection property. When enabled,
 all API requests are made impersonating the supplied service account. The
 IAM principal must have the iam.serviceAccounts.getAccessToken permission or
 the role roles/iam.serviceAccounts.serviceAccountTokenCreator.
 
 Example:
 ```java
-    // Set up URL parameters
-    String jdbcURL = String.format("jdbc:mariadb://ignoreme:123/%s", DB_NAME);
-    Properties connProps = new Properties();
-    connProps.setProperty("user", "mysql-iam-user@gmail.com");
-    connProps.setProperty("password", "password");
-    connProps.setProperty("sslmode", "disable");
-    connProps.setProperty("socketFactory", "com.google.cloud.sql.mariadb.SocketFactory");
-    connProps.setProperty("cloudSqlInstance", "project:region:instance");
-    connProps.setProperty("enableIamAuth", "true");
-    connProps.setProperty("targetPrincipal", "mysql-iam-user@gmail.com");
+// Set up URL parameters
+String jdbcURL = String.format("jdbc:mariadb://ignoreme:123/%s", DB_NAME);
+Properties connProps = new Properties();
+connProps.setProperty("user", "mysql-iam-user@gmail.com");
+connProps.setProperty("password", "password");
+connProps.setProperty("sslmode", "disable");
+connProps.setProperty("socketFactory", "com.google.cloud.sql.mariadb.SocketFactory");
+connProps.setProperty("cloudSqlInstance", "project:region:instance");
+connProps.setProperty("enableIamAuth", "true");
+connProps.setProperty("cloudSqlTargetPrincipal", "mysql-iam-user@gmail.com");
 
-    // Initialize connection pool
-    HikariConfig config = new HikariConfig();
-    config.setJdbcUrl(jdbcURL);
-    config.setDataSourceProperties(connProps);
-    config.setConnectionTimeout(10000); // 10s
+// Initialize connection pool
+HikariConfig config = new HikariConfig();
+config.setJdbcUrl(jdbcURL);
+config.setDataSourceProperties(connProps);
+config.setConnectionTimeout(10000); // 10s
 
-    HikariDataSource connectionPool = new HikariDataSource(config);
+HikariDataSource connectionPool = new HikariDataSource(config);
 ```
 
-In addition, the `delegates` property controls impersonation delegation. 
+In addition, the `cloudSqlDelegates` property controls impersonation delegation. 
 The value is a comma-separated list of service accounts containing chained 
 list of delegates required to grant the final access_token. If set,
 the sequence of identities must have "Service Account Token Creator" capability
@@ -134,15 +134,15 @@ granted to the preceding identity. For example, if set to
 `"serviceAccountB,serviceAccountC"`, the application default credentials must 
 have the Token Creator role on serviceAccountB. serviceAccountB must have
 the Token Creator on serviceAccountC. Finally, C must have Token Creator on 
-targetPrincipal. If unset, the application default credential principal
+`cloudSqlTargetPrincipal`. If unset, the application default credential principal
 must "Service Account Token Creator" capability granted that role on the
 targetPrincipal service account.
 
 
 For example:
 ```java
-    connProps.setProperty("targetPrincipal", "TARGET_SERVICE_ACCOUNT");
-    connProps.setProperty("delegates", "SERVICE_ACCOUNT_1,SERVICE_ACCOUNT_2");
+connProps.setProperty("cloudSqlTargetPrincipal", "TARGET_SERVICE_ACCOUNT");
+connProps.setProperty("cloudSqlDelegates", "SERVICE_ACCOUNT_1,SERVICE_ACCOUNT_2");
 ```
 
 In this example, the environment's application default principal impersonates

--- a/docs/jdbc-mariadb.md
+++ b/docs/jdbc-mariadb.md
@@ -99,7 +99,7 @@ driver-level validations to fail.
 ### Service Account Impersonation
 
 The Java Connector supports service account impersonation with the
-`delegates` JDBC connection property. When enabled,
+`targetPrincipal` JDBC connection property. When enabled,
 all API requests are made impersonating the supplied service account. The
 IAM principal must have the iam.serviceAccounts.getAccessToken permission or
 the role roles/iam.serviceAccounts.serviceAccountTokenCreator.
@@ -115,7 +115,7 @@ Example:
     connProps.setProperty("socketFactory", "com.google.cloud.sql.mariadb.SocketFactory");
     connProps.setProperty("cloudSqlInstance", "project:region:instance");
     connProps.setProperty("enableIamAuth", "true");
-    connProps.setProperty("delegates", "mysql-iam-user@gmail.com");
+    connProps.setProperty("targetPrincipal", "mysql-iam-user@gmail.com");
 
     // Initialize connection pool
     HikariConfig config = new HikariConfig();
@@ -126,21 +126,28 @@ Example:
     HikariDataSource connectionPool = new HikariDataSource(config);
 ```
 
-In addition, the `delegates` property supports an impersonation delegation chain
-where the value is a comma-separated list of service accounts. The first service
-account in the list is the impersonation target. Each subsequent service
-account is a delegate to the previous service account. When delegation is
-used, each delegate must have the permissions named above on the service
-account it is delegating to.
+In addition, the `delegates` property controls impersonation delegation. 
+The value is a comma-separated list of service accounts containing chained 
+list of delegates required to grant the final access_token. If set,
+the sequence of identities must have "Service Account Token Creator" capability
+granted to the preceding identity. For example, if set to 
+`"serviceAccountB,serviceAccountC"`, the application default credentials must 
+have the Token Creator role on serviceAccountB. serviceAccountB must have
+the Token Creator on serviceAccountC. Finally, C must have Token Creator on 
+targetPrincipal. If unset, the application default credential principal
+must "Service Account Token Creator" capability granted that role on the
+targetPrincipal service account.
+
 
 For example:
 ```java
-    connProps.setProperty("delegates", "SERVICE_ACCOUNT_1,SERVICE_ACCOUNT_2,SERVICE_ACCOUNT_3");
+    connProps.setProperty("targetPrincipal", "TARGET_SERVICE_ACCOUNT");
+    connProps.setProperty("delegates", "SERVICE_ACCOUNT_1,SERVICE_ACCOUNT_2");
 ```
 
-In this example, the environment's IAM principal impersonates
-SERVICE_ACCOUNT_3 which impersonates SERVICE_ACCOUNT_2 which then
-impersonates the target SERVICE_ACCOUNT_1.
+In this example, the environment's application default principal impersonates
+SERVICE_ACCOUNT_2 which impersonates SERVICE_ACCOUNT_3 which then
+impersonates the TARGET_SERVICE_ACCOUNT.
 
 ## Examples
 

--- a/docs/jdbc-mysql.md
+++ b/docs/jdbc-mysql.md
@@ -97,7 +97,7 @@ Example:
 ### Service Account Impersonation
 
 The Java Connector supports service account impersonation with the
-`delegates` JDBC connection property. When enabled,
+`targetPrincipal` JDBC connection property. When enabled,
 all API requests are made impersonating the supplied service account. The
 IAM principal must have the iam.serviceAccounts.getAccessToken permission or
 the role roles/iam.serviceAccounts.serviceAccountTokenCreator.
@@ -112,7 +112,7 @@ Example:
     connProps.setProperty("socketFactory", "com.google.cloud.sql.postgres.SocketFactory");
     connProps.setProperty("cloudSqlInstance", "project:region:instance");
     connProps.setProperty("enableIamAuth", "true");
-    connProps.setProperty("delegates", "iam-user@gmail.com");
+    connProps.setProperty("targetPrincipal", "iam-user@gmail.com");
 
     // Initialize connection pool
     HikariConfig config = new HikariConfig();
@@ -123,21 +123,29 @@ Example:
     HikariDataSource connectionPool = new HikariDataSource(config);
 ```
 
-In addition, the `delegates` property supports an impersonation delegation chain
-where the value is a comma-separated list of service accounts. The first service
-account in the list is the impersonation target. Each subsequent service
-account is a delegate to the previous service account. When delegation is
-used, each delegate must have the permissions named above on the service
-account it is delegating to.
+In addition, the `delegates` property controls impersonation delegation.
+The value is a comma-separated list of service accounts containing chained
+list of delegates required to grant the final access_token. If set,
+the sequence of identities must have "Service Account Token Creator" capability
+granted to the preceding identity. For example, if set to 
+`"serviceAccountB,serviceAccountC"`, the application default credentials must
+have the Token Creator role on serviceAccountB. serviceAccountB must have
+the Token Creator on serviceAccountC. Finally, C must have Token Creator on
+targetPrincipal. If unset, the application default credential principal
+must "Service Account Token Creator" capability granted that role on the
+targetPrincipal service account.
+
 
 For example:
 ```java
-    connProps.setProperty("delegates", "SERVICE_ACCOUNT_1,SERVICE_ACCOUNT_2,SERVICE_ACCOUNT_3");
+    connProps.setProperty("targetPrincipal", "TARGET_SERVICE_ACCOUNT");
+    connProps.setProperty("delegates", "SERVICE_ACCOUNT_1,SERVICE_ACCOUNT_2");
 ```
 
-In this example, the environment's IAM principal impersonates
-SERVICE_ACCOUNT_3 which impersonates SERVICE_ACCOUNT_2 which then
-impersonates the target SERVICE_ACCOUNT_1.
+In this example, the environment's application default principal impersonates
+SERVICE_ACCOUNT_2 which impersonates SERVICE_ACCOUNT_3 which then
+impersonates the TARGET_SERVICE_ACCOUNT.
+
 
 ### Connection via Unix Sockets
 

--- a/docs/jdbc-mysql.md
+++ b/docs/jdbc-mysql.md
@@ -97,33 +97,33 @@ Example:
 ### Service Account Impersonation
 
 The Java Connector supports service account impersonation with the
-`targetPrincipal` JDBC connection property. When enabled,
+`cloudSqlTargetPrincipal` JDBC connection property. When enabled,
 all API requests are made impersonating the supplied service account. The
 IAM principal must have the iam.serviceAccounts.getAccessToken permission or
 the role roles/iam.serviceAccounts.serviceAccountTokenCreator.
 
 Example:
 ```java
-    // Set up URL parameters
-    String jdbcURL = String.format("jdbc:mysql:///%s", DB_NAME);
-    Properties connProps = new Properties();
-    connProps.setProperty("user", "iam-user"); // iam-user@gmail.com
-    connProps.setProperty("sslmode", "disable");
-    connProps.setProperty("socketFactory", "com.google.cloud.sql.postgres.SocketFactory");
-    connProps.setProperty("cloudSqlInstance", "project:region:instance");
-    connProps.setProperty("enableIamAuth", "true");
-    connProps.setProperty("targetPrincipal", "iam-user@gmail.com");
+// Set up URL parameters
+String jdbcURL = String.format("jdbc:mysql:///%s", DB_NAME);
+Properties connProps = new Properties();
+connProps.setProperty("user", "iam-user"); // iam-user@gmail.com
+connProps.setProperty("sslmode", "disable");
+connProps.setProperty("socketFactory", "com.google.cloud.sql.postgres.SocketFactory");
+connProps.setProperty("cloudSqlInstance", "project:region:instance");
+connProps.setProperty("enableIamAuth", "true");
+connProps.setProperty("cloudSqlTargetPrincipal", "iam-user@gmail.com");
 
-    // Initialize connection pool
-    HikariConfig config = new HikariConfig();
-    config.setJdbcUrl(jdbcURL);
-    config.setDataSourceProperties(connProps);
-    config.setConnectionTimeout(10000); // 10s
+// Initialize connection pool
+HikariConfig config = new HikariConfig();
+config.setJdbcUrl(jdbcURL);
+config.setDataSourceProperties(connProps);
+config.setConnectionTimeout(10000); // 10s
 
-    HikariDataSource connectionPool = new HikariDataSource(config);
+HikariDataSource connectionPool = new HikariDataSource(config);
 ```
 
-In addition, the `delegates` property controls impersonation delegation.
+In addition, the `cloudSqlDelegates` property controls impersonation delegation.
 The value is a comma-separated list of service accounts containing chained
 list of delegates required to grant the final access_token. If set,
 the sequence of identities must have "Service Account Token Creator" capability
@@ -131,15 +131,15 @@ granted to the preceding identity. For example, if set to
 `"serviceAccountB,serviceAccountC"`, the application default credentials must
 have the Token Creator role on serviceAccountB. serviceAccountB must have
 the Token Creator on serviceAccountC. Finally, C must have Token Creator on
-targetPrincipal. If unset, the application default credential principal
+`cloudSqlTargetPrincipal`. If unset, the application default credential principal
 must "Service Account Token Creator" capability granted that role on the
-targetPrincipal service account.
+`cloudSqlTargetPrincipal` service account.
 
 
 For example:
 ```java
-    connProps.setProperty("targetPrincipal", "TARGET_SERVICE_ACCOUNT");
-    connProps.setProperty("delegates", "SERVICE_ACCOUNT_1,SERVICE_ACCOUNT_2");
+connProps.setProperty("cloudSqlTargetPrincipal", "TARGET_SERVICE_ACCOUNT");
+connProps.setProperty("cloudSqlDelegates", "SERVICE_ACCOUNT_1,SERVICE_ACCOUNT_2");
 ```
 
 In this example, the environment's application default principal impersonates

--- a/docs/jdbc-mysql.md
+++ b/docs/jdbc-mysql.md
@@ -143,7 +143,7 @@ For example:
 ```
 
 In this example, the environment's application default principal impersonates
-SERVICE_ACCOUNT_2 which impersonates SERVICE_ACCOUNT_3 which then
+SERVICE_ACCOUNT_1 which impersonates SERVICE_ACCOUNT_2 which then
 impersonates the TARGET_SERVICE_ACCOUNT.
 
 

--- a/docs/jdbc-postgres.md
+++ b/docs/jdbc-postgres.md
@@ -95,35 +95,36 @@ driver-level validations to fail.
 ### Service Account Impersonation
 
 The Java Connector supports service account impersonation with the
-`targetPrincipal` JDBC connection property. When enabled,
+`cloudSqlTargetPrincipal` JDBC connection property. When enabled,
 all API requests are made impersonating the supplied service account. The
 IAM principal must have the iam.serviceAccounts.getAccessToken permission or
 the role roles/iam.serviceAccounts.serviceAccountTokenCreator.
 
 Example:
+
 ```java
-    // Set up URL parameters
-    String jdbcURL = String.format("jdbc:postgresql:///%s", DB_NAME);
-    Properties connProps = new Properties();
-    connProps.setProperty("user", "postgres-iam-user@gmail.com");
-    connProps.setProperty("password", "password");
-    connProps.setProperty("sslmode", "disable");
-    connProps.setProperty("socketFactory", "com.google.cloud.sql.postgres.SocketFactory");
-    connProps.setProperty("cloudSqlInstance", "project:region:instance");
-    connProps.setProperty("enableIamAuth", "true");
-    connProps.setProperty("targetPrincipal", "postgres-iam-user@gmail.com");
+// Set up URL parameters
+String jdbcURL = String.format("jdbc:postgresql:///%s", DB_NAME);
+Properties connProps = new Properties();
+connProps.setProperty("user", "postgres-iam-user@gmail.com");
+connProps.setProperty("password", "password");
+connProps.setProperty("sslmode", "disable");
+connProps.setProperty("socketFactory", "com.google.cloud.sql.postgres.SocketFactory");
+connProps.setProperty("cloudSqlInstance", "project:region:instance");
+connProps.setProperty("enableIamAuth", "true");
+connProps.setProperty("cloudSqlTargetPrincipal", "postgres-iam-user@gmail.com");
 
-    // Initialize connection pool
-    HikariConfig config = new HikariConfig();
-    config.setJdbcUrl(jdbcURL);
-    config.setDataSourceProperties(connProps);
-    config.setConnectionTimeout(10000); // 10s
+// Initialize connection pool
+HikariConfig config = new HikariConfig();
+config.setJdbcUrl(jdbcURL);
+config.setDataSourceProperties(connProps);
+config.setConnectionTimeout(10000); // 10s
 
-    HikariDataSource connectionPool = new HikariDataSource(config);
+HikariDataSource connectionPool = new HikariDataSource(config);
 ```
 
 
-In addition, the `delegates` property controls impersonation delegation.
+In addition, the `cloudSqlDelegates` property controls impersonation delegation.
 The value is a comma-separated list of service accounts containing chained
 list of delegates required to grant the final access_token. If set,
 the sequence of identities must have "Service Account Token Creator" capability
@@ -131,15 +132,15 @@ granted to the preceding identity. For example, if set to
 `"serviceAccountB,serviceAccountC"`, the application default credentials must
 have the Token Creator role on serviceAccountB. serviceAccountB must have
 the Token Creator on serviceAccountC. Finally, C must have Token Creator on
-targetPrincipal. If unset, the application default credential principal
+`cloudSqlTargetPrincipal`. If unset, the application default credential principal
 must "Service Account Token Creator" capability granted that role on the
-targetPrincipal service account.
+cloudSqlTargetPrincipal service account.
 
 
 For example:
 ```java
-    connProps.setProperty("targetPrincipal", "TARGET_SERVICE_ACCOUNT");
-    connProps.setProperty("delegates", "SERVICE_ACCOUNT_1,SERVICE_ACCOUNT_2");
+connProps.setProperty("cloudSqlTargetPrincipal", "TARGET_SERVICE_ACCOUNT");
+connProps.setProperty("cloudSqlDelegates", "SERVICE_ACCOUNT_1,SERVICE_ACCOUNT_2");
 ```
 
 In this example, the environment's application default principal impersonates

--- a/docs/jdbc-postgres.md
+++ b/docs/jdbc-postgres.md
@@ -91,6 +91,53 @@ Note: a non-empty string value for the `password` property must be set. While th
 be ignored when connecting with the Cloud SQL Connector using IAM auth, leaving it empty will cause
 driver-level validations to fail.
 
+
+### Service Account Impersonation
+
+The Java Connector supports service account impersonation with the
+`delegates` JDBC connection property. When enabled,
+all API requests are made impersonating the supplied service account. The
+IAM principal must have the iam.serviceAccounts.getAccessToken permission or
+the role roles/iam.serviceAccounts.serviceAccountTokenCreator.
+
+Example:
+```java
+    // Set up URL parameters
+    String jdbcURL = String.format("jdbc:postgresql:///%s", DB_NAME);
+    Properties connProps = new Properties();
+    connProps.setProperty("user", "postgres-iam-user@gmail.com");
+    connProps.setProperty("password", "password");
+    connProps.setProperty("sslmode", "disable");
+    connProps.setProperty("socketFactory", "com.google.cloud.sql.postgres.SocketFactory");
+    connProps.setProperty("cloudSqlInstance", "project:region:instance");
+    connProps.setProperty("enableIamAuth", "true");
+    connProps.setProperty("delegates", "postgres-iam-user@gmail.com");
+
+    // Initialize connection pool
+    HikariConfig config = new HikariConfig();
+    config.setJdbcUrl(jdbcURL);
+    config.setDataSourceProperties(connProps);
+    config.setConnectionTimeout(10000); // 10s
+
+    HikariDataSource connectionPool = new HikariDataSource(config);
+```
+
+In addition, the `delegates` property supports an impersonation delegation chain
+where the value is a comma-separated list of service accounts. The first service
+account in the list is the impersonation target. Each subsequent service
+account is a delegate to the previous service account. When delegation is
+used, each delegate must have the permissions named above on the service
+account it is delegating to.
+
+For example:
+```java
+    connProps.setProperty("delegates", "SERVICE_ACCOUNT_1,SERVICE_ACCOUNT_2,SERVICE_ACCOUNT_3");
+```
+
+In this example, the environment's IAM principal impersonates
+SERVICE_ACCOUNT_3 which impersonates SERVICE_ACCOUNT_2 which then
+impersonates the target SERVICE_ACCOUNT_1.
+
 ### Connection via Unix Sockets
 
 To connect using a Unix domain socket (such as the one created by the Cloud SQL 

--- a/docs/jdbc-postgres.md
+++ b/docs/jdbc-postgres.md
@@ -95,7 +95,7 @@ driver-level validations to fail.
 ### Service Account Impersonation
 
 The Java Connector supports service account impersonation with the
-`delegates` JDBC connection property. When enabled,
+`targetPrincipal` JDBC connection property. When enabled,
 all API requests are made impersonating the supplied service account. The
 IAM principal must have the iam.serviceAccounts.getAccessToken permission or
 the role roles/iam.serviceAccounts.serviceAccountTokenCreator.
@@ -111,7 +111,7 @@ Example:
     connProps.setProperty("socketFactory", "com.google.cloud.sql.postgres.SocketFactory");
     connProps.setProperty("cloudSqlInstance", "project:region:instance");
     connProps.setProperty("enableIamAuth", "true");
-    connProps.setProperty("delegates", "postgres-iam-user@gmail.com");
+    connProps.setProperty("targetPrincipal", "postgres-iam-user@gmail.com");
 
     // Initialize connection pool
     HikariConfig config = new HikariConfig();
@@ -122,21 +122,30 @@ Example:
     HikariDataSource connectionPool = new HikariDataSource(config);
 ```
 
-In addition, the `delegates` property supports an impersonation delegation chain
-where the value is a comma-separated list of service accounts. The first service
-account in the list is the impersonation target. Each subsequent service
-account is a delegate to the previous service account. When delegation is
-used, each delegate must have the permissions named above on the service
-account it is delegating to.
+
+In addition, the `delegates` property controls impersonation delegation.
+The value is a comma-separated list of service accounts containing chained
+list of delegates required to grant the final access_token. If set,
+the sequence of identities must have "Service Account Token Creator" capability
+granted to the preceding identity. For example, if set to 
+`"serviceAccountB,serviceAccountC"`, the application default credentials must
+have the Token Creator role on serviceAccountB. serviceAccountB must have
+the Token Creator on serviceAccountC. Finally, C must have Token Creator on
+targetPrincipal. If unset, the application default credential principal
+must "Service Account Token Creator" capability granted that role on the
+targetPrincipal service account.
+
 
 For example:
 ```java
-    connProps.setProperty("delegates", "SERVICE_ACCOUNT_1,SERVICE_ACCOUNT_2,SERVICE_ACCOUNT_3");
+    connProps.setProperty("targetPrincipal", "TARGET_SERVICE_ACCOUNT");
+    connProps.setProperty("delegates", "SERVICE_ACCOUNT_1,SERVICE_ACCOUNT_2");
 ```
 
-In this example, the environment's IAM principal impersonates
-SERVICE_ACCOUNT_3 which impersonates SERVICE_ACCOUNT_2 which then
-impersonates the target SERVICE_ACCOUNT_1.
+In this example, the environment's application default principal impersonates
+SERVICE_ACCOUNT_2 which impersonates SERVICE_ACCOUNT_3 which then
+impersonates the TARGET_SERVICE_ACCOUNT.
+
 
 ### Connection via Unix Sockets
 

--- a/docs/jdbc-postgres.md
+++ b/docs/jdbc-postgres.md
@@ -143,7 +143,7 @@ For example:
 ```
 
 In this example, the environment's application default principal impersonates
-SERVICE_ACCOUNT_2 which impersonates SERVICE_ACCOUNT_3 which then
+SERVICE_ACCOUNT_1 which impersonates SERVICE_ACCOUNT_2 which then
 impersonates the TARGET_SERVICE_ACCOUNT.
 
 

--- a/docs/r2dbc-mysql.md
+++ b/docs/r2dbc-mysql.md
@@ -86,7 +86,7 @@ For example:
 ```
 
 In this example, the environment's application default principal impersonates
-SERVICE_ACCOUNT_2 which impersonates SERVICE_ACCOUNT_3 which then
+SERVICE_ACCOUNT_1 which impersonates SERVICE_ACCOUNT_2 which then
 impersonates the TARGET_SERVICE_ACCOUNT.
 
 In addition, the `DELEGATES` option supports an impersonation delegation chain

--- a/docs/r2dbc-mysql.md
+++ b/docs/r2dbc-mysql.md
@@ -39,8 +39,8 @@ Add the following parameters:
 
 
 The Java Connector supports service account impersonation with the
-`DELEGATES` option. When enabled, all API requests are made impersonating the
-supplied service account. The IAM principal must have the
+`TARGET_PRINCIPAL` option. When enabled, all API requests are made impersonating
+the supplied service account. The IAM principal must have the
 iam.serviceAccounts.getAccessToken permission or the role
 roles/iam.serviceAccounts.serviceAccountTokenCreator.
 
@@ -54,7 +54,7 @@ roles/iam.serviceAccounts.serviceAccountTokenCreator.
         .option(DATABASE, "my_db")
         .option(HOST, "project:region:instance")
         .option(ENABLE_IAM_AUTH, true)
-        .option(DELEGATES, "mysql-iam-user@gmail.com,db-service-account@iam.gooogle.com")
+        .option(TARGET_PRINCIPAL, "mysql-iam-user@gmail.com")
         .build();
 
     // Initialize connection pool
@@ -66,21 +66,35 @@ roles/iam.serviceAccounts.serviceAccountTokenCreator.
     this.connectionPool = new ConnectionPool(configuration);
 ```
 
+In addition, the `DELEGATES` option controls impersonation delegation.
+The value is a comma-separated list of service accounts containing chained
+list of delegates required to grant the final access_token. If set,
+the sequence of identities must have "Service Account Token Creator" capability
+granted to the preceding identity. For example, if set to 
+`"serviceAccountB,serviceAccountC"`, the application default credentials must
+have the Token Creator role on serviceAccountB. serviceAccountB must have
+the Token Creator on serviceAccountC. Finally, C must have Token Creator on
+targetPrincipal. If unset, the application default credential principal
+must "Service Account Token Creator" capability granted that role on the
+targetPrincipal service account.
+
+
+For example:
+```java
+    options.option(TARGET_PRINCIPAL, "TARGET_SERVICE_ACCOUNT");
+    options.option(DELEGATES, "SERVICE_ACCOUNT_1,SERVICE_ACCOUNT_2");
+```
+
+In this example, the environment's application default principal impersonates
+SERVICE_ACCOUNT_2 which impersonates SERVICE_ACCOUNT_3 which then
+impersonates the TARGET_SERVICE_ACCOUNT.
+
 In addition, the `DELEGATES` option supports an impersonation delegation chain
 where the value is a comma-separated list of service accounts. The first service
 account in the list is the impersonation target. Each subsequent service
 account is a delegate to the previous service account. When delegation is
 used, each delegate must have the permissions named above on the service
 account it is delegating to.
-
-For example:
-```java
-    options.option(DELEGATES, "SERVICE_ACCOUNT_1,SERVICE_ACCOUNT_2,SERVICE_ACCOUNT_3");
-```
-
-In this example, the environment's IAM principal impersonates
-SERVICE_ACCOUNT_3 which impersonates SERVICE_ACCOUNT_2 which then
-impersonates the target SERVICE_ACCOUNT_1.
 
 
 ## Examples

--- a/docs/r2dbc-mysql.md
+++ b/docs/r2dbc-mysql.md
@@ -35,6 +35,54 @@ Add the following parameters:
 | DB_USER         | MySQL username |
 | DB_PASS         | MySQL user's password |
 
+## Service Account Delegation
+
+
+The Java Connector supports service account impersonation with the
+`DELEGATES` option. When enabled, all API requests are made impersonating the
+supplied service account. The IAM principal must have the
+iam.serviceAccounts.getAccessToken permission or the role
+roles/iam.serviceAccounts.serviceAccountTokenCreator.
+
+```java
+    // Set up ConnectionFactoryOptions
+    ConnectionFactoryOptions options = ConnectionFactoryOptions.builder()
+        .option(DRIVER, "gcp")
+        .option(PROTOCOL, "mysql")
+        .option(PASSWORD, "password")
+        .option(USER, "mysql-iam-user@gmail.com")
+        .option(DATABASE, "my_db")
+        .option(HOST, "project:region:instance")
+        .option(ENABLE_IAM_AUTH, true)
+        .option(DELEGATES, "mysql-iam-user@gmail.com,db-service-account@iam.gooogle.com")
+        .build();
+
+    // Initialize connection pool
+    ConnectionFactory connectionFactory = ConnectionFactories.get(options);
+    ConnectionPoolConfiguration configuration = ConnectionPoolConfiguration
+        .builder(connectionFactory)
+        .build();
+
+    this.connectionPool = new ConnectionPool(configuration);
+```
+
+In addition, the `DELEGATES` option supports an impersonation delegation chain
+where the value is a comma-separated list of service accounts. The first service
+account in the list is the impersonation target. Each subsequent service
+account is a delegate to the previous service account. When delegation is
+used, each delegate must have the permissions named above on the service
+account it is delegating to.
+
+For example:
+```java
+    options.option(DELEGATES, "SERVICE_ACCOUNT_1,SERVICE_ACCOUNT_2,SERVICE_ACCOUNT_3");
+```
+
+In this example, the environment's IAM principal impersonates
+SERVICE_ACCOUNT_3 which impersonates SERVICE_ACCOUNT_2 which then
+impersonates the target SERVICE_ACCOUNT_1.
+
+
 ## Examples
 
 Examples for using the Cloud SQL JDBC Connector for Postgres can be found by looking at the integration tests in this repository.

--- a/docs/r2dbc-mysql.md
+++ b/docs/r2dbc-mysql.md
@@ -45,25 +45,25 @@ iam.serviceAccounts.getAccessToken permission or the role
 roles/iam.serviceAccounts.serviceAccountTokenCreator.
 
 ```java
-    // Set up ConnectionFactoryOptions
-    ConnectionFactoryOptions options = ConnectionFactoryOptions.builder()
-        .option(DRIVER, "gcp")
-        .option(PROTOCOL, "mysql")
-        .option(PASSWORD, "password")
-        .option(USER, "mysql-iam-user@gmail.com")
-        .option(DATABASE, "my_db")
-        .option(HOST, "project:region:instance")
-        .option(ENABLE_IAM_AUTH, true)
-        .option(TARGET_PRINCIPAL, "mysql-iam-user@gmail.com")
-        .build();
+// Set up ConnectionFactoryOptions
+ConnectionFactoryOptions options = ConnectionFactoryOptions.builder()
+    .option(DRIVER, "gcp")
+    .option(PROTOCOL, "mysql")
+    .option(PASSWORD, "password")
+    .option(USER, "mysql-iam-user@gmail.com")
+    .option(DATABASE, "my_db")
+    .option(HOST, "project:region:instance")
+    .option(ENABLE_IAM_AUTH, true)
+    .option(TARGET_PRINCIPAL, "mysql-iam-user@gmail.com")
+    .build();
 
-    // Initialize connection pool
-    ConnectionFactory connectionFactory = ConnectionFactories.get(options);
-    ConnectionPoolConfiguration configuration = ConnectionPoolConfiguration
-        .builder(connectionFactory)
-        .build();
+// Initialize connection pool
+ConnectionFactory connectionFactory = ConnectionFactories.get(options);
+ConnectionPoolConfiguration configuration = ConnectionPoolConfiguration
+    .builder(connectionFactory)
+    .build();
 
-    this.connectionPool = new ConnectionPool(configuration);
+this.connectionPool = new ConnectionPool(configuration);
 ```
 
 In addition, the `DELEGATES` option controls impersonation delegation.
@@ -74,15 +74,15 @@ granted to the preceding identity. For example, if set to
 `"serviceAccountB,serviceAccountC"`, the application default credentials must
 have the Token Creator role on serviceAccountB. serviceAccountB must have
 the Token Creator on serviceAccountC. Finally, C must have Token Creator on
-targetPrincipal. If unset, the application default credential principal
+target principal. If unset, the application default credential principal
 must "Service Account Token Creator" capability granted that role on the
-targetPrincipal service account.
+target principal service account.
 
 
 For example:
 ```java
-    options.option(TARGET_PRINCIPAL, "TARGET_SERVICE_ACCOUNT");
-    options.option(DELEGATES, "SERVICE_ACCOUNT_1,SERVICE_ACCOUNT_2");
+options.option(TARGET_PRINCIPAL, "TARGET_SERVICE_ACCOUNT");
+options.option(DELEGATES, "SERVICE_ACCOUNT_1,SERVICE_ACCOUNT_2");
 ```
 
 In this example, the environment's application default principal impersonates

--- a/docs/r2dbc-postgres.md
+++ b/docs/r2dbc-postgres.md
@@ -123,7 +123,7 @@ For example:
 ```
 
 In this example, the environment's application default principal impersonates
-SERVICE_ACCOUNT_2 which impersonates SERVICE_ACCOUNT_3 which then
+SERVICE_ACCOUNT_1 which impersonates SERVICE_ACCOUNT_2 which then
 impersonates the TARGET_SERVICE_ACCOUNT.
 
 In addition, the `DELEGATES` option supports an impersonation delegation chain

--- a/docs/r2dbc-postgres.md
+++ b/docs/r2dbc-postgres.md
@@ -82,25 +82,25 @@ iam.serviceAccounts.getAccessToken permission or the role
 roles/iam.serviceAccounts.serviceAccountTokenCreator.
 
 ```java
-    // Set up ConnectionFactoryOptions
-    ConnectionFactoryOptions options = ConnectionFactoryOptions.builder()
-        .option(DRIVER, "gcp")
-        .option(PROTOCOL, "postgresql")
-        .option(PASSWORD, "password")
-        .option(USER, "postgres-iam-user@gmail.com")
-        .option(DATABASE, "my_db")
-        .option(HOST, "project:region:instance")
-        .option(ENABLE_IAM_AUTH, true)
-        .option(TARGET_PRINCIPAL, "postgres-iam-user@gmail.com,db-service-account@iam.gooogle.com")
-        .build();
+// Set up ConnectionFactoryOptions
+ConnectionFactoryOptions options = ConnectionFactoryOptions.builder()
+    .option(DRIVER, "gcp")
+    .option(PROTOCOL, "postgresql")
+    .option(PASSWORD, "password")
+    .option(USER, "postgres-iam-user@gmail.com")
+    .option(DATABASE, "my_db")
+    .option(HOST, "project:region:instance")
+    .option(ENABLE_IAM_AUTH, true)
+    .option(TARGET_PRINCIPAL, "postgres-iam-user@gmail.com,db-service-account@iam.gooogle.com")
+    .build();
 
-    // Initialize connection pool
-    ConnectionFactory connectionFactory = ConnectionFactories.get(options);
-    ConnectionPoolConfiguration configuration = ConnectionPoolConfiguration
-        .builder(connectionFactory)
-        .build();
+// Initialize connection pool
+ConnectionFactory connectionFactory = ConnectionFactories.get(options);
+ConnectionPoolConfiguration configuration = ConnectionPoolConfiguration
+    .builder(connectionFactory)
+    .build();
 
-    this.connectionPool = new ConnectionPool(configuration);
+this.connectionPool = new ConnectionPool(configuration);
 ```
 
 In addition, the `DELEGATES` option controls impersonation delegation.
@@ -111,15 +111,15 @@ granted to the preceding identity. For example, if set to
 `"serviceAccountB,serviceAccountC"`, the application default credentials must
 have the Token Creator role on serviceAccountB. serviceAccountB must have
 the Token Creator on serviceAccountC. Finally, C must have Token Creator on
-targetPrincipal. If unset, the application default credential principal
+target principal. If unset, the application default credential principal
 must "Service Account Token Creator" capability granted that role on the
-targetPrincipal service account.
+target principal service account.
 
 
 For example:
 ```java
-    options.option(TARGET_PRINCIPAL, "TARGET_SERVICE_ACCOUNT");
-    options.option(DELEGATES, "SERVICE_ACCOUNT_1,SERVICE_ACCOUNT_2");
+options.option(TARGET_PRINCIPAL, "TARGET_SERVICE_ACCOUNT");
+options.option(DELEGATES, "SERVICE_ACCOUNT_1,SERVICE_ACCOUNT_2");
 ```
 
 In this example, the environment's application default principal impersonates

--- a/docs/r2dbc-sqlserver.md
+++ b/docs/r2dbc-sqlserver.md
@@ -34,6 +34,52 @@ Add the following parameters:
 | DB_USER         | SQL Server username |
 | DB_PASS         | SQL Server user's password |
 
+
+## Service Account Delegation
+The Java Connector supports service account impersonation with the
+`DELEGATES` option. When enabled, all API requests are made impersonating the
+supplied service account. The IAM principal must have the
+iam.serviceAccounts.getAccessToken permission or the role
+roles/iam.serviceAccounts.serviceAccountTokenCreator.
+
+```java
+    // Set up ConnectionFactoryOptions
+    ConnectionFactoryOptions options = ConnectionFactoryOptions.builder()
+        .option(DRIVER, "gcp")
+        .option(PROTOCOL, "mssql")
+        .option(PASSWORD, "password")
+        .option(USER, "my_db_user")
+        .option(DATABASE, "my_db")
+        .option(HOST, "project:region:instance")
+        .option(DELEGATES, "mssql-iam-user@gmail.com,db-service-account@iam.gooogle.com")
+        .build();
+
+    // Initialize connection pool
+    ConnectionFactory connectionFactory = ConnectionFactories.get(options);
+    ConnectionPoolConfiguration configuration = ConnectionPoolConfiguration
+        .builder(connectionFactory)
+        .build();
+
+    this.connectionPool = new ConnectionPool(configuration);
+```
+
+In addition, the `DELEGATES` option supports an impersonation delegation chain
+where the value is a comma-separated list of service accounts. The first service
+account in the list is the impersonation target. Each subsequent service
+account is a delegate to the previous service account. When delegation is
+used, each delegate must have the permissions named above on the service
+account it is delegating to.
+
+For example:
+```java
+    options.option(DELEGATES, "SERVICE_ACCOUNT_1,SERVICE_ACCOUNT_2,SERVICE_ACCOUNT_3");
+```
+
+In this example, the environment's IAM principal impersonates
+SERVICE_ACCOUNT_3 which impersonates SERVICE_ACCOUNT_2 which then
+impersonates the target SERVICE_ACCOUNT_1.
+
+
 ## Examples
 
 Examples for using the Cloud SQL JDBC Connector for Postgres can be found by looking at the integration tests in this repository.

--- a/docs/r2dbc-sqlserver.md
+++ b/docs/r2dbc-sqlserver.md
@@ -43,24 +43,24 @@ iam.serviceAccounts.getAccessToken permission or the role
 roles/iam.serviceAccounts.serviceAccountTokenCreator.
 
 ```java
-    // Set up ConnectionFactoryOptions
-    ConnectionFactoryOptions options = ConnectionFactoryOptions.builder()
-        .option(DRIVER, "gcp")
-        .option(PROTOCOL, "mssql")
-        .option(PASSWORD, "password")
-        .option(USER, "my_db_user")
-        .option(DATABASE, "my_db")
-        .option(HOST, "project:region:instance")
-        .option(TARGET_PRINCIPAL, "mssql-iam-user@gmail.com,db-service-account@iam.gooogle.com")
-        .build();
+// Set up ConnectionFactoryOptions
+ConnectionFactoryOptions options = ConnectionFactoryOptions.builder()
+    .option(DRIVER, "gcp")
+    .option(PROTOCOL, "mssql")
+    .option(PASSWORD, "password")
+    .option(USER, "my_db_user")
+    .option(DATABASE, "my_db")
+    .option(HOST, "project:region:instance")
+    .option(TARGET_PRINCIPAL, "mssql-iam-user@gmail.com,db-service-account@iam.gooogle.com")
+    .build();
 
-    // Initialize connection pool
-    ConnectionFactory connectionFactory = ConnectionFactories.get(options);
-    ConnectionPoolConfiguration configuration = ConnectionPoolConfiguration
-        .builder(connectionFactory)
-        .build();
+// Initialize connection pool
+ConnectionFactory connectionFactory = ConnectionFactories.get(options);
+ConnectionPoolConfiguration configuration = ConnectionPoolConfiguration
+    .builder(connectionFactory)
+    .build();
 
-    this.connectionPool = new ConnectionPool(configuration);
+this.connectionPool = new ConnectionPool(configuration);
 ```
 
 In addition, the `DELEGATES` option controls impersonation delegation.
@@ -71,15 +71,15 @@ granted to the preceding identity. For example, if set to
 `"serviceAccountB,serviceAccountC"`, the application default credentials must
 have the Token Creator role on serviceAccountB. serviceAccountB must have
 the Token Creator on serviceAccountC. Finally, C must have Token Creator on
-targetPrincipal. If unset, the application default credential principal
+target principal. If unset, the application default credential principal
 must "Service Account Token Creator" capability granted that role on the
-targetPrincipal service account.
+target principal service account.
 
 
 For example:
 ```java
-    options.option(TARGET_PRINCIPAL, "TARGET_SERVICE_ACCOUNT");
-    options.option(DELEGATES, "SERVICE_ACCOUNT_1,SERVICE_ACCOUNT_2");
+options.option(TARGET_PRINCIPAL, "TARGET_SERVICE_ACCOUNT");
+options.option(DELEGATES, "SERVICE_ACCOUNT_1,SERVICE_ACCOUNT_2");
 ```
 
 In this example, the environment's application default principal impersonates

--- a/docs/r2dbc-sqlserver.md
+++ b/docs/r2dbc-sqlserver.md
@@ -83,7 +83,7 @@ For example:
 ```
 
 In this example, the environment's application default principal impersonates
-SERVICE_ACCOUNT_2 which impersonates SERVICE_ACCOUNT_3 which then
+SERVICE_ACCOUNT_1 which impersonates SERVICE_ACCOUNT_2 which then
 impersonates the TARGET_SERVICE_ACCOUNT.
 
 In addition, the `DELEGATES` option supports an impersonation delegation chain

--- a/docs/r2dbc-sqlserver.md
+++ b/docs/r2dbc-sqlserver.md
@@ -37,8 +37,8 @@ Add the following parameters:
 
 ## Service Account Delegation
 The Java Connector supports service account impersonation with the
-`DELEGATES` option. When enabled, all API requests are made impersonating the
-supplied service account. The IAM principal must have the
+`TARGET_PRINCIPAL` option. When enabled, all API requests are made impersonating
+the supplied service account. The IAM principal must have the
 iam.serviceAccounts.getAccessToken permission or the role
 roles/iam.serviceAccounts.serviceAccountTokenCreator.
 
@@ -51,7 +51,7 @@ roles/iam.serviceAccounts.serviceAccountTokenCreator.
         .option(USER, "my_db_user")
         .option(DATABASE, "my_db")
         .option(HOST, "project:region:instance")
-        .option(DELEGATES, "mssql-iam-user@gmail.com,db-service-account@iam.gooogle.com")
+        .option(TARGET_PRINCIPAL, "mssql-iam-user@gmail.com,db-service-account@iam.gooogle.com")
         .build();
 
     // Initialize connection pool
@@ -63,6 +63,29 @@ roles/iam.serviceAccounts.serviceAccountTokenCreator.
     this.connectionPool = new ConnectionPool(configuration);
 ```
 
+In addition, the `DELEGATES` option controls impersonation delegation.
+The value is a comma-separated list of service accounts containing chained
+list of delegates required to grant the final access_token. If set,
+the sequence of identities must have "Service Account Token Creator" capability
+granted to the preceding identity. For example, if set to 
+`"serviceAccountB,serviceAccountC"`, the application default credentials must
+have the Token Creator role on serviceAccountB. serviceAccountB must have
+the Token Creator on serviceAccountC. Finally, C must have Token Creator on
+targetPrincipal. If unset, the application default credential principal
+must "Service Account Token Creator" capability granted that role on the
+targetPrincipal service account.
+
+
+For example:
+```java
+    options.option(TARGET_PRINCIPAL, "TARGET_SERVICE_ACCOUNT");
+    options.option(DELEGATES, "SERVICE_ACCOUNT_1,SERVICE_ACCOUNT_2");
+```
+
+In this example, the environment's application default principal impersonates
+SERVICE_ACCOUNT_2 which impersonates SERVICE_ACCOUNT_3 which then
+impersonates the TARGET_SERVICE_ACCOUNT.
+
 In addition, the `DELEGATES` option supports an impersonation delegation chain
 where the value is a comma-separated list of service accounts. The first service
 account in the list is the impersonation target. Each subsequent service
@@ -70,14 +93,6 @@ account is a delegate to the previous service account. When delegation is
 used, each delegate must have the permissions named above on the service
 account it is delegating to.
 
-For example:
-```java
-    options.option(DELEGATES, "SERVICE_ACCOUNT_1,SERVICE_ACCOUNT_2,SERVICE_ACCOUNT_3");
-```
-
-In this example, the environment's IAM principal impersonates
-SERVICE_ACCOUNT_3 which impersonates SERVICE_ACCOUNT_2 which then
-impersonates the target SERVICE_ACCOUNT_1.
 
 
 ## Examples


### PR DESCRIPTION
Add documentation of the new `delegates` property that holds the list of service accounts to impersonate.

fixes #1168 