### PR TITLE
fix: do not discard current instance info on force refresh.

### DIFF
--- a/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstance.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstance.java
@@ -155,8 +155,7 @@ class CloudSqlInstance {
 
   /**
    * Attempts to force a new refresh of the instance data. May fail if called too frequently or if a
-   * new refresh is already in progress. If successful, other methods will block until refresh has
-   * been completed.
+   * new refresh is already in progress.
    */
   void forceRefresh() {
     synchronized (instanceDataGuard) {
@@ -173,8 +172,7 @@ class CloudSqlInstance {
               "[%s] Force Refresh: the next refresh operation was cancelled."
                   + " Scheduling new refresh operation immediately.",
               instanceName));
-      currentInstanceData = executor.submit(this::performRefresh);
-      nextInstanceData = currentInstanceData;
+      nextInstanceData = executor.submit(this::performRefresh);
     }
   }
 


### PR DESCRIPTION
This commit changes the force-refresh behavior in that the current instance details will be retained in case the connection issues are caused by temporary network or instance availability issues. When the refresh operation completes, it will update the connection info with a refreshed value.