### PR TITLE
chore: fix lint warnings

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -207,12 +207,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.google.auth</groupId>
-      <artifactId>google-auth-library-credentials</artifactId>
-      <version>1.19.0</version>
-    </dependency>
-
-    <dependency>
       <groupId>com.google.oauth-client</groupId>
       <artifactId>google-oauth-client</artifactId>
       <version>1.34.1</version>

--- a/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
@@ -21,6 +21,7 @@ import com.google.cloud.sql.AuthType;
 import com.google.cloud.sql.CredentialFactory;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
@@ -252,13 +253,13 @@ public final class CoreSocketFactory {
    * Converts the string property of IP types to a list by splitting by commas, and upper-casing.
    */
   private static List<String> listIpTypes(String cloudSqlIpTypes) {
-    String[] rawTypes = cloudSqlIpTypes.split(",");
-    ArrayList<String> result = new ArrayList<>(rawTypes.length);
-    for (int i = 0; i < rawTypes.length; i++) {
-      if (rawTypes[i].trim().equalsIgnoreCase("PUBLIC")) {
-        result.add(i, "PRIMARY");
+    List<String> rawTypes = Splitter.on(',').splitToList(cloudSqlIpTypes);
+    ArrayList<String> result = new ArrayList<>(rawTypes.size());
+    for (String type : rawTypes) {
+      if (type.trim().equalsIgnoreCase("PUBLIC")) {
+        result.add("PRIMARY");
       } else {
-        result.add(i, rawTypes[i].trim().toUpperCase());
+        result.add(type.trim().toUpperCase());
       }
     }
     return result;

--- a/core/src/test/java/com/google/cloud/sql/core/CloudSqlInstanceConcurrencyTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/CloudSqlInstanceConcurrencyTest.java
@@ -49,6 +49,7 @@ public class CloudSqlInstanceConcurrencyTest {
       return this;
     }
 
+    @Override
     public void initialize(HttpRequest var1) throws IOException {
       // do nothing
     }
@@ -101,10 +102,9 @@ public class CloudSqlInstanceConcurrencyTest {
       instance.forceRefresh();
       // force Java to run a different thread now. That gives the refresh task an opportunity to
       // start.
-      Thread.yield();
+      Thread.sleep(0);
       instance.forceRefresh();
       instance.forceRefresh();
-      Thread.yield();
 
       Thread.sleep(DEFAULT_WAIT); // Wait for the refresh to occur
 
@@ -209,7 +209,7 @@ public class CloudSqlInstanceConcurrencyTest {
               inst.forceRefresh();
               inst.forceRefresh();
               inst.forceRefresh();
-              Thread.yield();
+              Thread.sleep(0);
               inst.getSslData();
             } catch (Exception e) {
               logger.info("Exception in force refresh loop.");

--- a/core/src/test/java/com/google/cloud/sql/core/CoreSocketFactoryTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/CoreSocketFactoryTest.java
@@ -148,13 +148,12 @@ public class CoreSocketFactoryTest extends CloudSqlCoreTestingBase {
         new CoreSocketFactory(clientKeyPair, factory, credentialFactory, port, defaultExecutor);
     try {
 
-      Socket socket =
-          coreSocketFactory.createSslSocket(
-              "myProject:myRegion:myInstance",
-              Collections.singletonList("PRIMARY"),
-              AuthType.PASSWORD,
-              null,
-              Arrays.asList("delegate-service-principal@example.com"));
+      coreSocketFactory.createSslSocket(
+          "myProject:myRegion:myInstance",
+          Collections.singletonList("PRIMARY"),
+          AuthType.PASSWORD,
+          null,
+          Arrays.asList("delegate-service-principal@example.com"));
       fail("IllegalArgumentException expected.");
     } catch (IllegalArgumentException e) {
       assertThat(e.getMessage()).contains(CoreSocketFactory.CLOUD_SQL_TARGET_PRINCIPAL_PROPERTY);

--- a/core/src/test/java/com/google/cloud/sql/core/StubApiFetcherFactory.java
+++ b/core/src/test/java/com/google/cloud/sql/core/StubApiFetcherFactory.java
@@ -21,7 +21,6 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.client.testing.http.MockHttpTransport;
 import com.google.api.services.sqladmin.SQLAdmin;
-import com.google.api.services.sqladmin.SQLAdmin.Builder;
 
 public class StubApiFetcherFactory implements ApiFetcherFactory {
 
@@ -34,7 +33,7 @@ public class StubApiFetcherFactory implements ApiFetcherFactory {
   @Override
   public SqlAdminApiFetcher create(HttpRequestInitializer credentials) {
     SQLAdmin sqlAdmin =
-        new Builder(
+        new SQLAdmin.Builder(
                 httpTransport != null ? httpTransport : new MockHttpTransport(),
                 GsonFactory.getDefaultInstance(),
                 credentials)

--- a/jdbc/mariadb/src/test/java/com/google/cloud/sql/mariadb/JdbcMariaDBIamAuthIntegrationTests.java
+++ b/jdbc/mariadb/src/test/java/com/google/cloud/sql/mariadb/JdbcMariaDBIamAuthIntegrationTests.java
@@ -46,7 +46,6 @@ public class JdbcMariaDBIamAuthIntegrationTests {
   @Rule public Timeout globalTimeout = new Timeout(60, TimeUnit.SECONDS);
 
   private HikariDataSource connectionPool;
-  private String tableName;
 
   @BeforeClass
   public static void checkEnvVars() {

--- a/pom.xml
+++ b/pom.xml
@@ -171,6 +171,7 @@
               <version>2.10.0</version>
             </path>
           </annotationProcessorPaths>
+          <failOnWarning>true</failOnWarning>
         </configuration>
       </plugin>
 


### PR DESCRIPTION
Fixes #1460

Notes:

* Now the build fails on warnings.
* `Thread.yield();` triggers the warning [ThreadPriorityCheck](https://errorprone.info/bugpattern/ThreadPriorityCheck). So I replaced it by `Thread.sleep(0);` as they may call same system calls in some platforms. Please let me know if you have any other suggestions.