### PR TITLE
chore: Update credential factory contract to match ImpersonatingCredentials

### DIFF
--- a/core/src/main/java/com/google/cloud/sql/core/ServiceAccountImpersonatingCredentialFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/core/ServiceAccountImpersonatingCredentialFactory.java
@@ -22,26 +22,23 @@ import com.google.auth.http.HttpCredentialsAdapter;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.auth.oauth2.ImpersonatedCredentials;
 import com.google.cloud.sql.CredentialFactory;
-import com.google.common.collect.Lists;
 import java.util.Arrays;
 import java.util.List;
 
 /**
- * Wraps an existing CredentialFactory, adding service account impersonation for the list of
- * delegates.
+ * Wraps an existing CredentialFactory to impersonate the targetPrincipal, with an optional list of
+ * delegating service accounts in accordance with the ImpersonatedCredentials API.
  *
- * <p>The "delegates" property is built to work like the cloud-sql-proxy
- * --impersonate-service-account and gcloud --impersonate-service-account flags: The first element
- * in the list is the target service account. Intermediate delegated credentials are applied first
- * from end of the list, working towards the beginning of the list. For example, if <code>
- * delegates = Arrays.asList( "first@serviceaccount.com", "second@serviceaccount.com",
- * "third@serviceaccount.com")
- * </code>
+ * <p>targetPrincipal – the service account to impersonate
  *
- * <p>The connector will start with the GoogleCredentials supplied by `source`. It will use those to
- * impersonate "third@serviceaccount.com", then with a token for "third@serviceaccount.com",
- * impersonate "second@serviceaccount.com", and then impersonate "first@serviceaccount.com".
- * Finally, the connector will attempt to access the services as "first@serviceaccount.com".
+ * <p>delegates – the chained list of delegates required to grant the final access_token. If set,
+ * the sequence of identities must have "Service Account Token Creator" capability granted to the
+ * preceding identity. For example, if set to [serviceAccountB, serviceAccountC], the
+ * sourceCredential must have the Token Creator role on serviceAccountB. serviceAccountB must have
+ * the Token Creator on serviceAccountC. Finally, C must have Token Creator on target_principal. If
+ * unset, sourceCredential must have that role on targetPrincipal.
+ *
+ * @see com.google.auth.oauth2.ImpersonatedCredentials
  */
 class ServiceAccountImpersonatingCredentialFactory implements CredentialFactory {
 
@@ -49,30 +46,21 @@ class ServiceAccountImpersonatingCredentialFactory implements CredentialFactory 
   private final List<String> delegates;
   private final String targetPrincipal;
 
-  ServiceAccountImpersonatingCredentialFactory(CredentialFactory source, List<String> delegates) {
-    if (delegates == null || delegates.isEmpty()) {
-      throw new IllegalArgumentException("delegates must not be empty");
+  /**
+   * Creates a new ServiceAccountImpersonatingCredentialFactory.
+   *
+   * @param source the source of the original credentials, before they are impersonated.
+   * @param targetPrincipal The target principal in the form of a service account, must not be null.
+   * @param delegates The optional list of delegate service accounts, may be null or empty.
+   */
+  ServiceAccountImpersonatingCredentialFactory(
+      CredentialFactory source, String targetPrincipal, List<String> delegates) {
+    if (targetPrincipal == null || targetPrincipal.isEmpty()) {
+      throw new IllegalArgumentException("targetPrincipal must not be empty");
     }
     this.source = source;
-
-    // The "delegates" property is built so that delegated credentials are applied first from end
-    // of the list, working towards the beginning of the list. However, the
-    // ImpersonatedCredentials.setDelegates() expects the list to be in the opposite order,
-    // so we have to reverse the list.
-    //
-    // From the ImpersonatedCredentials doc:
-    //
-    //    targetPrincipal – the service account to impersonate
-    //    delegates – the chained list of delegates required to grant the final access_token.
-    //      If set, the sequence of identities must have "Service Account Token Creator"
-    //      capability granted to the preceding identity. For example, if set to
-    //      [serviceAccountB, serviceAccountC], the sourceCredential must have the Token Creator
-    //      role on serviceAccountB. serviceAccountB must have the Token Creator on
-    //      serviceAccountC. Finally, C must have Token Creator on target_principal.
-    //      If unset, sourceCredential must have that role on targetPrincipal.
-    List<String> reversedDelegates = Lists.reverse(delegates);
-    this.targetPrincipal = reversedDelegates.get(reversedDelegates.size() - 1);
-    this.delegates = reversedDelegates.subList(0, reversedDelegates.size() - 1);
+    this.delegates = delegates;
+    this.targetPrincipal = targetPrincipal;
   }
 
   @Override

--- a/core/src/test/java/com/google/cloud/sql/core/ServiceAccountImpersonatingCredentialFactoryTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/ServiceAccountImpersonatingCredentialFactoryTest.java
@@ -38,10 +38,8 @@ public class ServiceAccountImpersonatingCredentialFactoryTest {
     CredentialFactory impersonatedFactory =
         new ServiceAccountImpersonatingCredentialFactory(
             factory,
-            Arrays.asList(
-                "first@serviceaccount.com",
-                "second@serviceaccount.com",
-                "third@serviceaccount.com"));
+            "first@serviceaccount.com",
+            Arrays.asList("third@serviceaccount.com", "second@serviceaccount.com"));
 
     // Test that the CredentialsFactory.create() works.
     Credentials impersonatedCredentials = newCredentials(impersonatedFactory);
@@ -60,8 +58,7 @@ public class ServiceAccountImpersonatingCredentialFactoryTest {
     Credentials credentials = factory.getCredentials();
 
     CredentialFactory impersonatedFactory =
-        new ServiceAccountImpersonatingCredentialFactory(
-            factory, Arrays.asList("first@serviceaccount.com"));
+        new ServiceAccountImpersonatingCredentialFactory(factory, "first@serviceaccount.com", null);
 
     // Test that the CredentialsFactory.create() works.
     Credentials impersonatedCredentials = newCredentials(impersonatedFactory);
@@ -80,7 +77,7 @@ public class ServiceAccountImpersonatingCredentialFactoryTest {
     assertThrows(
         IllegalArgumentException.class,
         () -> {
-          new ServiceAccountImpersonatingCredentialFactory(factory, Collections.emptyList());
+          new ServiceAccountImpersonatingCredentialFactory(factory, null, Collections.emptyList());
         });
   }
 


### PR DESCRIPTION
Make the ServiceAccountImpersonatingCredentialFactory match the Google Cloud Auth Impersonation API,
using the two fields `targetPrincipal` and `delegates`. 

Part of #1168 