### PR TITLE
test: set timeout for refresh operation in CoreSocketFactory.

### DIFF
--- a/core/src/test/java/com/google/cloud/sql/core/CloudSqlInstanceConcurrencyTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/CloudSqlInstanceConcurrencyTest.java
@@ -78,7 +78,7 @@ public class CloudSqlInstanceConcurrencyTest {
     }
 
     // Get SSL Data for each instance, forcing the first refresh to complete.
-    instances.forEach(CloudSqlInstance::getSslData);
+    instances.forEach((inst) -> inst.getSslData(2000L));
 
     assertThat(supplier.counter.get()).isEqualTo(instanceCount);
 
@@ -117,7 +117,7 @@ public class CloudSqlInstanceConcurrencyTest {
               inst.forceRefresh();
               inst.forceRefresh();
               Thread.sleep(0);
-              inst.getSslData();
+              inst.getSslData(2000L);
             } catch (Exception e) {
               logger.info("Exception in force refresh loop.");
             }

--- a/core/src/test/java/com/google/cloud/sql/core/CoreSocketFactoryTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/CoreSocketFactoryTest.java
@@ -43,6 +43,7 @@ import org.junit.runners.JUnit4;
 // TODO(berezv): add multithreaded test
 @RunWith(JUnit4.class)
 public class CoreSocketFactoryTest extends CloudSqlCoreTestingBase {
+  private final long TEST_MAX_REFRESH_MS = 5000L;
 
   ListeningScheduledExecutorService defaultExecutor;
 
@@ -62,7 +63,8 @@ public class CoreSocketFactoryTest extends CloudSqlCoreTestingBase {
     ApiFetcherFactory factory =
         new StubApiFetcherFactory(fakeSuccessHttpTransport(Duration.ofSeconds(0)));
     CoreSocketFactory coreSocketFactory =
-        new CoreSocketFactory(clientKeyPair, factory, credentialFactory, 3307, defaultExecutor);
+        new CoreSocketFactory(
+            clientKeyPair, factory, credentialFactory, 3307, TEST_MAX_REFRESH_MS, defaultExecutor);
     try {
       coreSocketFactory.createSslSocket(
           "myProject",
@@ -95,7 +97,8 @@ public class CoreSocketFactoryTest extends CloudSqlCoreTestingBase {
     ApiFetcherFactory factory =
         new StubApiFetcherFactory(fakeSuccessHttpTransport(Duration.ofSeconds(0)));
     CoreSocketFactory coreSocketFactory =
-        new CoreSocketFactory(clientKeyPair, factory, credentialFactory, 3307, defaultExecutor);
+        new CoreSocketFactory(
+            clientKeyPair, factory, credentialFactory, 3307, TEST_MAX_REFRESH_MS, defaultExecutor);
     try {
       coreSocketFactory.createSslSocket(
           "myProject:notMyRegion:myInstance",
@@ -125,7 +128,8 @@ public class CoreSocketFactoryTest extends CloudSqlCoreTestingBase {
     ApiFetcherFactory factory =
         new StubApiFetcherFactory(fakeSuccessHttpTransport(Duration.ofSeconds(0)));
     CoreSocketFactory coreSocketFactory =
-        new CoreSocketFactory(clientKeyPair, factory, credentialFactory, port, defaultExecutor);
+        new CoreSocketFactory(
+            clientKeyPair, factory, credentialFactory, port, TEST_MAX_REFRESH_MS, defaultExecutor);
     Socket socket =
         coreSocketFactory.createSslSocket(
             "myProject:myRegion:myInstance",
@@ -145,7 +149,8 @@ public class CoreSocketFactoryTest extends CloudSqlCoreTestingBase {
     ApiFetcherFactory factory =
         new StubApiFetcherFactory(fakeSuccessHttpTransport(Duration.ofSeconds(0)));
     CoreSocketFactory coreSocketFactory =
-        new CoreSocketFactory(clientKeyPair, factory, credentialFactory, port, defaultExecutor);
+        new CoreSocketFactory(
+            clientKeyPair, factory, credentialFactory, port, TEST_MAX_REFRESH_MS, defaultExecutor);
     try {
 
       coreSocketFactory.createSslSocket(
@@ -168,7 +173,8 @@ public class CoreSocketFactoryTest extends CloudSqlCoreTestingBase {
     ApiFetcherFactory factory =
         new StubApiFetcherFactory(fakeSuccessHttpTransport(Duration.ofSeconds(0)));
     CoreSocketFactory coreSocketFactory =
-        new CoreSocketFactory(clientKeyPair, factory, credentialFactory, port, defaultExecutor);
+        new CoreSocketFactory(
+            clientKeyPair, factory, credentialFactory, port, TEST_MAX_REFRESH_MS, defaultExecutor);
 
     Socket socket =
         coreSocketFactory.createSslSocket(
@@ -189,7 +195,8 @@ public class CoreSocketFactoryTest extends CloudSqlCoreTestingBase {
     ApiFetcherFactory factory =
         new StubApiFetcherFactory(fakeSuccessHttpTransport(Duration.ofSeconds(0)));
     CoreSocketFactory coreSocketFactory =
-        new CoreSocketFactory(clientKeyPair, factory, credentialFactory, port, defaultExecutor);
+        new CoreSocketFactory(
+            clientKeyPair, factory, credentialFactory, port, TEST_MAX_REFRESH_MS, defaultExecutor);
     Socket socket =
         coreSocketFactory.createSslSocket(
             "example.com:myProject:myRegion:myInstance",
@@ -204,7 +211,8 @@ public class CoreSocketFactoryTest extends CloudSqlCoreTestingBase {
   public void create_adminApiNotEnabled() throws IOException {
     ApiFetcherFactory factory = new StubApiFetcherFactory(fakeNotConfiguredException());
     CoreSocketFactory coreSocketFactory =
-        new CoreSocketFactory(clientKeyPair, factory, credentialFactory, 3307, defaultExecutor);
+        new CoreSocketFactory(
+            clientKeyPair, factory, credentialFactory, 3307, TEST_MAX_REFRESH_MS, defaultExecutor);
     try {
       // Use a different project to get Api Not Enabled Error.
       coreSocketFactory.createSslSocket(
@@ -228,7 +236,8 @@ public class CoreSocketFactoryTest extends CloudSqlCoreTestingBase {
   public void create_notAuthorized() throws IOException {
     ApiFetcherFactory factory = new StubApiFetcherFactory(fakeNotAuthorizedException());
     CoreSocketFactory coreSocketFactory =
-        new CoreSocketFactory(clientKeyPair, factory, credentialFactory, 3307, defaultExecutor);
+        new CoreSocketFactory(
+            clientKeyPair, factory, credentialFactory, 3307, TEST_MAX_REFRESH_MS, defaultExecutor);
     try {
       // Use a different instance to simulate incorrect permissions.
       coreSocketFactory.createSslSocket(
@@ -262,7 +271,13 @@ public class CoreSocketFactoryTest extends CloudSqlCoreTestingBase {
         new StubApiFetcherFactory(fakeSuccessHttpTransport(Duration.ofSeconds(0)));
 
     CoreSocketFactory coreSocketFactory =
-        new CoreSocketFactory(clientKeyPair, factory, stubCredentialFactory, port, defaultExecutor);
+        new CoreSocketFactory(
+            clientKeyPair,
+            factory,
+            stubCredentialFactory,
+            port,
+            TEST_MAX_REFRESH_MS,
+            defaultExecutor);
     Socket socket =
         coreSocketFactory.createSslSocket(
             "myProject:myRegion:myInstance",
@@ -285,7 +300,13 @@ public class CoreSocketFactoryTest extends CloudSqlCoreTestingBase {
     ApiFetcherFactory factory =
         new StubApiFetcherFactory(fakeSuccessHttpTransport(Duration.ofSeconds(0)));
     CoreSocketFactory coreSocketFactory =
-        new CoreSocketFactory(clientKeyPair, factory, stubCredentialFactory, port, defaultExecutor);
+        new CoreSocketFactory(
+            clientKeyPair,
+            factory,
+            stubCredentialFactory,
+            port,
+            TEST_MAX_REFRESH_MS,
+            defaultExecutor);
     Socket socket =
         coreSocketFactory.createSslSocket(
             "myProject:myRegion:myInstance",
@@ -315,7 +336,13 @@ public class CoreSocketFactoryTest extends CloudSqlCoreTestingBase {
     ApiFetcherFactory factory =
         new StubApiFetcherFactory(fakeSuccessHttpTransport(Duration.ofSeconds(0)));
     CoreSocketFactory coreSocketFactory =
-        new CoreSocketFactory(clientKeyPair, factory, stubCredentialFactory, port, defaultExecutor);
+        new CoreSocketFactory(
+            clientKeyPair,
+            factory,
+            stubCredentialFactory,
+            port,
+            TEST_MAX_REFRESH_MS,
+            defaultExecutor);
     assertThrows(
         RuntimeException.class,
         () ->

--- a/r2dbc/core/src/test/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderTest.java
+++ b/r2dbc/core/src/test/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderTest.java
@@ -178,6 +178,12 @@ public class GcpConnectionFactoryProviderTest {
         new StubApiFetcherFactory(fakeSuccessHttpTransport(Duration.ofSeconds(0)));
 
     coreSocketFactoryStub =
-        new CoreSocketFactory(clientKeyPair, fetcher, credentialFactory, 3307, defaultExecutor);
+        new CoreSocketFactory(
+            clientKeyPair,
+            fetcher,
+            credentialFactory,
+            3307,
+            CoreSocketFactory.DEFAULT_MAX_REFRESH_MS,
+            defaultExecutor);
   }
 }


### PR DESCRIPTION
Introduce a new testing parameter to the CoreSocketFactory that sets a maximum time to wait to establish a socket
connection before throwing a TimeoutException. This will make running CoreSocketFactoryTest for failures go 
much faster. 

Also this is a step towards improving the refresh operation.