### PR TITLE
chore: Set project-wide config for CLIRR version compatibility checks

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -294,17 +294,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>clirr-maven-plugin</artifactId>
-        <!--
-        Ignore changes before 1.14.0. This is our first release with updated
-        methods.
-        -->
-        <configuration>
-          <comparisonVersion>1.14.0</comparisonVersion>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -240,6 +240,23 @@
           </dependency>
         </dependencies>
       </plugin>
+
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>clirr-maven-plugin</artifactId>
+        <configuration>
+          <includes>com/google/cloud/sql/CredentialFactory</includes>
+          <includes>com/google/cloud/sql/core/CoreSocketFactory</includes>
+          <includes>com/google/cloud/sql/mariadb/SocketFactory</includes>
+          <includes>com/google/cloud/sql/mysql/SocketFactory</includes>
+          <includes>com/google/cloud/sql/postgres/SocketFactory</includes>
+          <includes>com/google/cloud/sql/sqlserver/SocketFactory</includes>
+          <includes>com/google/cloud/sql/core/GcpConnectionFactoryProviderMysql</includes>
+          <includes>com/google/cloud/sql/core/GcpConnectionFactoryProviderPostgres</includes>
+          <includes>com/google/cloud/sql/core/GcpConnectionFactoryProviderMssql</includes>
+        </configuration>
+      </plugin>
+
     </plugins>
   </build>
 


### PR DESCRIPTION
Update the maven configuration so that the CLIRR plugin only checks classes that are documented
to be part of our public API.