### PR TITLE
fix: Improve handling of futures and threads during refresh.

### DIFF
--- a/core/src/main/java/com/google/cloud/sql/core/InstanceDataSupplier.java
+++ b/core/src/main/java/com/google/cloud/sql/core/InstanceDataSupplier.java
@@ -30,7 +30,7 @@ interface InstanceDataSupplier {
    * @throws ExecutionException if an exception is thrown during execution.
    * @throws InterruptedException if the executor is interrupted.
    */
-  InstanceData getInstanceData(
+  ListenableFuture<InstanceData> getInstanceData(
       CloudSqlInstanceName instanceName,
       AccessTokenSupplier accessTokenSupplier,
       AuthType authType,

--- a/core/src/main/java/com/google/cloud/sql/core/SqlAdminApiFetcher.java
+++ b/core/src/main/java/com/google/cloud/sql/core/SqlAdminApiFetcher.java
@@ -95,7 +95,7 @@ class SqlAdminApiFetcher implements InstanceDataSupplier {
    * @throws InterruptedException if the executor is interrupted.
    */
   @Override
-  public InstanceData getInstanceData(
+  public ListenableFuture<InstanceData> getInstanceData(
       CloudSqlInstanceName instanceName,
       AccessTokenSupplier accessTokenSupplier,
       AuthType authType,
@@ -163,9 +163,9 @@ class SqlAdminApiFetcher implements InstanceDataSupplier {
                 },
                 executor);
 
-    InstanceData instanceData = done.get();
-    logger.fine(String.format("[%s] ALL FUTURES DONE", instanceName));
-    return instanceData;
+    done.addListener(
+        () -> logger.fine(String.format("[%s] ALL FUTURES DONE", instanceName)), executor);
+    return done;
   }
 
   String getApplicationName() {

--- a/core/src/test/java/com/google/cloud/sql/core/SqlAdminApiFetcherTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/SqlAdminApiFetcherTest.java
@@ -54,12 +54,14 @@ public class SqlAdminApiFetcherTest {
             .create(new StubCredentialFactory().create());
 
     InstanceData instanceData =
-        fetcher.getInstanceData(
-            new CloudSqlInstanceName(INSTANCE_CONNECTION_NAME),
-            () -> Optional.empty(),
-            AuthType.PASSWORD,
-            newTestExecutor(),
-            Futures.immediateFuture(mockAdminApi.getClientKeyPair()));
+        fetcher
+            .getInstanceData(
+                new CloudSqlInstanceName(INSTANCE_CONNECTION_NAME),
+                () -> Optional.empty(),
+                AuthType.PASSWORD,
+                newTestExecutor(),
+                Futures.immediateFuture(mockAdminApi.getClientKeyPair()))
+            .get();
     assertThat(instanceData.getSslContext()).isInstanceOf(SSLContext.class);
 
     Map<String, String> ipAddrs = instanceData.getIpAddrs();
@@ -83,12 +85,14 @@ public class SqlAdminApiFetcherTest {
             .create(new StubCredentialFactory().create());
 
     InstanceData instanceData =
-        fetcher.getInstanceData(
-            new CloudSqlInstanceName(INSTANCE_CONNECTION_NAME),
-            () -> Optional.empty(),
-            AuthType.PASSWORD,
-            newTestExecutor(),
-            Futures.immediateFuture(mockAdminApi.getClientKeyPair()));
+        fetcher
+            .getInstanceData(
+                new CloudSqlInstanceName(INSTANCE_CONNECTION_NAME),
+                () -> Optional.empty(),
+                AuthType.PASSWORD,
+                newTestExecutor(),
+                Futures.immediateFuture(mockAdminApi.getClientKeyPair()))
+            .get();
     assertThat(instanceData.getSslContext()).isInstanceOf(SSLContext.class);
 
     Map<String, String> ipAddrs = instanceData.getIpAddrs();
@@ -118,12 +122,14 @@ public class SqlAdminApiFetcherTest {
         assertThrows(
             ExecutionException.class,
             () -> {
-              fetcher.getInstanceData(
-                  new CloudSqlInstanceName(INSTANCE_CONNECTION_NAME),
-                  () -> Optional.empty(),
-                  AuthType.IAM,
-                  newTestExecutor(),
-                  Futures.immediateFuture(mockAdminApi.getClientKeyPair()));
+              fetcher
+                  .getInstanceData(
+                      new CloudSqlInstanceName(INSTANCE_CONNECTION_NAME),
+                      () -> Optional.empty(),
+                      AuthType.IAM,
+                      newTestExecutor(),
+                      Futures.immediateFuture(mockAdminApi.getClientKeyPair()))
+                  .get();
             });
     assertThat(ex)
         .hasMessageThat()
@@ -142,14 +148,16 @@ public class SqlAdminApiFetcherTest {
         assertThrows(
             ExecutionException.class,
             () -> {
-              fetcher.getInstanceData(
-                  new CloudSqlInstanceName(INSTANCE_CONNECTION_NAME),
-                  () -> {
-                    throw new IOException("Fake connect timeout");
-                  },
-                  AuthType.IAM,
-                  newTestExecutor(),
-                  Futures.immediateFuture(mockAdminApi.getClientKeyPair()));
+              fetcher
+                  .getInstanceData(
+                      new CloudSqlInstanceName(INSTANCE_CONNECTION_NAME),
+                      () -> {
+                        throw new IOException("Fake connect timeout");
+                      },
+                      AuthType.IAM,
+                      newTestExecutor(),
+                      Futures.immediateFuture(mockAdminApi.getClientKeyPair()))
+                  .get();
             });
 
     assertThat(ex.getCause()).hasMessageThat().contains("Fake connect timeout");

--- a/core/src/test/java/com/google/cloud/sql/core/TestDataSupplier.java
+++ b/core/src/test/java/com/google/cloud/sql/core/TestDataSupplier.java
@@ -48,7 +48,7 @@ class TestDataSupplier implements InstanceDataSupplier {
   }
 
   @Override
-  public InstanceData getInstanceData(
+  public ListenableFuture<InstanceData> getInstanceData(
       CloudSqlInstanceName instanceName,
       AccessTokenSupplier accessTokenSupplier,
       AuthType authType,
@@ -73,6 +73,6 @@ class TestDataSupplier implements InstanceDataSupplier {
               return response;
             });
 
-    return f.get();
+    return f;
   }
 }


### PR DESCRIPTION
Rewrite the performRefresh() as a chain of task futures from the ListeningScheduledExecutorService. Now, tasks
submitted to the ListeningScheduledExecutorService never block on another task submitted to the ListeningScheduledExecutorService.

This should fix a category of bugs that show up in exceptions and logs as "connection timed out" or "refresh failed"
or "bad client certificate". These exceptions can occur when the credentials fail to refresh.

This is the underlying bug: The ListeningScheduledExecutorService gets into a state where all its threads are busy
running tasks, all running tasks are blocked waiting for recently submitted task to complete, and the recently
submitted tasks can't start because there are no available threads in the ListeningScheduledExecutorService.

This changes the behavior of CloudSqlInstance.getInstanceData() and CloudSqlInstance.startRefreshAttempt()
in ways that have a very small possibility of destabilizing customer applications. 

In version 1.14.1 and earlier:  CloudSqlInstance.getInstanceData() behaved like this: When no refresh attempt is 
in progress, returns immediately. Otherwise, blocks application thread until the current refresh attempt finishes. 
If the refresh attempt succeeds, this returns the InstanceData. If not, this throws a RuntimeException, while a 
new refresh attempt is submitted to the executor in the background.