### PR TITLE
feat: Java API to configure named connections

### DIFF
--- a/core/src/main/java/com/google/cloud/sql/ConnectorRegistry.java
+++ b/core/src/main/java/com/google/cloud/sql/ConnectorRegistry.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.sql;
+
+import com.google.cloud.sql.core.InternalConnectorRegistry;
+
+/** Configure the CloudSQL JDBC Connector. */
+public final class ConnectorRegistry {
+
+  /**
+   * Register a named connection so that it can later be referenced by name in a JDBC or R2DBC URL.
+   *
+   * @param name the named connection name.
+   * @param config the full configuration of the connection.
+   */
+  public static void register(String name, ConnectorConfig config) {
+    InternalConnectorRegistry.getInstance().register(name, config);
+  }
+
+  /**
+   * Close a named connector. This will stop all background credential refresh processes. All future
+   * attempts to connect via this named connection will fail.
+   *
+   * @param name the name of the connector to close.
+   */
+  public static void close(String name) {
+    InternalConnectorRegistry.getInstance().close(name);
+  }
+
+  /**
+   * Shutdown the entire CloudSQL JDBC Connector. This will stop all background threads. All future
+   * attempts to connect to a CloudSQL database will fail.
+   */
+  public static void shutdown() {
+    InternalConnectorRegistry.shutdownInstance();
+  }
+
+  /**
+   * Adds an external application name to the user agent string for tracking. This is known to be
+   * used by the spring-cloud-gcp project.
+   *
+   * @throws IllegalStateException if the SQLAdmin client has already been initialized
+   */
+  public static void addArtifactId(String artifactId) {
+    InternalConnectorRegistry.getInstance().addArtifactId(artifactId);
+  }
+}

--- a/core/src/main/java/com/google/cloud/sql/core/ConnectionConfig.java
+++ b/core/src/main/java/com/google/cloud/sql/core/ConnectionConfig.java
@@ -167,6 +167,18 @@ public class ConnectionConfig {
     this.authType = authType;
   }
 
+  /** Creates a new instance of the ConnectionConfig with an updated connectorConfig. */
+  public ConnectionConfig withConnectorConfig(ConnectorConfig config) {
+    return new ConnectionConfig(
+        cloudSqlInstance,
+        namedConnector,
+        unixSocketPath,
+        ipTypes,
+        authType,
+        unixSocketPathSuffix,
+        config);
+  }
+
   public String getNamedConnector() {
     return namedConnector;
   }

--- a/core/src/main/java/com/google/cloud/sql/core/DefaultConnectionInfoCache.java
+++ b/core/src/main/java/com/google/cloud/sql/core/DefaultConnectionInfoCache.java
@@ -147,4 +147,8 @@ class DefaultConnectionInfoCache {
   public CloudSqlInstanceName getInstanceName() {
     return instanceName;
   }
+
+  void close() {
+    refresher.close();
+  }
 }

--- a/core/src/test/java/com/google/cloud/sql/core/CloudSqlCoreTestingBase.java
+++ b/core/src/test/java/com/google/cloud/sql/core/CloudSqlCoreTestingBase.java
@@ -145,6 +145,10 @@ public class CloudSqlCoreTestingBase {
   }
 
   HttpTransport fakeSuccessHttpTransport(Duration certDuration) {
+    return fakeSuccessHttpTransport(certDuration, null);
+  }
+
+  HttpTransport fakeSuccessHttpTransport(Duration certDuration, String baseUrl) {
     final JsonFactory jsonFactory = new GsonFactory();
     return new MockHttpTransport() {
       @Override
@@ -152,6 +156,9 @@ public class CloudSqlCoreTestingBase {
         return new MockLowLevelHttpRequest() {
           @Override
           public LowLevelHttpResponse execute() throws IOException {
+            if (baseUrl != null && !url.startsWith(baseUrl)) {
+              throw new RuntimeException("url " + url + " does not start with baseUrl " + baseUrl);
+            }
             MockLowLevelHttpResponse response = new MockLowLevelHttpResponse();
             if (method.equals("GET") && url.contains("connectSettings")) {
               ConnectSettings settings =

--- a/core/src/test/java/com/google/cloud/sql/core/ConnectionConfigTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/ConnectionConfigTest.java
@@ -114,4 +114,29 @@ public class ConnectionConfigTest {
     assertThat(c.getConnectorConfig().getAdminServicePath()).isEqualTo(wantAdminServicePath);
     assertThat(c.getUnixSocketPathSuffix()).isEqualTo(wantUnixSuffix);
   }
+
+  @Test
+  public void testWithConnectorConfig() {
+    final String wantCsqlInstance = "proj:region:inst";
+    final String wantNamedConnector = "my-connection";
+
+    ConnectorConfig cc = new ConnectorConfig.Builder().build();
+
+    ConnectionConfig c =
+        new ConnectionConfig.Builder()
+            .withCloudSqlInstance(wantCsqlInstance)
+            .withNamedConnector(wantNamedConnector)
+            .build();
+
+    assertThat(c.getCloudSqlInstance()).isEqualTo(wantCsqlInstance);
+    assertThat(c.getNamedConnector()).isEqualTo(wantNamedConnector);
+    assertThat(c.getConnectorConfig()).isNotSameInstanceAs(cc);
+
+    ConnectionConfig c1 = c.withConnectorConfig(cc);
+
+    assertThat(c1).isNotSameInstanceAs(c);
+    assertThat(c1.getCloudSqlInstance()).isEqualTo(wantCsqlInstance);
+    assertThat(c1.getNamedConnector()).isEqualTo(wantNamedConnector);
+    assertThat(c1.getConnectorConfig()).isSameInstanceAs(cc);
+  }
 }

--- a/core/src/test/java/com/google/cloud/sql/core/ConnectorTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/ConnectorTest.java
@@ -103,6 +103,7 @@ public class ConnectorTest extends CloudSqlCoreTestingBase {
         new StubConnectionInfoRepositoryFactory(fakeSuccessHttpTransport(Duration.ofSeconds(0)));
     Connector connector =
         new Connector(
+            config,
             factory.create(credentialFactory.create(), config),
             credentialFactory,
             defaultExecutor,

--- a/jdbc/postgres/src/test/java/com/google/cloud/sql/postgres/JdbcPostgresNamedConnectorIntegrationTests.java
+++ b/jdbc/postgres/src/test/java/com/google/cloud/sql/postgres/JdbcPostgresNamedConnectorIntegrationTests.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.sql.postgres;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+
+import com.google.cloud.sql.ConnectorConfig;
+import com.google.cloud.sql.ConnectorRegistry;
+import com.google.common.collect.ImmutableList;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class JdbcPostgresNamedConnectorIntegrationTests {
+
+  private static final String CONNECTION_NAME = System.getenv("POSTGRES_IAM_CONNECTION_NAME");
+  private static final String DB_NAME = System.getenv("POSTGRES_DB");
+  private static final String DB_USER = System.getenv("POSTGRES_IAM_USER");
+  private static final ImmutableList<String> requiredEnvVars =
+      ImmutableList.of("POSTGRES_IAM_USER", "POSTGRES_DB", "POSTGRES_IAM_CONNECTION_NAME");
+  @Rule public Timeout globalTimeout = new Timeout(60, TimeUnit.SECONDS);
+
+  private HikariDataSource connectionPool;
+
+  @BeforeClass
+  public static void checkEnvVars() {
+    // Check that required env vars are set
+    requiredEnvVars.forEach(
+        (varName) ->
+            assertWithMessage(
+                    String.format(
+                        "Environment variable '%s' must be set to perform these tests.", varName))
+                .that(System.getenv(varName))
+                .isNotEmpty());
+  }
+
+  @Before
+  public void setUpPool() throws SQLException {
+    // Register a named Cloud SQL Connector with specific configuration
+    ConnectorConfig namedConnectorConfig =
+        new ConnectorConfig.Builder()
+            // Set connector configuration, for example, to use service
+            // account impersonation, set the target principal:
+            // .withTargetPrincipal("example@project.iam.googleapis.com")
+            // .withDelegates(Arrays.asList("delegate@project.iam.googleapis.com"))
+            .build();
+
+    // Register the named connector
+    ConnectorRegistry.register("my-connector", namedConnectorConfig);
+
+    // Set up URL parameters
+    String jdbcURL = String.format("jdbc:postgresql:///%s", DB_NAME);
+    Properties connProps = new Properties();
+
+    // Configure Postgres driver properties
+    connProps.setProperty("user", DB_USER);
+    connProps.setProperty("password", "password");
+    connProps.setProperty("socketFactory", "com.google.cloud.sql.postgres.SocketFactory");
+
+    // Configure Cloud SQL connector properties
+    connProps.setProperty("cloudSqlInstance", CONNECTION_NAME);
+    connProps.setProperty("enableIamAuth", "true");
+
+    // Configure the named connector registered as "my-connector"
+    connProps.setProperty("cloudSqlNamedConnector", "my-connector");
+
+    // Initialize connection pool
+    HikariConfig config = new HikariConfig();
+    config.setJdbcUrl(jdbcURL);
+    config.setDataSourceProperties(connProps);
+    config.setConnectionTimeout(10000); // 10s
+
+    this.connectionPool = new HikariDataSource(config);
+  }
+
+  @Test
+  public void pooledConnectionTest() throws SQLException {
+
+    List<Timestamp> rows = new ArrayList<>();
+    try (Connection conn = connectionPool.getConnection()) {
+      try (PreparedStatement selectStmt = conn.prepareStatement("SELECT NOW() as TS")) {
+        ResultSet rs = selectStmt.executeQuery();
+        while (rs.next()) {
+          rows.add(rs.getTimestamp("TS"));
+        }
+      }
+    }
+    assertThat(rows.size()).isEqualTo(1);
+  }
+}

--- a/r2dbc/core/src/main/java/com/google/cloud/sql/core/CloudSqlConnectionFactory.java
+++ b/r2dbc/core/src/main/java/com/google/cloud/sql/core/CloudSqlConnectionFactory.java
@@ -24,7 +24,6 @@ import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.ConnectionFactoryMetadata;
 import io.r2dbc.spi.ConnectionFactoryOptions;
 import io.r2dbc.spi.ConnectionFactoryProvider;
-import java.io.IOException;
 import java.util.function.Supplier;
 import org.reactivestreams.Publisher;
 import reactor.util.annotation.NonNull;
@@ -50,30 +49,22 @@ public class CloudSqlConnectionFactory implements ConnectionFactory {
   @Override
   @NonNull
   public Publisher<? extends Connection> create() {
-    try {
-      String hostIp =
-          InternalConnectorRegistry.getInstance()
-              .getConnectionMetadata(config)
-              .getPreferredIpAddress();
-      builder.option(HOST, hostIp).option(PORT, SERVER_PROXY_PORT);
-      return supplier.get().create(builder.build()).create();
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
+    String hostIp =
+        InternalConnectorRegistry.getInstance()
+            .getConnectionMetadata(config)
+            .getPreferredIpAddress();
+    builder.option(HOST, hostIp).option(PORT, SERVER_PROXY_PORT);
+    return supplier.get().create(builder.build()).create();
   }
 
   @Override
   @NonNull
   public ConnectionFactoryMetadata getMetadata() {
-    try {
-      String hostIp =
-          InternalConnectorRegistry.getInstance()
-              .getConnectionMetadata(config)
-              .getPreferredIpAddress();
-      builder.option(HOST, hostIp).option(PORT, SERVER_PROXY_PORT);
-      return supplier.get().create(builder.build()).getMetadata();
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
+    String hostIp =
+        InternalConnectorRegistry.getInstance()
+            .getConnectionMetadata(config)
+            .getPreferredIpAddress();
+    builder.option(HOST, hostIp).option(PORT, SERVER_PROXY_PORT);
+    return supplier.get().create(builder.build()).getMetadata();
   }
 }


### PR DESCRIPTION
In real usage, an application would first call `Connector.register()` to register the configuration for a named connection.

```java
ConnectorConfig config =  new ConnectorConfig.Builder()
            .withTargetPrincipal("example@project.iam.googleapis.com")
            .withDelegates(Arrays.asList("delegate@project.iam.googleapis.com"))
            .build();
ConnectorRegistry.register("my-connector", config);
```

Then the application would use the connector by adding the `cloudSqlNamedConnector` parameter to the JDBC URL: 

```java
String jdbcUrl = "jdbc:mysql:///<DATABASE_NAME>?"+
  + "cloudSqlInstance=project:region:instance"
  + "&cloudSqlNamedConnector=my-connector"
  + "&socketFactory=com.google.cloud.sql.mysql.SocketFactory"
  + "&user=<DB_USER>&password=<PASSWORD>";
```

Or using JDBC connection properties, by adding the `cloudSqlNamedConnector` property: 

```java
// Set up URL parameters
Properties connProps=new Properties();
connProps.setProperty("user","<DB_USER>");
connProps.setProperty("password","<PASSWORD>");
connProps.setProperty("sslmode","disable");
connProps.setProperty("socketFactory","<DRIVER_CLASS>");
connProps.setProperty("cloudSqlInstance","my-connection");
connProps.setProperty("cloudSqlNamedConnector","[my-connection](project:region:instance)");

// Initialize connection pool
HikariConfig config=new HikariConfig();
config.setJdbcUrl("jdbc:mysql:///<DB_NAME>");
config.setDataSourceProperties(connProps);
config.setConnectionTimeout(10000); // 10s

HikariDataSource connectionPool=new HikariDataSource(config);
```

The application can stop individual named connectors, or all connectors: 
```java
ConnectorRegistry.close("my-connector");
```

The application can shutdown the connector, preventing any new connections
and stoping all connector threads. 

```java
ConnectorRegistry.shutdown();
```

Fixes #1226