### PR TITLE
chore: ignore java 8 deprecation warnings.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,6 +153,7 @@
           <compilerArgs>
             <arg>-XDcompilePolicy=simple</arg>
             <arg>-Xplugin:ErrorProne</arg>
+            <arg>-Xlint:-options</arg> <!-- ignore warning about deprecated java 8 src -->
             <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
             <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
             <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>


### PR DESCRIPTION
Java compilers v20 and higher issue a warning that java 8 source will be deprecated. This change causes 
the compiler not to treat this warning as an error. 