### PR TITLE
deps: Update dependency graalvm to v23.1.0

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -118,7 +118,7 @@
       </dependency>
       <dependency>
         <groupId>org.graalvm.sdk</groupId>
-        <artifactId>graal-sdk</artifactId>
+        <artifactId>nativeimage</artifactId>
         <version>${graal-sdk.version}</version>
       </dependency>
       <dependency>
@@ -224,7 +224,7 @@
 
     <dependency>
       <groupId>org.graalvm.sdk</groupId>
-      <artifactId>graal-sdk</artifactId>
+      <artifactId>nativeimage</artifactId>
       <scope>provided</scope>
     </dependency>
     <!-- GAX provides native-image metadata for core Google libraries, such as

--- a/jdbc/mariadb/pom.xml
+++ b/jdbc/mariadb/pom.xml
@@ -115,7 +115,7 @@
       </dependency>
       <dependency>
         <groupId>org.graalvm.sdk</groupId>
-        <artifactId>graal-sdk</artifactId>
+        <artifactId>nativeimage</artifactId>
         <version>${graal-sdk.version}</version>
       </dependency>
       <dependency>

--- a/jdbc/mysql-j-8/pom.xml
+++ b/jdbc/mysql-j-8/pom.xml
@@ -113,7 +113,7 @@
       </dependency>
       <dependency>
         <groupId>org.graalvm.sdk</groupId>
-        <artifactId>graal-sdk</artifactId>
+        <artifactId>nativeimage</artifactId>
         <version>${graal-sdk.version}</version>
       </dependency>
       <dependency>

--- a/jdbc/postgres/pom.xml
+++ b/jdbc/postgres/pom.xml
@@ -109,7 +109,7 @@
       </dependency>
       <dependency>
         <groupId>org.graalvm.sdk</groupId>
-        <artifactId>graal-sdk</artifactId>
+        <artifactId>nativeimage</artifactId>
         <version>${graal-sdk.version}</version>
       </dependency>
       <dependency>

--- a/jdbc/sqlserver/pom.xml
+++ b/jdbc/sqlserver/pom.xml
@@ -109,7 +109,7 @@
       </dependency>
       <dependency>
         <groupId>org.graalvm.sdk</groupId>
-        <artifactId>graal-sdk</artifactId>
+        <artifactId>nativeimage</artifactId>
         <version>${graal-sdk.version}</version>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <javac.version>9+181-r4173-1</javac.version>
     <native-image.version>0.9.27</native-image.version>
-    <graal-sdk.version>23.0.1</graal-sdk.version>
+    <graal-sdk.version>23.1.0</graal-sdk.version>
     <assembly.skipAssembly>true</assembly.skipAssembly>
   </properties>
 

--- a/r2dbc/core/pom.xml
+++ b/r2dbc/core/pom.xml
@@ -97,7 +97,7 @@
       </dependency>
       <dependency>
         <groupId>org.graalvm.sdk</groupId>
-        <artifactId>graal-sdk</artifactId>
+        <artifactId>nativeimage</artifactId>
         <version>${graal-sdk.version}</version>
       </dependency>
       <dependency>

--- a/r2dbc/mysql/pom.xml
+++ b/r2dbc/mysql/pom.xml
@@ -163,7 +163,7 @@
       </dependency>
       <dependency>
         <groupId>org.graalvm.sdk</groupId>
-        <artifactId>graal-sdk</artifactId>
+        <artifactId>nativeimage</artifactId>
         <version>${graal-sdk.version}</version>
       </dependency>
       <dependency>

--- a/r2dbc/postgres/pom.xml
+++ b/r2dbc/postgres/pom.xml
@@ -169,7 +169,7 @@
       </dependency>
       <dependency>
         <groupId>org.graalvm.sdk</groupId>
-        <artifactId>graal-sdk</artifactId>
+        <artifactId>nativeimage</artifactId>
         <version>${graal-sdk.version}</version>
       </dependency>
       <dependency>

--- a/r2dbc/sqlserver/pom.xml
+++ b/r2dbc/sqlserver/pom.xml
@@ -164,7 +164,7 @@
       </dependency>
       <dependency>
         <groupId>org.graalvm.sdk</groupId>
-        <artifactId>graal-sdk</artifactId>
+        <artifactId>nativeimage</artifactId>
         <version>${graal-sdk.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
Update dependency graalvm to `v23.1.0` and use module `nativeimage`.

Note: The GraalVM SDK `v23.1.0` was split into several more fine-grained modules. The use of the `graalvm-sdk` module is now deprecated ([CHANGELOG](https://github.com/oracle/graal/blob/f72c19ac64e20d94b7166426b303e4e860f58d07/sdk/CHANGELOG.md)).