### PR TITLE
chore: group com.google.auth dependencies in renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -101,6 +101,12 @@
         "^org.ow2.asm"
       ],
       "groupName": "org.ow2.asm dependencies"
+    },
+    {
+      "matchPackagePatterns": [
+        "^com.google.auth"
+      ],
+      "groupName": "com.google.auth dependencies"
     }
   ]
 }


### PR DESCRIPTION
Fixes #1578