### PR TITLE
refactor: Use IpType instead of String

### DIFF
--- a/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstance.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstance.java
@@ -18,6 +18,7 @@ package com.google.cloud.sql.core;
 
 import com.google.cloud.sql.AuthType;
 import com.google.cloud.sql.CredentialFactory;
+import com.google.cloud.sql.IpType;
 import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -169,9 +170,9 @@ class CloudSqlInstance {
    * @throws IllegalArgumentException If the instance has no IP addresses matching the provided
    *     preferences.
    */
-  String getPreferredIp(List<String> preferredTypes, long timeoutMs) {
-    Map<String, String> ipAddrs = getInstanceData(timeoutMs).getIpAddrs();
-    for (String ipType : preferredTypes) {
+  String getPreferredIp(List<IpType> preferredTypes, long timeoutMs) {
+    Map<IpType, String> ipAddrs = getInstanceData(timeoutMs).getIpAddrs();
+    for (IpType ipType : preferredTypes) {
       String preferredIp = ipAddrs.get(ipType);
       if (preferredIp != null) {
         return preferredIp;
@@ -181,7 +182,7 @@ class CloudSqlInstance {
         String.format(
             "[%s] Cloud SQL instance  does not have any IP addresses matching preferences (%s)",
             instanceName.getConnectionName(),
-            preferredTypes.stream().collect(Collectors.joining(","))));
+            preferredTypes.stream().map(IpType::toString).collect(Collectors.joining(","))));
   }
 
   /**

--- a/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
@@ -19,7 +19,6 @@ package com.google.cloud.sql.core;
 import com.google.api.client.http.HttpRequestInitializer;
 import com.google.cloud.sql.ConnectionConfig;
 import com.google.cloud.sql.CredentialFactory;
-import com.google.cloud.sql.IpType;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
@@ -41,7 +40,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 import javax.net.ssl.SSLSocket;
 import jnr.unixsocket.UnixSocketAddress;
 import jnr.unixsocket.UnixSocketChannel;
@@ -250,22 +248,7 @@ public final class CoreSocketFactory {
     CoreSocketFactory instance = getInstance();
     return instance
         .getCloudSqlInstance(config)
-        .getPreferredIp(ipTypeStrings(config.getIpTypes()), instance.refreshTimeoutMs);
-  }
-
-  /**
-   * A function to convert from newer API that uses the IpType enum to the legacy ip type strings.
-   */
-  private static List<String> ipTypeStrings(List<IpType> ipTypes) {
-    return ipTypes.stream()
-        .map(
-            (t) -> {
-              if (t == IpType.PUBLIC) {
-                return "PRIMARY";
-              }
-              return t.toString();
-            })
-        .collect(Collectors.toList());
+        .getPreferredIp(config.getIpTypes(), instance.refreshTimeoutMs);
   }
 
   private static KeyPair generateRsaKeyPair() {
@@ -364,8 +347,7 @@ public final class CoreSocketFactory {
       socket.setKeepAlive(true);
       socket.setTcpNoDelay(true);
 
-      String instanceIp =
-          instance.getPreferredIp(ipTypeStrings(config.getIpTypes()), refreshTimeoutMs);
+      String instanceIp = instance.getPreferredIp(config.getIpTypes(), refreshTimeoutMs);
 
       socket.connect(new InetSocketAddress(instanceIp, serverProxyPort));
       socket.startHandshake();

--- a/core/src/main/java/com/google/cloud/sql/core/InstanceData.java
+++ b/core/src/main/java/com/google/cloud/sql/core/InstanceData.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.sql.core;
 
+import com.google.cloud.sql.IpType;
 import java.time.Instant;
 import java.util.Map;
 import javax.net.ssl.SSLContext;
@@ -43,7 +44,7 @@ class InstanceData {
     return sslContext;
   }
 
-  Map<String, String> getIpAddrs() {
+  Map<IpType, String> getIpAddrs() {
     return metadata.getIpAddrs();
   }
 

--- a/core/src/main/java/com/google/cloud/sql/core/Metadata.java
+++ b/core/src/main/java/com/google/cloud/sql/core/Metadata.java
@@ -16,21 +16,22 @@
 
 package com.google.cloud.sql.core;
 
+import com.google.cloud.sql.IpType;
 import java.security.cert.Certificate;
 import java.util.Map;
 
 /** Represents the results of @link #fetchMetadata(). */
 class Metadata {
 
-  private final Map<String, String> ipAddrs;
+  private final Map<IpType, String> ipAddrs;
   private final Certificate instanceCaCertificate;
 
-  Metadata(Map<String, String> ipAddrs, Certificate instanceCaCertificate) {
+  Metadata(Map<IpType, String> ipAddrs, Certificate instanceCaCertificate) {
     this.ipAddrs = ipAddrs;
     this.instanceCaCertificate = instanceCaCertificate;
   }
 
-  Map<String, String> getIpAddrs() {
+  Map<IpType, String> getIpAddrs() {
     return ipAddrs;
   }
 

--- a/core/src/test/java/com/google/cloud/sql/core/CloudSqlInstanceTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/CloudSqlInstanceTest.java
@@ -18,6 +18,7 @@ package com.google.cloud.sql.core;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.cloud.sql.AuthType;
+import com.google.cloud.sql.IpType;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -482,9 +483,9 @@ public class CloudSqlInstanceTest {
         new InstanceData(
             new Metadata(
                 ImmutableMap.of(
-                    "PUBLIC", "10.1.2.3",
-                    "PRIVATE", "10.10.10.10",
-                    "PSC", "abcde.12345.us-central1.sql.goog"),
+                    IpType.PUBLIC, "10.1.2.3",
+                    IpType.PRIVATE, "10.10.10.10",
+                    IpType.PSC, "abcde.12345.us-central1.sql.goog"),
                 null),
             sslData,
             Instant.now().plus(1, ChronoUnit.HOURS));
@@ -507,15 +508,17 @@ public class CloudSqlInstanceTest {
             keyPairFuture,
             TEST_RATE_LIMITER);
 
-    assertThat(instance.getPreferredIp(Arrays.asList("PUBLIC", "PRIVATE"), TEST_TIMEOUT_MS))
+    assertThat(
+            instance.getPreferredIp(Arrays.asList(IpType.PUBLIC, IpType.PRIVATE), TEST_TIMEOUT_MS))
         .isEqualTo("10.1.2.3");
-    assertThat(instance.getPreferredIp(Collections.singletonList("PUBLIC"), TEST_TIMEOUT_MS))
+    assertThat(instance.getPreferredIp(Collections.singletonList(IpType.PUBLIC), TEST_TIMEOUT_MS))
         .isEqualTo("10.1.2.3");
-    assertThat(instance.getPreferredIp(Arrays.asList("PRIVATE", "PUBLIC"), TEST_TIMEOUT_MS))
+    assertThat(
+            instance.getPreferredIp(Arrays.asList(IpType.PRIVATE, IpType.PUBLIC), TEST_TIMEOUT_MS))
         .isEqualTo("10.10.10.10");
-    assertThat(instance.getPreferredIp(Collections.singletonList("PRIVATE"), TEST_TIMEOUT_MS))
+    assertThat(instance.getPreferredIp(Collections.singletonList(IpType.PRIVATE), TEST_TIMEOUT_MS))
         .isEqualTo("10.10.10.10");
-    assertThat(instance.getPreferredIp(Collections.singletonList("PSC"), TEST_TIMEOUT_MS))
+    assertThat(instance.getPreferredIp(Collections.singletonList(IpType.PSC), TEST_TIMEOUT_MS))
         .isEqualTo("abcde.12345.us-central1.sql.goog");
   }
 
@@ -524,7 +527,7 @@ public class CloudSqlInstanceTest {
     SslData sslData = new SslData(null, null, null);
     InstanceData data =
         new InstanceData(
-            new Metadata(ImmutableMap.of("PUBLIC", "10.1.2.3"), null),
+            new Metadata(ImmutableMap.of(IpType.PUBLIC, "10.1.2.3"), null),
             sslData,
             Instant.now().plus(1, ChronoUnit.HOURS));
     AtomicInteger refreshCount = new AtomicInteger();
@@ -547,7 +550,7 @@ public class CloudSqlInstanceTest {
             TEST_RATE_LIMITER);
     Assert.assertThrows(
         IllegalArgumentException.class,
-        () -> instance.getPreferredIp(Collections.singletonList("PRIVATE"), TEST_TIMEOUT_MS));
+        () -> instance.getPreferredIp(Collections.singletonList(IpType.PRIVATE), TEST_TIMEOUT_MS));
   }
 
   private ListeningScheduledExecutorService newTestExecutor() {

--- a/core/src/test/java/com/google/cloud/sql/core/SqlAdminApiFetcherTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/SqlAdminApiFetcherTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertThrows;
 
 import com.google.cloud.sql.AuthType;
 import com.google.cloud.sql.ConnectionConfig;
+import com.google.cloud.sql.IpType;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
@@ -40,7 +41,6 @@ public class SqlAdminApiFetcherTest {
 
   public static final String SAMPLE_PUBLIC_IP = "34.1.2.3";
   public static final String SAMPLE_PRIVATE_IP = "10.0.0.1";
-  public static final String SAMPLE_PSC_IP = "10.0.0.2";
   public static final String SAMPLE_PCS_DNS_NAME = "abcde.12345.us-central1.sql.goog";
   public static final String INSTANCE_CONNECTION_NAME = "p:r:i";
   public static final String DATABASE_VERSION = "POSTGRES14";
@@ -68,10 +68,10 @@ public class SqlAdminApiFetcherTest {
             .get();
     assertThat(instanceData.getSslContext()).isInstanceOf(SSLContext.class);
 
-    Map<String, String> ipAddrs = instanceData.getIpAddrs();
-    assertThat(ipAddrs.get("PRIMARY")).isEqualTo(SAMPLE_PUBLIC_IP);
-    assertThat(ipAddrs.get("PRIVATE")).isEqualTo(SAMPLE_PRIVATE_IP);
-    assertThat(ipAddrs.get("PSC")).isEqualTo(SAMPLE_PCS_DNS_NAME);
+    Map<IpType, String> ipAddrs = instanceData.getIpAddrs();
+    assertThat(ipAddrs.get(IpType.PUBLIC)).isEqualTo(SAMPLE_PUBLIC_IP);
+    assertThat(ipAddrs.get(IpType.PRIVATE)).isEqualTo(SAMPLE_PRIVATE_IP);
+    assertThat(ipAddrs.get(IpType.PSC)).isEqualTo(SAMPLE_PCS_DNS_NAME);
   }
 
   @Test
@@ -106,8 +106,8 @@ public class SqlAdminApiFetcherTest {
             .get();
     assertThat(instanceData.getSslContext()).isInstanceOf(SSLContext.class);
 
-    Map<String, String> ipAddrs = instanceData.getIpAddrs();
-    assertThat(ipAddrs.get("PSC")).isEqualTo(SAMPLE_PCS_DNS_NAME);
+    Map<IpType, String> ipAddrs = instanceData.getIpAddrs();
+    assertThat(ipAddrs.get(IpType.PSC)).isEqualTo(SAMPLE_PCS_DNS_NAME);
     assertThat(ipAddrs.size()).isEqualTo(1);
   }
 
@@ -207,10 +207,10 @@ public class SqlAdminApiFetcherTest {
             .get();
     assertThat(instanceData.getSslContext()).isInstanceOf(SSLContext.class);
 
-    Map<String, String> ipAddrs = instanceData.getIpAddrs();
-    assertThat(ipAddrs.get("PRIMARY")).isEqualTo(SAMPLE_PUBLIC_IP);
-    assertThat(ipAddrs.get("PRIVATE")).isEqualTo(SAMPLE_PRIVATE_IP);
-    assertThat(ipAddrs.get("PSC")).isEqualTo(SAMPLE_PCS_DNS_NAME);
+    Map<IpType, String> ipAddrs = instanceData.getIpAddrs();
+    assertThat(ipAddrs.get(IpType.PUBLIC)).isEqualTo(SAMPLE_PUBLIC_IP);
+    assertThat(ipAddrs.get(IpType.PRIVATE)).isEqualTo(SAMPLE_PRIVATE_IP);
+    assertThat(ipAddrs.get(IpType.PSC)).isEqualTo(SAMPLE_PCS_DNS_NAME);
   }
 
   @SuppressWarnings("SameParameterValue")

--- a/core/src/test/java/com/google/cloud/sql/core/TestDataSupplier.java
+++ b/core/src/test/java/com/google/cloud/sql/core/TestDataSupplier.java
@@ -17,6 +17,7 @@
 package com.google.cloud.sql.core;
 
 import com.google.cloud.sql.AuthType;
+import com.google.cloud.sql.IpType;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
@@ -36,9 +37,9 @@ class TestDataSupplier implements InstanceDataSupplier {
       new InstanceData(
           new Metadata(
               ImmutableMap.of(
-                  "PUBLIC", "10.1.2.3",
-                  "PRIVATE", "10.10.10.10",
-                  "PSC", "abcde.12345.us-central1.sql.goog"),
+                  IpType.PUBLIC, "10.1.2.3",
+                  IpType.PRIVATE, "10.10.10.10",
+                  IpType.PSC, "abcde.12345.us-central1.sql.goog"),
               null),
           new SslData(null, null, null),
           Instant.now().plus(1, ChronoUnit.HOURS));


### PR DESCRIPTION
The new public configuration class IpType should be used throughtout our connector instead of using
strings to represent IpTypes. 

This moves the translation from a String returned by the API into the `SqlAdminApiFetcher`, the class that is responsible for translating API responses into internal data. 

The old unit test `SqlAdminApiFetcherTest.testFetchInstanceData_returnsIpAddresses()` confirms that the translation works correctly.