### PR TITLE
chore: Create a connector configuration value object

### DIFF
--- a/core/src/main/java/com/google/cloud/sql/ConnectionConfig.java
+++ b/core/src/main/java/com/google/cloud/sql/ConnectionConfig.java
@@ -22,7 +22,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
-import java.util.stream.Collectors;
 
 /**
  * ConnectionConfig is an immutable configuration value object that holds the entire configuration
@@ -131,8 +130,8 @@ public class ConnectionConfig {
     return delegates;
   }
 
-  public List<String> getIpTypes() {
-    return ipTypes.stream().map(IpType::getApiName).collect(Collectors.toList());
+  public List<IpType> getIpTypes() {
+    return ipTypes;
   }
 
   /** The builder for the ConnectionConfig. */

--- a/core/src/main/java/com/google/cloud/sql/ConnectionConfig.java
+++ b/core/src/main/java/com/google/cloud/sql/ConnectionConfig.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.sql;
+
+import com.google.common.base.Splitter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.stream.Collectors;
+
+/**
+ * ConnectionConfig is an immutable configuration value object that holds the entire configuration
+ * of a CloudSqlInstance connection.
+ */
+public class ConnectionConfig {
+
+  public static final String CLOUD_SQL_INSTANCE_PROPERTY = "cloudSqlInstance";
+  public static final String CLOUD_SQL_DELEGATES_PROPERTY = "cloudSqlDelegates";
+  public static final String CLOUD_SQL_TARGET_PRINCIPAL_PROPERTY = "cloudSqlTargetPrincipal";
+  public static final String UNIX_SOCKET_PROPERTY = "unixSocketPath";
+  public static final String ENABLE_IAM_AUTH_PROPERTY = "enableIamAuth";
+  public static final String IP_TYPES_PROPERTY = "ipTypes";
+  public static final String DEFAULT_IP_TYPES = "PUBLIC,PRIVATE";
+  public static final List<IpType> DEFAULT_IP_TYPE_LIST =
+      Arrays.asList(IpType.PUBLIC, IpType.PRIVATE);
+  public static final AuthType DEFAULT_AUTH_TYPE = AuthType.PASSWORD;
+  private final String cloudSqlInstance;
+  private final String targetPrincipal;
+  private final List<String> delegates;
+  private final String unixSocketPath;
+  private final AuthType authType;
+  private final List<IpType> ipTypes;
+
+  /** Create a new ConnectionConfig from the well known JDBC Connection properties. */
+  public static ConnectionConfig fromConnectionProperties(Properties props) {
+    final String csqlInstanceName = props.getProperty(ConnectionConfig.CLOUD_SQL_INSTANCE_PROPERTY);
+    final String unixSocketPath = props.getProperty(ConnectionConfig.UNIX_SOCKET_PROPERTY);
+    final AuthType authType =
+        Boolean.parseBoolean(props.getProperty(ConnectionConfig.ENABLE_IAM_AUTH_PROPERTY))
+            ? AuthType.IAM
+            : AuthType.PASSWORD;
+    final String targetPrincipal =
+        props.getProperty(ConnectionConfig.CLOUD_SQL_TARGET_PRINCIPAL_PROPERTY);
+    final String delegatesStr = props.getProperty(ConnectionConfig.CLOUD_SQL_DELEGATES_PROPERTY);
+    final List<String> delegates;
+    if (delegatesStr != null && !delegatesStr.isEmpty()) {
+      delegates = Arrays.asList(delegatesStr.split(","));
+    } else {
+      delegates = Collections.emptyList();
+    }
+    final List<IpType> ipTypes =
+        listIpTypes(
+            props.getProperty(
+                ConnectionConfig.IP_TYPES_PROPERTY, ConnectionConfig.DEFAULT_IP_TYPES));
+
+    return new ConnectionConfig(
+        csqlInstanceName, targetPrincipal, delegates, unixSocketPath, authType, ipTypes);
+  }
+
+  /**
+   * Converts the string property of IP types to a list by splitting by commas, and upper-casing.
+   */
+  private static List<IpType> listIpTypes(String cloudSqlIpTypes) {
+    List<String> rawTypes = Splitter.on(',').splitToList(cloudSqlIpTypes);
+    ArrayList<IpType> result = new ArrayList<>(rawTypes.size());
+    for (String type : rawTypes) {
+      if (type.trim().equalsIgnoreCase("PUBLIC")) {
+        result.add(IpType.PUBLIC);
+      } else if (type.trim().equalsIgnoreCase("PRIMARY")) {
+        result.add(IpType.PUBLIC);
+      } else if (type.trim().equalsIgnoreCase("PRIVATE")) {
+        result.add(IpType.PRIVATE);
+      } else if (type.trim().equalsIgnoreCase("PSC")) {
+        result.add(IpType.PSC);
+      } else {
+        throw new IllegalArgumentException(
+            "Unsupported IP type: " + type + " found in ipTypes parameter");
+      }
+    }
+    return result;
+  }
+
+  private ConnectionConfig(
+      String cloudSqlInstance,
+      String targetPrincipal,
+      List<String> delegates,
+      String unixSocketPath,
+      AuthType authType,
+      List<IpType> ipTypes) {
+    this.cloudSqlInstance = cloudSqlInstance;
+    this.targetPrincipal = targetPrincipal;
+    this.delegates = delegates;
+    this.unixSocketPath = unixSocketPath;
+    this.authType = authType;
+    this.ipTypes = ipTypes;
+  }
+
+  public String getCloudSqlInstance() {
+    return cloudSqlInstance;
+  }
+
+  public String getTargetPrincipal() {
+    return targetPrincipal;
+  }
+
+  public String getUnixSocketPath() {
+    return unixSocketPath;
+  }
+
+  public AuthType getAuthType() {
+    return authType;
+  }
+
+  public List<String> getDelegates() {
+    return delegates;
+  }
+
+  public List<String> getIpTypes() {
+    return ipTypes.stream().map(IpType::getApiName).collect(Collectors.toList());
+  }
+
+  /** The builder for the ConnectionConfig. */
+  public static class Builder {
+
+    private String cloudSqlInstance;
+    private String targetPrincipal;
+    private List<String> delegates;
+    private String unixSocketPath;
+    private AuthType authType = DEFAULT_AUTH_TYPE;
+    private List<IpType> ipTypes = DEFAULT_IP_TYPE_LIST;
+
+    public Builder withCloudSqlInstance(String cloudSqlInstance) {
+      this.cloudSqlInstance = cloudSqlInstance;
+      return this;
+    }
+
+    public Builder withTargetPrincipal(String targetPrincipal) {
+      this.targetPrincipal = targetPrincipal;
+      return this;
+    }
+
+    public Builder withDelegates(List<String> delegates) {
+      this.delegates = delegates;
+      return this;
+    }
+
+    public Builder withUnixSocketPath(String unixSocketPath) {
+      this.unixSocketPath = unixSocketPath;
+      return this;
+    }
+
+    public Builder withAuthType(AuthType authType) {
+      this.authType = authType;
+      return this;
+    }
+
+    /** Use ipTypes as a comma-delimited string. */
+    public Builder withIpTypes(String ipTypes) {
+      this.ipTypes = listIpTypes(ipTypes);
+      return this;
+    }
+
+    /** Use ipTypes as a comma-delimited string. */
+    public Builder withIpTypes(List<IpType> ipTypes) {
+      this.ipTypes = ipTypes;
+      return this;
+    }
+
+    public ConnectionConfig build() {
+      return new ConnectionConfig(
+          cloudSqlInstance, targetPrincipal, delegates, unixSocketPath, authType, ipTypes);
+    }
+  }
+}

--- a/core/src/main/java/com/google/cloud/sql/IpType.java
+++ b/core/src/main/java/com/google/cloud/sql/IpType.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.sql;
+
+/** IP types that for connecting to a Cloud SQL Database. */
+public enum IpType {
+  PUBLIC("PRIMARY"),
+  PRIVATE("PRIVATE"),
+  PSC("PSC");
+  private final String apiName;
+
+  IpType(String apiName) {
+    this.apiName = apiName;
+  }
+
+  public String getApiName() {
+    return apiName;
+  }
+}

--- a/core/src/main/java/com/google/cloud/sql/IpType.java
+++ b/core/src/main/java/com/google/cloud/sql/IpType.java
@@ -18,16 +18,7 @@ package com.google.cloud.sql;
 
 /** IP types that for connecting to a Cloud SQL Database. */
 public enum IpType {
-  PUBLIC("PRIMARY"),
-  PRIVATE("PRIVATE"),
-  PSC("PSC");
-  private final String apiName;
-
-  IpType(String apiName) {
-    this.apiName = apiName;
-  }
-
-  public String getApiName() {
-    return apiName;
-  }
+  PUBLIC,
+  PRIVATE,
+  PSC;
 }

--- a/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstance.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstance.java
@@ -36,6 +36,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import javax.net.ssl.SSLSocket;
 
 /**
@@ -179,7 +180,8 @@ class CloudSqlInstance {
     throw new IllegalArgumentException(
         String.format(
             "[%s] Cloud SQL instance  does not have any IP addresses matching preferences (%s)",
-            instanceName.getConnectionName(), String.join(", ", preferredTypes)));
+            instanceName.getConnectionName(),
+            preferredTypes.stream().collect(Collectors.joining(","))));
   }
 
   /**

--- a/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
@@ -17,11 +17,10 @@
 package com.google.cloud.sql.core;
 
 import com.google.api.client.http.HttpRequestInitializer;
-import com.google.cloud.sql.AuthType;
+import com.google.cloud.sql.ConnectionConfig;
 import com.google.cloud.sql.CredentialFactory;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
@@ -35,8 +34,6 @@ import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
@@ -58,9 +55,19 @@ import jnr.unixsocket.UnixSocketChannel;
  */
 public final class CoreSocketFactory {
 
-  public static final String CLOUD_SQL_INSTANCE_PROPERTY = "cloudSqlInstance";
-  public static final String CLOUD_SQL_DELEGATES_PROPERTY = "cloudSqlDelegates";
-  public static final String CLOUD_SQL_TARGET_PRINCIPAL_PROPERTY = "cloudSqlTargetPrincipal";
+  @Deprecated
+  public static final String CLOUD_SQL_INSTANCE_PROPERTY =
+      ConnectionConfig.CLOUD_SQL_INSTANCE_PROPERTY;
+
+  @Deprecated
+  public static final String CLOUD_SQL_DELEGATES_PROPERTY =
+      ConnectionConfig.CLOUD_SQL_DELEGATES_PROPERTY;
+
+  @Deprecated
+  public static final String CLOUD_SQL_TARGET_PRINCIPAL_PROPERTY =
+      ConnectionConfig.CLOUD_SQL_TARGET_PRINCIPAL_PROPERTY;
+
+  @Deprecated public static final String DEFAULT_IP_TYPES = ConnectionConfig.DEFAULT_IP_TYPES;
 
   /**
    * Property used to set the application name for the underlying SQLAdmin client.
@@ -71,8 +78,6 @@ public final class CoreSocketFactory {
   @Deprecated public static final String USER_TOKEN_PROPERTY_NAME = "_CLOUD_SQL_USER_TOKEN";
 
   static final long DEFAULT_MAX_REFRESH_MS = 30000;
-  public static final String DEFAULT_IP_TYPES = "PUBLIC,PRIVATE";
-  private static final String UNIX_SOCKET_PROPERTY = "unixSocketPath";
   private static final Logger logger = Logger.getLogger(CoreSocketFactory.class.getName());
 
   private static final int DEFAULT_SERVER_PROXY_PORT = 3307;
@@ -144,8 +149,8 @@ public final class CoreSocketFactory {
   }
 
   /** Extracts the Unix socket argument from specified properties object. If unset, returns null. */
-  private static String getUnixSocketArg(Properties props) {
-    String unixSocketPath = props.getProperty(UNIX_SOCKET_PROPERTY);
+  private static String getUnixSocketArg(ConnectionConfig config) {
+    String unixSocketPath = config.getUnixSocketPath();
     if (unixSocketPath != null) {
       // Get the Unix socket file path from the properties object
       return unixSocketPath;
@@ -157,8 +162,8 @@ public final class CoreSocketFactory {
               "\"CLOUD_SQL_FORCE_UNIX_SOCKET\" env var has been deprecated. Please use"
                   + " '%s=\"/cloudsql/INSTANCE_CONNECTION_NAME\"' property in your JDBC url"
                   + " instead.",
-              UNIX_SOCKET_PROPERTY));
-      return "/cloudsql/" + props.getProperty(CLOUD_SQL_INSTANCE_PROPERTY);
+              ConnectionConfig.UNIX_SOCKET_PROPERTY));
+      return "/cloudsql/" + config.getCloudSqlInstance();
     }
     return null; // if unset, default to null
   }
@@ -181,25 +186,17 @@ public final class CoreSocketFactory {
   public static Socket connect(Properties props, String unixPathSuffix)
       throws IOException, InterruptedException {
     // Gather parameters
-    final String csqlInstanceName = props.getProperty(CLOUD_SQL_INSTANCE_PROPERTY);
-    final boolean enableIamAuth = Boolean.parseBoolean(props.getProperty("enableIamAuth"));
-    final String targetPrincipal = props.getProperty(CLOUD_SQL_TARGET_PRINCIPAL_PROPERTY);
-    final String delegatesStr = props.getProperty(CLOUD_SQL_DELEGATES_PROPERTY);
-    final List<String> delegates;
-    if (delegatesStr != null && !delegatesStr.isEmpty()) {
-      delegates = Arrays.asList(delegatesStr.split(","));
-    } else {
-      delegates = Collections.emptyList();
-    }
+
+    ConnectionConfig config = ConnectionConfig.fromConnectionProperties(props);
 
     // Validate parameters
     Preconditions.checkArgument(
-        csqlInstanceName != null,
+        config.getCloudSqlInstance() != null,
         "cloudSqlInstance property not set. Please specify this property in the JDBC URL or the "
             + "connection Properties with value in form \"project:region:instance\"");
 
     // Connect using the specified Unix socket
-    String unixSocket = getUnixSocketArg(props);
+    String unixSocket = getUnixSocketArg(config);
     if (unixSocket != null) {
       // Verify it ends with the correct suffix
       if (unixPathSuffix != null && !unixSocket.endsWith(unixPathSuffix)) {
@@ -208,68 +205,26 @@ public final class CoreSocketFactory {
       logger.info(
           String.format(
               "Connecting to Cloud SQL instance [%s] via unix socket at %s.",
-              csqlInstanceName, unixSocket));
+              config.getCloudSqlInstance(), unixSocket));
       UnixSocketAddress socketAddress = new UnixSocketAddress(new File(unixSocket));
       return UnixSocketChannel.open(socketAddress).socket();
     }
 
-    final List<String> ipTypes = listIpTypes(props.getProperty("ipTypes", DEFAULT_IP_TYPES));
-    if (enableIamAuth) {
-      return getInstance()
-          .createSslSocket(csqlInstanceName, ipTypes, AuthType.IAM, targetPrincipal, delegates);
-    }
-    return getInstance()
-        .createSslSocket(csqlInstanceName, ipTypes, AuthType.PASSWORD, targetPrincipal, delegates);
+    return getInstance().createSslSocket(config);
   }
 
   /** Returns data that can be used to establish Cloud SQL SSL connection. */
-  public static SslData getSslData(
-      String csqlInstanceName,
-      boolean enableIamAuth,
-      String targetPrincipal,
-      List<String> delegates)
-      throws IOException {
-    if (enableIamAuth) {
-      CoreSocketFactory factory = getInstance();
-      return factory
-          .getCloudSqlInstance(csqlInstanceName, AuthType.IAM, targetPrincipal, delegates)
-          .getSslData(factory.refreshTimeoutMs);
-    }
-    CoreSocketFactory factory = getInstance();
-    return factory
-        .getCloudSqlInstance(csqlInstanceName, AuthType.PASSWORD, targetPrincipal, delegates)
-        .getSslData(factory.refreshTimeoutMs);
+  public static SslData getSslData(ConnectionConfig config) throws IOException {
+    CoreSocketFactory instance = getInstance();
+    return instance.getCloudSqlInstance(config).getSslData(instance.refreshTimeoutMs);
   }
 
   /** Returns preferred ip address that can be used to establish Cloud SQL connection. */
-  public static String getHostIp(
-      String csqlInstanceName, String ipTypes, String targetPrincipal, List<String> delegates)
-      throws IOException {
-    return getInstance()
-        .getHostIp(csqlInstanceName, listIpTypes(ipTypes), targetPrincipal, delegates);
-  }
-
-  private String getHostIp(
-      String instanceName, List<String> ipTypes, String targetPrincipal, List<String> delegates) {
-    CloudSqlInstance instance =
-        getCloudSqlInstance(instanceName, AuthType.PASSWORD, targetPrincipal, delegates);
-    return instance.getPreferredIp(ipTypes, refreshTimeoutMs);
-  }
-
-  /**
-   * Converts the string property of IP types to a list by splitting by commas, and upper-casing.
-   */
-  private static List<String> listIpTypes(String cloudSqlIpTypes) {
-    List<String> rawTypes = Splitter.on(',').splitToList(cloudSqlIpTypes);
-    ArrayList<String> result = new ArrayList<>(rawTypes.size());
-    for (String type : rawTypes) {
-      if (type.trim().equalsIgnoreCase("PUBLIC")) {
-        result.add("PRIMARY");
-      } else {
-        result.add(type.trim().toUpperCase());
-      }
-    }
-    return result;
+  public static String getHostIp(ConnectionConfig config) throws IOException {
+    CoreSocketFactory instance = getInstance();
+    return instance
+        .getCloudSqlInstance(config)
+        .getPreferredIp(config.getIpTypes(), instance.refreshTimeoutMs);
   }
 
   private static KeyPair generateRsaKeyPair() {
@@ -352,22 +307,13 @@ public final class CoreSocketFactory {
   /**
    * Creates a secure socket representing a connection to a Cloud SQL instance.
    *
-   * @param instanceName Name of the Cloud SQL instance.
-   * @param ipTypes Preferred type of IP to use ("PRIVATE", "PUBLIC", "PSC")
    * @return the newly created Socket.
    * @throws IOException if error occurs during socket creation.
    */
   // TODO(berezv): separate creating socket and performing connection to make it easier to test
   @VisibleForTesting
-  Socket createSslSocket(
-      String instanceName,
-      List<String> ipTypes,
-      AuthType authType,
-      String targetPrincipal,
-      List<String> delegates)
-      throws IOException, InterruptedException {
-    CloudSqlInstance instance =
-        getCloudSqlInstance(instanceName, authType, targetPrincipal, delegates);
+  Socket createSslSocket(ConnectionConfig config) throws IOException, InterruptedException {
+    CloudSqlInstance instance = getCloudSqlInstance(config);
 
     try {
       SSLSocket socket = instance.createSslSocket(this.refreshTimeoutMs);
@@ -377,7 +323,7 @@ public final class CoreSocketFactory {
       socket.setKeepAlive(true);
       socket.setTcpNoDelay(true);
 
-      String instanceIp = instance.getPreferredIp(ipTypes, refreshTimeoutMs);
+      String instanceIp = instance.getPreferredIp(config.getIpTypes(), refreshTimeoutMs);
 
       socket.connect(new InetSocketAddress(instanceIp, serverProxyPort));
       socket.startHandshake();
@@ -390,26 +336,24 @@ public final class CoreSocketFactory {
     }
   }
 
-  CloudSqlInstance getCloudSqlInstance(
-      String instanceName, AuthType authType, String targetPrincipal, List<String> delegates) {
-    return instances.computeIfAbsent(
-        instanceName, k -> apiFetcher(k, authType, targetPrincipal, delegates));
+  CloudSqlInstance getCloudSqlInstance(ConnectionConfig config) {
+    return instances.computeIfAbsent(config.getCloudSqlInstance(), k -> apiFetcher(config));
   }
 
-  private CloudSqlInstance apiFetcher(
-      String instanceName, AuthType authType, String targetPrincipal, List<String> delegates) {
+  private CloudSqlInstance apiFetcher(ConnectionConfig config) {
 
     final CredentialFactory instanceCredentialFactory;
-    if (targetPrincipal != null && !targetPrincipal.isEmpty()) {
+    if (config.getTargetPrincipal() != null && !config.getTargetPrincipal().isEmpty()) {
       instanceCredentialFactory =
           new ServiceAccountImpersonatingCredentialFactory(
-              credentialFactory, targetPrincipal, delegates);
+              credentialFactory, config.getTargetPrincipal(), config.getDelegates());
     } else {
-      if (delegates != null && !delegates.isEmpty()) {
+      if (config.getDelegates() != null && !config.getDelegates().isEmpty()) {
         throw new IllegalArgumentException(
             String.format(
                 "Connection property %s must be when %s is set.",
-                CLOUD_SQL_TARGET_PRINCIPAL_PROPERTY, CLOUD_SQL_DELEGATES_PROPERTY));
+                ConnectionConfig.CLOUD_SQL_TARGET_PRINCIPAL_PROPERTY,
+                ConnectionConfig.CLOUD_SQL_DELEGATES_PROPERTY));
       }
       instanceCredentialFactory = credentialFactory;
     }
@@ -418,9 +362,9 @@ public final class CoreSocketFactory {
     SqlAdminApiFetcher adminApi = apiFetcherFactory.create(credential);
 
     return new CloudSqlInstance(
-        instanceName,
+        config.getCloudSqlInstance(),
         adminApi,
-        authType,
+        config.getAuthType(),
         instanceCredentialFactory,
         executor,
         localKeyPair,

--- a/core/src/test/java/com/google/cloud/sql/ConnectionConfigTest.java
+++ b/core/src/test/java/com/google/cloud/sql/ConnectionConfigTest.java
@@ -14,13 +14,10 @@
  * limitations under the License.
  */
 
-package com.google.cloud.sql.config;
+package com.google.cloud.sql;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import com.google.cloud.sql.AuthType;
-import com.google.cloud.sql.ConnectionConfig;
-import com.google.cloud.sql.IpType;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
@@ -39,8 +36,7 @@ public class ConnectionConfigTest {
     final String wantUnixSocket = "/path/to/socket";
     final List<IpType> wantIpTypes =
         Arrays.asList(IpType.PSC, IpType.PRIVATE, IpType.PUBLIC); // PUBLIC is replaced with PRIMARY
-    final String ipTypes =
-        wantIpTypes.stream().map(IpType::toString).collect(Collectors.joining(","));
+    final String ipTypes = "psc,Private,PUBLIC";
 
     Properties props = new Properties();
     props.setProperty(ConnectionConfig.CLOUD_SQL_INSTANCE_PROPERTY, wantCsqlInstance);
@@ -57,8 +53,7 @@ public class ConnectionConfigTest {
     assertThat(c.getDelegates()).isEqualTo(wantDelegates);
     assertThat(c.getAuthType()).isEqualTo(AuthType.IAM);
     assertThat(c.getUnixSocketPath()).isEqualTo(wantUnixSocket);
-    assertThat(c.getIpTypes())
-        .isEqualTo(wantIpTypes.stream().map(IpType::getApiName).collect(Collectors.toList()));
+    assertThat(c.getIpTypes()).isEqualTo(wantIpTypes);
   }
 
   @Test
@@ -67,8 +62,7 @@ public class ConnectionConfigTest {
     final String wantTargetPrincipal = "test@example.com";
     final List<String> wantDelegates = Arrays.asList("test1@example.com", "test2@example.com");
     final String wantUnixSocket = "/path/to/socket";
-    final List<IpType> wantIpTypes =
-        Arrays.asList(IpType.PSC, IpType.PRIVATE, IpType.PUBLIC); // PUBLIC is replaced with PRIMARY
+    final List<IpType> wantIpTypes = Arrays.asList(IpType.PSC, IpType.PRIVATE, IpType.PUBLIC);
     final AuthType wantAuthType = AuthType.PASSWORD;
 
     ConnectionConfig c =
@@ -86,7 +80,6 @@ public class ConnectionConfigTest {
     assertThat(c.getDelegates()).isEqualTo(wantDelegates);
     assertThat(c.getAuthType()).isEqualTo(wantAuthType);
     assertThat(c.getUnixSocketPath()).isEqualTo(wantUnixSocket);
-    assertThat(c.getIpTypes())
-        .isEqualTo(wantIpTypes.stream().map(IpType::getApiName).collect(Collectors.toList()));
+    assertThat(c.getIpTypes()).isEqualTo(wantIpTypes);
   }
 }

--- a/core/src/test/java/com/google/cloud/sql/config/ConnectionConfigTest.java
+++ b/core/src/test/java/com/google/cloud/sql/config/ConnectionConfigTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.sql.config;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.cloud.sql.AuthType;
+import com.google.cloud.sql.ConnectionConfig;
+import com.google.cloud.sql.IpType;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+import java.util.stream.Collectors;
+import org.junit.Test;
+
+public class ConnectionConfigTest {
+
+  @Test
+  public void testConfigFromProps() {
+    final String wantCsqlInstance = "proj:region:inst";
+    final String wantTargetPrincipal = "test@example.com";
+    final List<String> wantDelegates = Arrays.asList("test1@example.com", "test2@example.com");
+    final String delegates = wantDelegates.stream().collect(Collectors.joining(","));
+    final String iamAuthN = "true";
+    final String wantUnixSocket = "/path/to/socket";
+    final List<IpType> wantIpTypes =
+        Arrays.asList(IpType.PSC, IpType.PRIVATE, IpType.PUBLIC); // PUBLIC is replaced with PRIMARY
+    final String ipTypes =
+        wantIpTypes.stream().map(IpType::toString).collect(Collectors.joining(","));
+
+    Properties props = new Properties();
+    props.setProperty(ConnectionConfig.CLOUD_SQL_INSTANCE_PROPERTY, wantCsqlInstance);
+    props.setProperty(ConnectionConfig.CLOUD_SQL_TARGET_PRINCIPAL_PROPERTY, wantTargetPrincipal);
+    props.setProperty(ConnectionConfig.CLOUD_SQL_DELEGATES_PROPERTY, delegates);
+    props.setProperty(ConnectionConfig.ENABLE_IAM_AUTH_PROPERTY, iamAuthN);
+    props.setProperty(ConnectionConfig.UNIX_SOCKET_PROPERTY, wantUnixSocket);
+    props.setProperty(ConnectionConfig.IP_TYPES_PROPERTY, ipTypes);
+
+    ConnectionConfig c = ConnectionConfig.fromConnectionProperties(props);
+
+    assertThat(c.getCloudSqlInstance()).isEqualTo(wantCsqlInstance);
+    assertThat(c.getTargetPrincipal()).isEqualTo(wantTargetPrincipal);
+    assertThat(c.getDelegates()).isEqualTo(wantDelegates);
+    assertThat(c.getAuthType()).isEqualTo(AuthType.IAM);
+    assertThat(c.getUnixSocketPath()).isEqualTo(wantUnixSocket);
+    assertThat(c.getIpTypes())
+        .isEqualTo(wantIpTypes.stream().map(IpType::getApiName).collect(Collectors.toList()));
+  }
+
+  @Test
+  public void testConfigFromBuilder() {
+    final String wantCsqlInstance = "proj:region:inst";
+    final String wantTargetPrincipal = "test@example.com";
+    final List<String> wantDelegates = Arrays.asList("test1@example.com", "test2@example.com");
+    final String wantUnixSocket = "/path/to/socket";
+    final List<IpType> wantIpTypes =
+        Arrays.asList(IpType.PSC, IpType.PRIVATE, IpType.PUBLIC); // PUBLIC is replaced with PRIMARY
+    final AuthType wantAuthType = AuthType.PASSWORD;
+
+    ConnectionConfig c =
+        new ConnectionConfig.Builder()
+            .withCloudSqlInstance(wantCsqlInstance)
+            .withTargetPrincipal(wantTargetPrincipal)
+            .withDelegates(wantDelegates)
+            .withIpTypes(wantIpTypes)
+            .withUnixSocketPath(wantUnixSocket)
+            .withAuthType(wantAuthType)
+            .build();
+
+    assertThat(c.getCloudSqlInstance()).isEqualTo(wantCsqlInstance);
+    assertThat(c.getTargetPrincipal()).isEqualTo(wantTargetPrincipal);
+    assertThat(c.getDelegates()).isEqualTo(wantDelegates);
+    assertThat(c.getAuthType()).isEqualTo(wantAuthType);
+    assertThat(c.getUnixSocketPath()).isEqualTo(wantUnixSocket);
+    assertThat(c.getIpTypes())
+        .isEqualTo(wantIpTypes.stream().map(IpType::getApiName).collect(Collectors.toList()));
+  }
+}

--- a/jdbc/postgres/src/main/java/com/google/cloud/sql/postgres/SocketFactory.java
+++ b/jdbc/postgres/src/main/java/com/google/cloud/sql/postgres/SocketFactory.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.sql.postgres;
 
+import com.google.cloud.sql.ConnectionConfig;
 import com.google.cloud.sql.core.CoreSocketFactory;
 import java.io.IOException;
 import java.net.InetAddress;
@@ -53,8 +54,8 @@ public class SocketFactory extends javax.net.SocketFactory {
           String.format(
               "The '%s' property has been deprecated. Please update your postgres driver and use"
                   + "the  '%s' property in your JDBC url instead.",
-              DEPRECATED_SOCKET_ARG, CoreSocketFactory.CLOUD_SQL_INSTANCE_PROPERTY));
-      info.setProperty(CoreSocketFactory.CLOUD_SQL_INSTANCE_PROPERTY, oldInstanceKey);
+              DEPRECATED_SOCKET_ARG, ConnectionConfig.CLOUD_SQL_INSTANCE_PROPERTY));
+      info.setProperty(ConnectionConfig.CLOUD_SQL_INSTANCE_PROPERTY, oldInstanceKey);
     }
     this.props = info;
   }

--- a/jdbc/sqlserver/src/main/java/com/google/cloud/sql/sqlserver/SocketFactory.java
+++ b/jdbc/sqlserver/src/main/java/com/google/cloud/sql/sqlserver/SocketFactory.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.sql.sqlserver;
 
+import com.google.cloud.sql.ConnectionConfig;
 import com.google.cloud.sql.core.CoreSocketFactory;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
@@ -49,7 +50,7 @@ public class SocketFactory extends javax.net.SocketFactory {
    */
   public SocketFactory(String socketFactoryConstructorArg) throws UnsupportedEncodingException {
     List<String> s = Splitter.on('?').splitToList(socketFactoryConstructorArg);
-    this.props.setProperty(CoreSocketFactory.CLOUD_SQL_INSTANCE_PROPERTY, s.get(0));
+    this.props.setProperty(ConnectionConfig.CLOUD_SQL_INSTANCE_PROPERTY, s.get(0));
     if (s.size() == 2 && s.get(1).length() > 0) {
       Iterable<String> queryParams = Splitter.on('&').split(s.get(1));
       for (String param : queryParams) {

--- a/jdbc/sqlserver/src/test/java/com/google/cloud/sql/sqlserver/JdbcSqlServerUnitTests.java
+++ b/jdbc/sqlserver/src/test/java/com/google/cloud/sql/sqlserver/JdbcSqlServerUnitTests.java
@@ -18,7 +18,7 @@ package com.google.cloud.sql.sqlserver;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import com.google.cloud.sql.core.CoreSocketFactory;
+import com.google.cloud.sql.ConnectionConfig;
 import java.io.UnsupportedEncodingException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -32,7 +32,7 @@ public class JdbcSqlServerUnitTests {
   @Test
   public void checkConnectionStringNoQueryParams() throws UnsupportedEncodingException {
     SocketFactory socketFactory = new SocketFactory(CONNECTION_NAME);
-    assertThat(socketFactory.props.get(CoreSocketFactory.CLOUD_SQL_INSTANCE_PROPERTY))
+    assertThat(socketFactory.props.get(ConnectionConfig.CLOUD_SQL_INSTANCE_PROPERTY))
         .isEqualTo(CONNECTION_NAME);
   }
 
@@ -41,7 +41,7 @@ public class JdbcSqlServerUnitTests {
     String socketFactoryConstructorArg =
         String.format("%s?%s=%s", CONNECTION_NAME, "ipTypes", "PRIVATE");
     SocketFactory socketFactory = new SocketFactory(socketFactoryConstructorArg);
-    assertThat(socketFactory.props.get(CoreSocketFactory.CLOUD_SQL_INSTANCE_PROPERTY))
+    assertThat(socketFactory.props.get(ConnectionConfig.CLOUD_SQL_INSTANCE_PROPERTY))
         .isEqualTo(CONNECTION_NAME);
     assertThat(socketFactory.props.get("ipTypes")).isEqualTo("PRIVATE");
   }
@@ -50,7 +50,7 @@ public class JdbcSqlServerUnitTests {
   public void checkConnectionStringWithEmptyQueryParam() throws UnsupportedEncodingException {
     String socketFactoryConstructorArg = String.format("%s?", CONNECTION_NAME);
     SocketFactory socketFactory = new SocketFactory(socketFactoryConstructorArg);
-    assertThat(socketFactory.props.get(CoreSocketFactory.CLOUD_SQL_INSTANCE_PROPERTY))
+    assertThat(socketFactory.props.get(ConnectionConfig.CLOUD_SQL_INSTANCE_PROPERTY))
         .isEqualTo(CONNECTION_NAME);
     assertThat(socketFactory.props.get("ipTypes")).isEqualTo(null);
   }
@@ -60,7 +60,7 @@ public class JdbcSqlServerUnitTests {
     String socketFactoryConstructorArg =
         String.format("%s?token=%s", CONNECTION_NAME, "abc%20def%20xyz%2F%26%3D");
     SocketFactory socketFactory = new SocketFactory(socketFactoryConstructorArg);
-    assertThat(socketFactory.props.get(CoreSocketFactory.CLOUD_SQL_INSTANCE_PROPERTY))
+    assertThat(socketFactory.props.get(ConnectionConfig.CLOUD_SQL_INSTANCE_PROPERTY))
         .isEqualTo(CONNECTION_NAME);
     assertThat(socketFactory.props.get("token")).isEqualTo("abc def xyz/&=");
   }

--- a/pom.xml
+++ b/pom.xml
@@ -245,6 +245,7 @@
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>clirr-maven-plugin</artifactId>
         <configuration>
+          <includes>com/google/cloud/sql/*</includes>
           <includes>com/google/cloud/sql/CredentialFactory</includes>
           <includes>com/google/cloud/sql/core/CoreSocketFactory</includes>
           <includes>com/google/cloud/sql/mariadb/SocketFactory</includes>

--- a/r2dbc/mysql/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderMysql.java
+++ b/r2dbc/mysql/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderMysql.java
@@ -19,13 +19,13 @@ package com.google.cloud.sql.core;
 import static io.r2dbc.spi.ConnectionFactoryOptions.Builder;
 import static io.r2dbc.spi.ConnectionFactoryOptions.DRIVER;
 
+import com.google.cloud.sql.ConnectionConfig;
 import io.asyncer.r2dbc.mysql.MySqlConnectionFactoryProvider;
 import io.asyncer.r2dbc.mysql.constant.SslMode;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.ConnectionFactoryOptions;
 import io.r2dbc.spi.ConnectionFactoryProvider;
-import java.util.List;
 import java.util.function.Function;
 
 /** {@link ConnectionFactoryProvider} for proxied access to GCP MySQL instances. */
@@ -45,25 +45,16 @@ public class GcpConnectionFactoryProviderMysql extends GcpConnectionFactoryProvi
 
   @Override
   ConnectionFactory tcpSocketConnectionFactory(
+      ConnectionConfig config,
       Builder builder,
-      String ipTypes,
-      String targetPrincipal,
-      List<String> delegates,
-      Function<SslContextBuilder, SslContextBuilder> customizer,
-      String hostname) {
+      Function<SslContextBuilder, SslContextBuilder> customizer) {
     builder
         .option(MySqlConnectionFactoryProvider.SSL_CONTEXT_BUILDER_CUSTOMIZER, customizer)
         .option(MySqlConnectionFactoryProvider.SSL_MODE, SslMode.TUNNEL)
         .option(MySqlConnectionFactoryProvider.TCP_NO_DELAY, true)
         .option(MySqlConnectionFactoryProvider.TCP_KEEP_ALIVE, true);
 
-    return new CloudSqlConnectionFactory(
-        MySqlConnectionFactoryProvider::new,
-        ipTypes,
-        targetPrincipal,
-        delegates,
-        builder,
-        hostname);
+    return new CloudSqlConnectionFactory(config, MySqlConnectionFactoryProvider::new, builder);
   }
 
   @Override

--- a/r2dbc/postgres/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderPostgres.java
+++ b/r2dbc/postgres/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderPostgres.java
@@ -19,13 +19,13 @@ package com.google.cloud.sql.core;
 import static io.r2dbc.spi.ConnectionFactoryOptions.Builder;
 import static io.r2dbc.spi.ConnectionFactoryOptions.DRIVER;
 
+import com.google.cloud.sql.ConnectionConfig;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.r2dbc.postgresql.PostgresqlConnectionFactoryProvider;
 import io.r2dbc.postgresql.client.SSLMode;
 import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.ConnectionFactoryOptions;
 import io.r2dbc.spi.ConnectionFactoryProvider;
-import java.util.List;
 import java.util.function.Function;
 
 /** {@link ConnectionFactoryProvider} for proxied access to GCP Postgres instances. */
@@ -47,25 +47,16 @@ public class GcpConnectionFactoryProviderPostgres extends GcpConnectionFactoryPr
 
   @Override
   ConnectionFactory tcpSocketConnectionFactory(
+      ConnectionConfig config,
       Builder builder,
-      String ipTypes,
-      String targetPrincipal,
-      List<String> delegates,
-      Function<SslContextBuilder, SslContextBuilder> customizer,
-      String hostname) {
+      Function<SslContextBuilder, SslContextBuilder> customizer) {
     builder
         .option(PostgresqlConnectionFactoryProvider.SSL_CONTEXT_BUILDER_CUSTOMIZER, customizer)
         .option(PostgresqlConnectionFactoryProvider.SSL_MODE, SSLMode.TUNNEL)
         .option(PostgresqlConnectionFactoryProvider.TCP_NODELAY, true)
         .option(PostgresqlConnectionFactoryProvider.TCP_KEEPALIVE, true);
 
-    return new CloudSqlConnectionFactory(
-        PostgresqlConnectionFactoryProvider::new,
-        ipTypes,
-        targetPrincipal,
-        delegates,
-        builder,
-        hostname);
+    return new CloudSqlConnectionFactory(config, PostgresqlConnectionFactoryProvider::new, builder);
   }
 
   @Override

--- a/r2dbc/sqlserver/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderMssql.java
+++ b/r2dbc/sqlserver/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderMssql.java
@@ -19,12 +19,12 @@ package com.google.cloud.sql.core;
 import static io.r2dbc.spi.ConnectionFactoryOptions.Builder;
 import static io.r2dbc.spi.ConnectionFactoryOptions.DRIVER;
 
+import com.google.cloud.sql.ConnectionConfig;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.r2dbc.mssql.MssqlConnectionFactoryProvider;
 import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.ConnectionFactoryOptions;
 import io.r2dbc.spi.ConnectionFactoryProvider;
-import java.util.List;
 import java.util.function.Function;
 
 /** {@link ConnectionFactoryProvider} for proxied access to GCP MsSQL instances. */
@@ -44,24 +44,15 @@ public class GcpConnectionFactoryProviderMssql extends GcpConnectionFactoryProvi
 
   @Override
   ConnectionFactory tcpSocketConnectionFactory(
+      ConnectionConfig config,
       Builder builder,
-      String ipTypes,
-      String targetPrincipal,
-      List<String> delegates,
-      Function<SslContextBuilder, SslContextBuilder> customizer,
-      String hostname) {
+      Function<SslContextBuilder, SslContextBuilder> customizer) {
     builder
         .option(MssqlConnectionFactoryProvider.SSL_TUNNEL, customizer)
         .option(MssqlConnectionFactoryProvider.TCP_NODELAY, true)
         .option(MssqlConnectionFactoryProvider.TCP_KEEPALIVE, true);
 
-    return new CloudSqlConnectionFactory(
-        MssqlConnectionFactoryProvider::new,
-        ipTypes,
-        targetPrincipal,
-        delegates,
-        builder,
-        hostname);
+    return new CloudSqlConnectionFactory(config, MssqlConnectionFactoryProvider::new, builder);
   }
 
   @Override


### PR DESCRIPTION
Create a value object containing connector configuration properties. This is the stable public Java API that configures
connectors. All connection configuration property names and defaults are constants on the new ConnectionConfig class. 
Logic to interpret a connection Properties object has moved into this class from CoreSocketFactory. This config object is
now passed within the CoreConnectorFactory instead of an long argument list. 

part of #1587 
part of #1226