### PR TITLE
chore: group org.ow2.asm dependencies in renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -95,6 +95,12 @@
         "^ossf/scorecard-action"
       ],
       "groupName": "dependencies for github"
+    },
+    {
+      "matchPackagePatterns": [
+        "^org.ow2.asm"
+      ],
+      "groupName": "org.ow2.asm dependencies"
     }
   ]
 }


### PR DESCRIPTION
Fixes #1565