### PR TITLE
chore(ci): Fix the distribution management URLs for new build scripts.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,15 +41,15 @@
 
   <distributionManagement>
     <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <id>sonatype-nexus-snapshots</id>
+      <url>https://google.oss.sonatype.org/content/repositories/snapshots</url>
     </snapshotRepository>
-
     <repository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+      <id>sonatype-nexus-staging</id>
+      <url>https://google.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
     </repository>
   </distributionManagement>
+
 
   <scm>
     <connection>


### PR DESCRIPTION
Update to correctly reflect the new configuration used by standard build tools. See [java-shared-config/pom.xml](https://github.com/googleapis/java-shared-config/blob/main/pom.xml#L42) This should unblock the release process.

Additional work needed to update and improve maven configuration is tracked in #1447