### PR TITLE
fix: Improve handling of futures and threads during refresh.

### DIFF
--- a/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstance.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstance.java
@@ -23,7 +23,6 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import com.google.common.util.concurrent.RateLimiter;
-import com.google.common.util.concurrent.Uninterruptibles;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import java.io.IOException;
 import java.security.KeyPair;
@@ -34,6 +33,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.net.ssl.SSLSocket;
@@ -46,6 +46,7 @@ import javax.net.ssl.SSLSocket;
 class CloudSqlInstance {
 
   private static final Logger logger = Logger.getLogger(CloudSqlInstance.class.getName());
+  public static final int MAX_INSTANCE_DATA_WAIT_SEC = 30;
 
   private final ListeningScheduledExecutorService executor;
   private final InstanceDataSupplier instanceDataSupplier;
@@ -68,6 +69,9 @@ class CloudSqlInstance {
 
   @GuardedBy("instanceDataGuard")
   private boolean forceRefreshRunning;
+
+  @GuardedBy("instanceDataGuard")
+  private Throwable currentRefreshFailure;
 
   /**
    * Initializes a new Cloud SQL instance based on the given connection name.
@@ -99,14 +103,14 @@ class CloudSqlInstance {
     }
 
     synchronized (instanceDataGuard) {
-      this.currentInstanceData = executor.submit(this::performRefresh);
+      this.currentInstanceData = this.startRefreshAttempt();
       this.nextInstanceData = currentInstanceData;
     }
   }
 
   /**
-   * Returns the current data related to the instance from {@link #performRefresh()}. May block if
-   * no valid data is currently available.
+   * Returns the current data related to the instance from {@link #startRefreshAttempt()}. May block
+   * if no valid data is currently available.
    */
   private InstanceData getInstanceData() {
     ListenableFuture<InstanceData> instanceDataFuture;
@@ -114,8 +118,19 @@ class CloudSqlInstance {
       instanceDataFuture = currentInstanceData;
     }
     try {
-      return Uninterruptibles.getUninterruptibly(instanceDataFuture);
-    } catch (ExecutionException ex) {
+      return instanceDataFuture.get(MAX_INSTANCE_DATA_WAIT_SEC, TimeUnit.SECONDS);
+    } catch (TimeoutException e) {
+      synchronized (instanceDataGuard) {
+        if (currentRefreshFailure != null) {
+          throw new RuntimeException(
+              "Unable to get valid instance data within 30 seconds. Last refresh attempt failed:"
+                  + currentRefreshFailure.getMessage(),
+              currentRefreshFailure);
+        }
+      }
+      throw new RuntimeException(
+          "Unable to get valid instance data within 30 seconds. No refresh has completed.", e);
+    } catch (ExecutionException | InterruptedException ex) {
       Throwable cause = ex.getCause();
       Throwables.throwIfUnchecked(cause);
       throw new RuntimeException(cause);
@@ -174,30 +189,64 @@ class CloudSqlInstance {
               "[%s] Force Refresh: the next refresh operation was cancelled."
                   + " Scheduling new refresh operation immediately.",
               instanceName));
-      nextInstanceData = executor.submit(this::performRefresh);
+      nextInstanceData = this.startRefreshAttempt();
     }
   }
 
   /**
-   * Triggers an update of internal information obtained from the Cloud SQL Admin API. Replaces the
-   * value of currentInstanceData and schedules the next refresh shortly before the information
-   * would expire.
+   * Triggers an update of internal information obtained from the Cloud SQL Admin API, returning a
+   * future that resolves once a valid InstanceData has been acquired. This sets up a chain of
+   * futures that will 1. Acquire a rate limiter. 2. Attempt to fetch instance data. 3. Schedule the
+   * next attempt to get instance data based on the success/failure of this attempt.
+   *
+   * @see com.google.cloud.sql.core.CloudSqlInstance#handleRefreshResult(
+   *     com.google.common.util.concurrent.ListenableFuture)
    */
-  private InstanceData performRefresh() throws InterruptedException, ExecutionException {
-    logger.fine(
-        String.format("[%s] Refresh Operation: Acquiring rate limiter permit.", instanceName));
-    // To avoid unreasonable SQL Admin API usage, use a rate limit to throttle our usage.
-    //noinspection UnstableApiUsage
-    forcedRenewRateLimiter.acquire();
-    logger.fine(
-        String.format(
-            "[%s] Refresh Operation: Acquired rate limiter permit. Starting refresh...",
-            instanceName));
+  private ListenableFuture<InstanceData> startRefreshAttempt() {
 
+    // To avoid unreasonable SQL Admin API usage, use a rate limit to throttle our usage.
+    ListenableFuture rateLimit =
+        executor.submit(
+            () -> {
+              logger.fine(
+                  String.format(
+                      "[%s] Refresh Operation: Acquiring rate limiter permit.", instanceName));
+              //noinspection UnstableApiUsage
+              forcedRenewRateLimiter.acquire();
+              logger.fine(
+                  String.format(
+                      "[%s] Refresh Operation: Acquired rate limiter permit. Starting refresh...",
+                      instanceName));
+            },
+            executor);
+
+    // Once rate limiter is done, attempt to getInstanceData.
+    ListenableFuture<InstanceData> dataFuture =
+        Futures.whenAllComplete(rateLimit)
+            .callAsync(
+                () ->
+                    instanceDataSupplier.getInstanceData(
+                        this.instanceName,
+                        this.accessTokenSupplier,
+                        this.authType,
+                        executor,
+                        keyPair),
+                executor);
+
+    // Finally, reschedule refresh after getInstanceData is complete.
+    ListenableFuture<InstanceData> rescheduleFuture =
+        Futures.whenAllComplete(dataFuture)
+            .callAsync(() -> handleRefreshResult(dataFuture), executor);
+
+    return rescheduleFuture;
+  }
+
+  private ListenableFuture<InstanceData> handleRefreshResult(
+      ListenableFuture<InstanceData> dataFuture) {
     try {
-      InstanceData data =
-          instanceDataSupplier.getInstanceData(
-              this.instanceName, this.accessTokenSupplier, this.authType, executor, keyPair);
+      // This does not block, because it only gets called when dataFuture has completed.
+      // This will throw an exception if the refresh attempt has failed.
+      InstanceData data = dataFuture.get();
 
       logger.fine(
           String.format(
@@ -216,13 +265,21 @@ class CloudSqlInstance {
                   .toString()));
 
       synchronized (instanceDataGuard) {
-        currentInstanceData = Futures.immediateFuture(data);
-        nextInstanceData =
-            executor.schedule(this::performRefresh, secondsToRefresh, TimeUnit.SECONDS);
         // Refresh completed successfully, reset forceRefreshRunning.
         forceRefreshRunning = false;
+        currentRefreshFailure = null;
+        currentInstanceData = Futures.immediateFuture(data);
+
+        // Now update nextInstanceData to perform a refresh after the
+        // scheduled delay
+        nextInstanceData =
+            Futures.scheduleAsync(
+                this::startRefreshAttempt, secondsToRefresh, TimeUnit.SECONDS, executor);
+
+        // Resolves to an InstanceData immediately
+        return currentInstanceData;
       }
-      return data;
+
     } catch (ExecutionException | InterruptedException e) {
       logger.log(
           Level.FINE,
@@ -231,9 +288,12 @@ class CloudSqlInstance {
               instanceName),
           e);
       synchronized (instanceDataGuard) {
-        nextInstanceData = executor.submit(this::performRefresh);
+        currentRefreshFailure = e;
+        nextInstanceData = this.startRefreshAttempt();
+
+        // Resolves after the next successful refresh attempt.
+        return nextInstanceData;
       }
-      throw e;
     }
   }
 

--- a/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstance.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstance.java
@@ -154,7 +154,8 @@ class CloudSqlInstance {
         if (currentRefreshFailure != null) {
           throw new RuntimeException(
               String.format(
-                      "Unable to get valid instance data within %d ms. Last refresh attempt failed:",
+                      "Unable to get valid instance data within %d ms."
+                          + " Last refresh attempt failed:",
                       timeoutMs)
                   + currentRefreshFailure.getMessage(),
               currentRefreshFailure);

--- a/core/src/main/java/com/google/cloud/sql/core/InstanceDataSupplier.java
+++ b/core/src/main/java/com/google/cloud/sql/core/InstanceDataSupplier.java
@@ -30,7 +30,7 @@ interface InstanceDataSupplier {
    * @throws ExecutionException if an exception is thrown during execution.
    * @throws InterruptedException if the executor is interrupted.
    */
-  InstanceData getInstanceData(
+  ListenableFuture<InstanceData> getInstanceData(
       CloudSqlInstanceName instanceName,
       AccessTokenSupplier accessTokenSupplier,
       AuthType authType,

--- a/core/src/main/java/com/google/cloud/sql/core/SqlAdminApiFetcher.java
+++ b/core/src/main/java/com/google/cloud/sql/core/SqlAdminApiFetcher.java
@@ -95,7 +95,7 @@ class SqlAdminApiFetcher implements InstanceDataSupplier {
    * @throws InterruptedException if the executor is interrupted.
    */
   @Override
-  public InstanceData getInstanceData(
+  public ListenableFuture<InstanceData> getInstanceData(
       CloudSqlInstanceName instanceName,
       AccessTokenSupplier accessTokenSupplier,
       AuthType authType,
@@ -163,9 +163,9 @@ class SqlAdminApiFetcher implements InstanceDataSupplier {
                 },
                 executor);
 
-    InstanceData instanceData = done.get();
-    logger.fine(String.format("[%s] ALL FUTURES DONE", instanceName));
-    return instanceData;
+    done.addListener(
+        () -> logger.fine(String.format("[%s] ALL FUTURES DONE", instanceName)), executor);
+    return done;
   }
 
   String getApplicationName() {

--- a/core/src/test/java/com/google/cloud/sql/core/CloudSqlInstanceConcurrencyTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/CloudSqlInstanceConcurrencyTest.java
@@ -30,7 +30,6 @@ import java.io.IOException;
 import java.security.KeyPair;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.ExecutionException;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import org.junit.Test;
@@ -53,98 +52,6 @@ public class CloudSqlInstanceConcurrencyTest {
     public void initialize(HttpRequest var1) throws IOException {
       // do nothing
     }
-  }
-
-  @Test(timeout = 20000)
-  public void testThatForceRefreshBalksWhenARefreshIsInProgress() throws Exception {
-    MockAdminApi mockAdminApi = new MockAdminApi();
-    ListenableFuture<KeyPair> keyPairFuture =
-        Futures.immediateFuture(mockAdminApi.getClientKeyPair());
-    ListeningScheduledExecutorService executor = CoreSocketFactory.getDefaultExecutor();
-    TestDataSupplier supplier = new TestDataSupplier(true);
-    CloudSqlInstance instance =
-        new CloudSqlInstance(
-            "a:b:c",
-            supplier,
-            AuthType.PASSWORD,
-            new TestCredentialFactory(),
-            executor,
-            keyPairFuture,
-            newRateLimiter());
-
-    // Attempt to retrieve data, ensure we wait for success
-    // 3 simultaneous requests can put enough pressure on the thread pool
-    // to cause a deadlock.
-    ListenableFuture<List<Object>> allData =
-        Futures.allAsList(
-            executor.submit(() -> instance.getSslData()),
-            executor.submit(() -> instance.getSslData()),
-            executor.submit(() -> instance.getSslData()));
-
-    List<Object> d = allData.get();
-    assertThat(d.get(0)).isNotNull();
-    assertThat(d.get(1)).isNotNull();
-    assertThat(d.get(2)).isNotNull();
-
-    // Test that there was 1 successful attempt from when the CloudSqlInstance was instantiated.
-    assertThat(supplier.successCounter.get()).isEqualTo(1);
-
-    // Now, run through a number of cycles where we call forceRefresh() multiple times and make sure
-    // that it only runs one successful refresh per cycle 10 times. This will prove that
-    // forceRefresh() will balk when an operation is in progress, and that forceRefresh() will retry
-    // after a failed attempt to get InstanceData.
-    for (int i = 1; i <= FORCE_REFRESH_COUNT; i++) {
-      // Assert the expected number of successful refresh operations
-      assertThat(supplier.successCounter.get()).isEqualTo(i);
-
-      // Call forceRefresh 3 times in rapid succession. This should only kick off 1 refresh
-      // cycle.
-      instance.forceRefresh();
-      // force Java to run a different thread now. That gives the refresh task an opportunity to
-      // start.
-      Thread.sleep(0);
-      instance.forceRefresh();
-      instance.forceRefresh();
-
-      Thread.sleep(DEFAULT_WAIT); // Wait for the refresh to occur
-
-      // This will loop forever if CloudSqlInstance does not successfully retry after a failed
-      // forceRefresh() attempt.
-      while (true) {
-        try {
-          // Attempt to get sslData 3 times, simultaneously, in different threads.
-          ListenableFuture<List<Object>> allData2 =
-              Futures.allAsList(
-                  executor.submit(() -> instance.getSslData()),
-                  executor.submit(() -> instance.getSslData()),
-                  executor.submit(() -> instance.getSslData()));
-
-          // This should return immediately
-          allData2.get();
-          break;
-
-        } catch (ExecutionException e) {
-          // We expect some of these to throw an exception indicating that the refresh cycle
-          // got a failed attempt. When they throw an exception,
-          // sleep and try again. This shows that the refresh cycle is working.
-          //noinspection BusyWait
-          Thread.sleep(DEFAULT_WAIT);
-        }
-      }
-
-      // Wait for the actual background refresh to complete before checking the success counter.
-      Thread.sleep(DEFAULT_WAIT);
-
-      // Assert the expected number of successful refresh operations at the end of the loop
-      // is only one more than the beginning of the loop.
-      // This means that only one additional refresh operation was run.
-      assertThat(supplier.successCounter.get()).isEqualTo(i + 1);
-
-      Thread.sleep(DEFAULT_WAIT);
-    }
-
-    // Refresh count should equal initial refresh plus FORCE_REFRESH_COUNT times refreshing
-    assertThat(supplier.successCounter.get()).isEqualTo(FORCE_REFRESH_COUNT + 1);
   }
 
   @Test(timeout = 20000) // 45 seconds timeout in case of deadlock

--- a/core/src/test/java/com/google/cloud/sql/core/CloudSqlInstanceConcurrencyTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/CloudSqlInstanceConcurrencyTest.java
@@ -77,9 +77,9 @@ public class CloudSqlInstanceConcurrencyTest {
     // to cause a deadlock.
     ListenableFuture<List<Object>> allData =
         Futures.allAsList(
-            executor.submit(instance::getSslData),
-            executor.submit(instance::getSslData),
-            executor.submit(instance::getSslData));
+            executor.submit(() -> instance.getSslData()),
+            executor.submit(() -> instance.getSslData()),
+            executor.submit(() -> instance.getSslData()));
 
     List<Object> d = allData.get();
     assertThat(d.get(0)).isNotNull();
@@ -115,9 +115,9 @@ public class CloudSqlInstanceConcurrencyTest {
           // Attempt to get sslData 3 times, simultaneously, in different threads.
           ListenableFuture<List<Object>> allData2 =
               Futures.allAsList(
-                  executor.submit(instance::getSslData),
-                  executor.submit(instance::getSslData),
-                  executor.submit(instance::getSslData));
+                  executor.submit(() -> instance.getSslData()),
+                  executor.submit(() -> instance.getSslData()),
+                  executor.submit(() -> instance.getSslData()));
 
           // This should return immediately
           allData2.get();

--- a/core/src/test/java/com/google/cloud/sql/core/CloudSqlInstanceTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/CloudSqlInstanceTest.java
@@ -422,9 +422,17 @@ public class CloudSqlInstanceTest {
       Thread.yield();
     }
 
-    // getSslData again, and assert the refresh operation completed exactly once
+    // getSslData until the refresh operation returns the newer
+    // SslData instance
     SslData d2 = instance.getSslData(1000);
+    for (int i = 0; i < 10 && d2 != data.getSslData(); i++) {
+      Thread.sleep(10);
+    }
+
+    // assert the refresh operation completed exactly once after
+    // forceRefresh was called multiple times.
     assertThat(d2).isSameInstanceAs(data.getSslData());
+    assertThat(refreshCount.get()).isEqualTo(2);
   }
 
   @Test

--- a/core/src/test/java/com/google/cloud/sql/core/PauseCondition.java
+++ b/core/src/test/java/com/google/cloud/sql/core/PauseCondition.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.cloud.sql.core;
 
 import java.util.concurrent.atomic.AtomicBoolean;

--- a/core/src/test/java/com/google/cloud/sql/core/PauseCondition.java
+++ b/core/src/test/java/com/google/cloud/sql/core/PauseCondition.java
@@ -1,0 +1,58 @@
+package com.google.cloud.sql.core;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Supplier;
+
+/**
+ * Allows a test case to pause and continue of another thread predictably, so that unit tests don't
+ * need to rely on carefully crafted timeouts using Thread.sleep() to test sequences of execution
+ * across threads.
+ */
+class PauseCondition {
+
+  final Lock lock = new ReentrantLock();
+  final Condition allowContinue = lock.newCondition();
+  final AtomicBoolean allowProceed = new AtomicBoolean(false);
+
+  /**
+   * Waits for the condition to become true, signaling the thread that is blocked on pause() to
+   * continue.
+   */
+  public void proceedWhen(Supplier<Boolean> cond) {
+    while (!cond.get()) {
+      proceed();
+      Thread.yield();
+    }
+  }
+
+  /**
+   * Immediately signals the thread blocked on pause() to continue. Note, if the thread is not yet
+   * blocked on pause(), then it will
+   */
+  public void proceed() {
+    try {
+      lock.lock();
+      allowProceed.set(true);
+      allowContinue.signal();
+    } finally {
+      lock.unlock();
+    }
+    Thread.yield();
+  }
+
+  /** Pause until signaled to proceed. */
+  public void pause() throws InterruptedException {
+    try {
+      lock.lock();
+      while (!allowProceed.get()) {
+        allowContinue.await();
+      }
+      allowProceed.set(false);
+    } finally {
+      lock.unlock();
+    }
+  }
+}

--- a/core/src/test/java/com/google/cloud/sql/core/SqlAdminApiFetcherTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/SqlAdminApiFetcherTest.java
@@ -54,12 +54,14 @@ public class SqlAdminApiFetcherTest {
             .create(new StubCredentialFactory().create());
 
     InstanceData instanceData =
-        fetcher.getInstanceData(
-            new CloudSqlInstanceName(INSTANCE_CONNECTION_NAME),
-            () -> Optional.empty(),
-            AuthType.PASSWORD,
-            newTestExecutor(),
-            Futures.immediateFuture(mockAdminApi.getClientKeyPair()));
+        fetcher
+            .getInstanceData(
+                new CloudSqlInstanceName(INSTANCE_CONNECTION_NAME),
+                () -> Optional.empty(),
+                AuthType.PASSWORD,
+                newTestExecutor(),
+                Futures.immediateFuture(mockAdminApi.getClientKeyPair()))
+            .get();
     assertThat(instanceData.getSslContext()).isInstanceOf(SSLContext.class);
 
     Map<String, String> ipAddrs = instanceData.getIpAddrs();
@@ -83,12 +85,14 @@ public class SqlAdminApiFetcherTest {
             .create(new StubCredentialFactory().create());
 
     InstanceData instanceData =
-        fetcher.getInstanceData(
-            new CloudSqlInstanceName(INSTANCE_CONNECTION_NAME),
-            () -> Optional.empty(),
-            AuthType.PASSWORD,
-            newTestExecutor(),
-            Futures.immediateFuture(mockAdminApi.getClientKeyPair()));
+        fetcher
+            .getInstanceData(
+                new CloudSqlInstanceName(INSTANCE_CONNECTION_NAME),
+                () -> Optional.empty(),
+                AuthType.PASSWORD,
+                newTestExecutor(),
+                Futures.immediateFuture(mockAdminApi.getClientKeyPair()))
+            .get();
     assertThat(instanceData.getSslContext()).isInstanceOf(SSLContext.class);
 
     Map<String, String> ipAddrs = instanceData.getIpAddrs();
@@ -118,12 +122,14 @@ public class SqlAdminApiFetcherTest {
         assertThrows(
             ExecutionException.class,
             () -> {
-              fetcher.getInstanceData(
-                  new CloudSqlInstanceName(INSTANCE_CONNECTION_NAME),
-                  () -> Optional.empty(),
-                  AuthType.IAM,
-                  newTestExecutor(),
-                  Futures.immediateFuture(mockAdminApi.getClientKeyPair()));
+              fetcher
+                  .getInstanceData(
+                      new CloudSqlInstanceName(INSTANCE_CONNECTION_NAME),
+                      () -> Optional.empty(),
+                      AuthType.IAM,
+                      newTestExecutor(),
+                      Futures.immediateFuture(mockAdminApi.getClientKeyPair()))
+                  .get();
             });
     assertThat(ex)
         .hasMessageThat()
@@ -142,14 +148,16 @@ public class SqlAdminApiFetcherTest {
         assertThrows(
             ExecutionException.class,
             () -> {
-              fetcher.getInstanceData(
-                  new CloudSqlInstanceName(INSTANCE_CONNECTION_NAME),
-                  () -> {
-                    throw new IOException("Fake connect timeout");
-                  },
-                  AuthType.IAM,
-                  newTestExecutor(),
-                  Futures.immediateFuture(mockAdminApi.getClientKeyPair()));
+              fetcher
+                  .getInstanceData(
+                      new CloudSqlInstanceName(INSTANCE_CONNECTION_NAME),
+                      () -> {
+                        throw new IOException("Fake connect timeout");
+                      },
+                      AuthType.IAM,
+                      newTestExecutor(),
+                      Futures.immediateFuture(mockAdminApi.getClientKeyPair()))
+                  .get();
             });
 
     assertThat(ex.getCause()).hasMessageThat().contains("Fake connect timeout");

--- a/core/src/test/java/com/google/cloud/sql/core/TestDataSupplier.java
+++ b/core/src/test/java/com/google/cloud/sql/core/TestDataSupplier.java
@@ -48,7 +48,7 @@ class TestDataSupplier implements InstanceDataSupplier {
   }
 
   @Override
-  public InstanceData getInstanceData(
+  public ListenableFuture<InstanceData> getInstanceData(
       CloudSqlInstanceName instanceName,
       AccessTokenSupplier accessTokenSupplier,
       AuthType authType,
@@ -73,6 +73,6 @@ class TestDataSupplier implements InstanceDataSupplier {
               return response;
             });
 
-    return f.get();
+    return f;
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -153,6 +153,7 @@
           <compilerArgs>
             <arg>-XDcompilePolicy=simple</arg>
             <arg>-Xplugin:ErrorProne</arg>
+            <arg>-Xlint:-options</arg>
             <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
             <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
             <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>


### PR DESCRIPTION
Rewrite the performRefresh() as a chain of task futures from the ListeningScheduledExecutorService. Now, tasks
submitted to the ListeningScheduledExecutorService never block on another task submitted to the ListeningScheduledExecutorService.

This should fix a category of bugs that show up in exceptions and logs as "connection timed out" or "refresh failed"
or "bad client certificate". These exceptions can occur when the credentials fail to refresh. 

This is the underlying bug: The ListeningScheduledExecutorService gets into a state where all its threads are busy 
running tasks, all running tasks are blocked waiting for recently submitted task to complete, and the recently
submitted tasks can't start because there are no available threads in the ListeningScheduledExecutorService. 