### PR TITLE
chore: Add Connector class

### DIFF
--- a/core/src/main/java/com/google/cloud/sql/core/Connector.java
+++ b/core/src/main/java/com/google/cloud/sql/core/Connector.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.sql.core;
+
+import com.google.cloud.sql.ConnectionConfig;
+import com.google.cloud.sql.CredentialFactory;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningScheduledExecutorService;
+import java.io.File;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.security.KeyPair;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Logger;
+import javax.net.ssl.SSLSocket;
+import jnr.unixsocket.UnixSocketAddress;
+import jnr.unixsocket.UnixSocketChannel;
+
+class Connector {
+  private static final Logger logger = Logger.getLogger(Connector.class.getName());
+
+  private final DefaultConnectionInfoRepository adminApi;
+  private final CredentialFactory instanceCredentialFactory;
+  private final ListeningScheduledExecutorService executor;
+  private final ListenableFuture<KeyPair> localKeyPair;
+  private final long minRefreshDelayMs;
+
+  private final ConcurrentHashMap<ConnectionConfig, DefaultConnectionInfoCache> instances =
+      new ConcurrentHashMap<>();
+  private final long refreshTimeoutMs;
+  private final int serverProxyPort;
+
+  Connector(
+      DefaultConnectionInfoRepository adminApi,
+      CredentialFactory instanceCredentialFactory,
+      ListeningScheduledExecutorService executor,
+      ListenableFuture<KeyPair> localKeyPair,
+      long minRefreshDelayMs,
+      long refreshTimeoutMs,
+      int serverProxyPort) {
+    this.adminApi = adminApi;
+    this.instanceCredentialFactory = instanceCredentialFactory;
+    this.executor = executor;
+    this.localKeyPair = localKeyPair;
+    this.minRefreshDelayMs = minRefreshDelayMs;
+    this.refreshTimeoutMs = refreshTimeoutMs;
+    this.serverProxyPort = serverProxyPort;
+  }
+
+  /** Extracts the Unix socket argument from specified properties object. If unset, returns null. */
+  private String getUnixSocketArg(ConnectionConfig config) {
+    String unixSocketPath = config.getUnixSocketPath();
+    if (unixSocketPath != null) {
+      // Get the Unix socket file path from the properties object
+      return unixSocketPath;
+    } else if (System.getenv("CLOUD_SQL_FORCE_UNIX_SOCKET") != null) {
+      // If the deprecated env var is set, warn and use `/cloudsql/INSTANCE_CONNECTION_NAME`
+      // A socket factory is provided at this path for GAE, GCF, and Cloud Run
+      logger.warning(
+          String.format(
+              "\"CLOUD_SQL_FORCE_UNIX_SOCKET\" env var has been deprecated. Please use"
+                  + " '%s=\"/cloudsql/INSTANCE_CONNECTION_NAME\"' property in your JDBC url"
+                  + " instead.",
+              ConnectionConfig.UNIX_SOCKET_PROPERTY));
+      return "/cloudsql/" + config.getCloudSqlInstance();
+    }
+    return null; // if unset, default to null
+  }
+
+  Socket connect(ConnectionConfig config) throws IOException {
+    // Connect using the specified Unix socket
+    String unixSocket = getUnixSocketArg(config);
+    String unixPathSuffix = config.getUnixSocketPathSuffix();
+    if (unixSocket != null) {
+      // Verify it ends with the correct suffix
+      if (unixPathSuffix != null && !unixSocket.endsWith(unixPathSuffix)) {
+        unixSocket = unixSocket + unixPathSuffix;
+      }
+      logger.info(
+          String.format(
+              "Connecting to Cloud SQL instance [%s] via unix socket at %s.",
+              config.getCloudSqlInstance(), unixSocket));
+      UnixSocketAddress socketAddress = new UnixSocketAddress(new File(unixSocket));
+      return UnixSocketChannel.open(socketAddress).socket();
+    }
+
+    DefaultConnectionInfoCache instance = getConnection(config);
+    try {
+
+      SSLSocket socket = instance.createSslSocket(this.refreshTimeoutMs);
+
+      socket.setKeepAlive(true);
+      socket.setTcpNoDelay(true);
+
+      String instanceIp = instance.getPreferredIp(config.getIpTypes(), refreshTimeoutMs);
+
+      socket.connect(new InetSocketAddress(instanceIp, serverProxyPort));
+      socket.startHandshake();
+
+      return socket;
+    } catch (IOException e) {
+      instance.forceRefresh();
+      throw e;
+    }
+  }
+
+  DefaultConnectionInfoCache getConnection(ConnectionConfig config) {
+    return instances.computeIfAbsent(config, k -> createConnectionInfo(config));
+  }
+
+  private DefaultConnectionInfoCache createConnectionInfo(ConnectionConfig config) {
+    return new DefaultConnectionInfoCache(
+        config, adminApi, instanceCredentialFactory, executor, localKeyPair, minRefreshDelayMs);
+  }
+}

--- a/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
@@ -22,7 +22,8 @@ import com.google.cloud.sql.ConnectionConfig;
  * Implementation of informally used Java API to preserve compatibility with older code that uses
  * CoreSocketFactory.
  *
- * @deprecated This will soon be replaced.
+ * @deprecated Use the official java API instead.
+ * @see com.google.cloud.sql.ConnectorRegistry
  */
 @Deprecated
 public final class CoreSocketFactory {
@@ -75,6 +76,12 @@ public final class CoreSocketFactory {
   public static final String USER_TOKEN_PROPERTY_NAME =
       InternalConnectorRegistry.USER_TOKEN_PROPERTY_NAME;
 
+  /**
+   * Sets the application name for the user agent.
+   *
+   * @deprecated Use the official java API instead.
+   * @see com.google.cloud.sql.ConnectorRegistry
+   */
   static void setApplicationName(String artifactId) {
     InternalConnectorRegistry.setApplicationName(artifactId);
   }

--- a/core/src/main/java/com/google/cloud/sql/core/InternalConnectorRegistry.java
+++ b/core/src/main/java/com/google/cloud/sql/core/InternalConnectorRegistry.java
@@ -25,9 +25,7 @@ import com.google.common.base.Strings;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
-import java.io.File;
 import java.io.IOException;
-import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
@@ -39,9 +37,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.logging.Logger;
-import javax.net.ssl.SSLSocket;
-import jnr.unixsocket.UnixSocketAddress;
-import jnr.unixsocket.UnixSocketChannel;
 
 /**
  * InternalConnectorRegistry keeps track of connectors. This class should not be used directly, but
@@ -50,18 +45,18 @@ import jnr.unixsocket.UnixSocketChannel;
  * <p>WARNING: This is an internal class. The API is subject to change without notice.
  */
 public final class InternalConnectorRegistry {
+
   static final long DEFAULT_MAX_REFRESH_MS = 30000;
   private static final Logger logger = Logger.getLogger(InternalConnectorRegistry.class.getName());
 
-  private static final int DEFAULT_SERVER_PROXY_PORT = 3307;
+  static final int DEFAULT_SERVER_PROXY_PORT = 3307;
   private static final int RSA_KEY_SIZE = 2048;
   private static final List<String> userAgents = new ArrayList<>();
   private static final String version = getVersion();
   private static final long MIN_REFRESH_DELAY_MS = 30000; // Minimum 30 seconds between refresh.
   private static InternalConnectorRegistry internalConnectorRegistry;
   private final ListenableFuture<KeyPair> localKeyPair;
-  private final ConcurrentHashMap<String, DefaultConnectionInfoCache> connectionInfoCaches =
-      new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<String, Connector> connectors = new ConcurrentHashMap<>();
   private final ListeningScheduledExecutorService executor;
   private final CredentialFactory credentialFactory;
   private final int serverProxyPort;
@@ -131,76 +126,40 @@ public final class InternalConnectorRegistry {
         MoreExecutors.getExitingScheduledExecutorService(executor));
   }
 
-  /** Extracts the Unix socket argument from specified properties object. If unset, returns null. */
-  private static String getUnixSocketArg(ConnectionConfig config) {
-    String unixSocketPath = config.getUnixSocketPath();
-    if (unixSocketPath != null) {
-      // Get the Unix socket file path from the properties object
-      return unixSocketPath;
-    } else if (System.getenv("CLOUD_SQL_FORCE_UNIX_SOCKET") != null) {
-      // If the deprecated env var is set, warn and use `/cloudsql/INSTANCE_CONNECTION_NAME`
-      // A socket factory is provided at this path for GAE, GCF, and Cloud Run
-      logger.warning(
-          String.format(
-              "\"CLOUD_SQL_FORCE_UNIX_SOCKET\" env var has been deprecated. Please use"
-                  + " '%s=\"/cloudsql/INSTANCE_CONNECTION_NAME\"' property in your JDBC url"
-                  + " instead.",
-              ConnectionConfig.UNIX_SOCKET_PROPERTY));
-      return "/cloudsql/" + config.getCloudSqlInstance();
-    }
-    return null; // if unset, default to null
-  }
-
   /**
    * Creates a socket representing a connection to a Cloud SQL instance.
    *
    * <p>Depending on the given properties, it may return either a SSL Socket or a Unix Socket.
    *
-   * @param props Properties used to configure the connection.
+   * @param config Configuration used to configure the connection.
    * @return the newly created Socket.
    * @throws IOException if error occurs during socket creation.
    */
-  public static Socket connect(Properties props) throws IOException, InterruptedException {
-    // Gather parameters
-
-    ConnectionConfig config = ConnectionConfig.fromConnectionProperties(props);
-
+  public Socket connect(ConnectionConfig config) throws IOException, InterruptedException {
     // Validate parameters
     Preconditions.checkArgument(
         config.getCloudSqlInstance() != null,
         "cloudSqlInstance property not set. Please specify this property in the JDBC URL or the "
             + "connection Properties with value in form \"project:region:instance\"");
 
-    // Connect using the specified Unix socket
-    String unixSocket = getUnixSocketArg(config);
-    if (unixSocket != null) {
-      // Verify it ends with the correct suffix
-      String unixPathSuffix = config.getUnixSocketPathSuffix();
-      if (unixPathSuffix != null && !unixSocket.endsWith(unixPathSuffix)) {
-        unixSocket = unixSocket + unixPathSuffix;
-      }
-      logger.info(
-          String.format(
-              "Connecting to Cloud SQL instance [%s] via unix socket at %s.",
-              config.getCloudSqlInstance(), unixSocket));
-      UnixSocketAddress socketAddress = new UnixSocketAddress(new File(unixSocket));
-      return UnixSocketChannel.open(socketAddress).socket();
-    }
-
-    return getInstance().createSslSocket(config);
+    return getConnector(config).connect(config);
   }
 
   /** Returns data that can be used to establish Cloud SQL SSL connection. */
   public static SslData getSslData(ConnectionConfig config) throws IOException {
     InternalConnectorRegistry instance = getInstance();
-    return instance.getConnectionInfoCache(config).getSslData(instance.refreshTimeoutMs);
+    return instance
+        .getConnector(config)
+        .getConnection(config)
+        .getSslData(instance.refreshTimeoutMs);
   }
 
   /** Returns preferred ip address that can be used to establish Cloud SQL connection. */
   public static String getHostIp(ConnectionConfig config) throws IOException {
     InternalConnectorRegistry instance = getInstance();
     return instance
-        .getConnectionInfoCache(config)
+        .getConnector(config)
+        .getConnection(config)
         .getPreferredIp(config.getIpTypes(), instance.refreshTimeoutMs);
   }
 
@@ -281,44 +240,11 @@ public final class InternalConnectorRegistry {
     System.setProperty(USER_TOKEN_PROPERTY_NAME, applicationName);
   }
 
-  /**
-   * Creates a secure socket representing a connection to a Cloud SQL instance.
-   *
-   * @return the newly created Socket.
-   * @throws IOException if error occurs during socket creation.
-   */
-  // TODO(berezv): separate creating socket and performing connection to make it easier to test
-  @VisibleForTesting
-  Socket createSslSocket(ConnectionConfig config) throws IOException, InterruptedException {
-    DefaultConnectionInfoCache connectionInfoCache = getConnectionInfoCache(config);
-
-    try {
-      SSLSocket socket = connectionInfoCache.createSslSocket(this.refreshTimeoutMs);
-
-      // TODO(kvg): Support all socket related options listed here:
-      // https://dev.mysql.com/doc/connector-j/en/connector-j-reference-configuration-properties.html
-      socket.setKeepAlive(true);
-      socket.setTcpNoDelay(true);
-
-      String instanceIp = connectionInfoCache.getPreferredIp(config.getIpTypes(), refreshTimeoutMs);
-
-      socket.connect(new InetSocketAddress(instanceIp, serverProxyPort));
-      socket.startHandshake();
-
-      return socket;
-    } catch (Exception ex) {
-      // TODO(kvg): Let user know about the rate limit
-      connectionInfoCache.forceRefresh();
-      throw ex;
-    }
+  private Connector getConnector(ConnectionConfig config) {
+    return connectors.computeIfAbsent(config.getCloudSqlInstance(), k -> createConnector(config));
   }
 
-  DefaultConnectionInfoCache getConnectionInfoCache(ConnectionConfig config) {
-    return connectionInfoCaches.computeIfAbsent(
-        config.getCloudSqlInstance(), k -> apiFetcher(config));
-  }
-
-  private DefaultConnectionInfoCache apiFetcher(ConnectionConfig config) {
+  private Connector createConnector(ConnectionConfig config) {
 
     final CredentialFactory instanceCredentialFactory;
     if (config.getTargetPrincipal() != null && !config.getTargetPrincipal().isEmpty()) {
@@ -340,13 +266,13 @@ public final class InternalConnectorRegistry {
     DefaultConnectionInfoRepository adminApi =
         connectionInfoRepositoryFactory.create(credential, config);
 
-    return new DefaultConnectionInfoCache(
-        config.getCloudSqlInstance(),
+    return new Connector(
         adminApi,
-        config.getAuthType(),
         instanceCredentialFactory,
         executor,
         localKeyPair,
-        MIN_REFRESH_DELAY_MS);
+        MIN_REFRESH_DELAY_MS,
+        refreshTimeoutMs,
+        serverProxyPort);
   }
 }

--- a/core/src/test/java/com/google/cloud/sql/core/ConnectorTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/ConnectorTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.sql.core;
+
+import static com.google.cloud.sql.core.InternalConnectorRegistry.DEFAULT_SERVER_PROXY_PORT;
+import static com.google.common.truth.Truth.assertThat;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.fail;
+
+import com.google.cloud.sql.ConnectionConfig;
+import com.google.common.util.concurrent.ListeningScheduledExecutorService;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.Socket;
+import java.time.Duration;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ConnectorTest extends CloudSqlCoreTestingBase {
+  ListeningScheduledExecutorService defaultExecutor;
+  private final long TEST_MAX_REFRESH_MS = 5000L;
+
+  @Before
+  public void setUp() throws Exception {
+    super.setup();
+    defaultExecutor = InternalConnectorRegistry.getDefaultExecutor();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    defaultExecutor.shutdownNow();
+  }
+
+  @Test
+  public void create_throwsErrorForInvalidInstanceName() throws IOException {
+    ConnectionConfig config =
+        new ConnectionConfig.Builder()
+            .withCloudSqlInstance("myProject")
+            .withIpTypes("PRIMARY")
+            .build();
+
+    ConnectionConfig config2 =
+        new ConnectionConfig.Builder()
+            .withCloudSqlInstance("myProject:myRegion")
+            .withIpTypes("PRIMARY")
+            .build();
+
+    Connector c = newConnector(config, DEFAULT_SERVER_PROXY_PORT);
+    try {
+      c.connect(config);
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessageThat().contains("Cloud SQL connection name is invalid");
+    }
+
+    try {
+      c.connect(config2);
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessageThat().contains("Cloud SQL connection name is invalid");
+    }
+  }
+
+  /**
+   * Start an SSL server on the private IP, and verifies that specifying a preference for private IP
+   * results in a connection to the private IP.
+   */
+  @Test
+  public void create_successfulPrivateConnection() throws IOException, InterruptedException {
+    FakeSslServer sslServer = new FakeSslServer();
+    ConnectionConfig config =
+        new ConnectionConfig.Builder()
+            .withCloudSqlInstance("myProject:myRegion:myInstance")
+            .withIpTypes("PRIVATE")
+            .build();
+
+    int port = sslServer.start(PRIVATE_IP);
+
+    Connector connector = newConnector(config, port);
+
+    Socket socket = connector.connect(config);
+
+    assertThat(readLine(socket)).isEqualTo(SERVER_MESSAGE);
+  }
+
+  private Connector newConnector(ConnectionConfig config, int port) {
+    ConnectionInfoRepositoryFactory factory =
+        new StubConnectionInfoRepositoryFactory(fakeSuccessHttpTransport(Duration.ofSeconds(0)));
+    Connector connector =
+        new Connector(
+            factory.create(credentialFactory.create(), config),
+            credentialFactory,
+            defaultExecutor,
+            clientKeyPair,
+            10,
+            TEST_MAX_REFRESH_MS,
+            port);
+    return connector;
+  }
+
+  private String readLine(Socket socket) throws IOException {
+    BufferedReader bufferedReader =
+        new BufferedReader(new InputStreamReader(socket.getInputStream(), UTF_8));
+    return bufferedReader.readLine();
+  }
+}

--- a/core/src/test/java/com/google/cloud/sql/core/DefaultConnectionInfoCacheConcurrencyTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/DefaultConnectionInfoCacheConcurrencyTest.java
@@ -20,7 +20,7 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.api.client.http.HttpRequest;
 import com.google.api.client.http.HttpRequestInitializer;
-import com.google.cloud.sql.AuthType;
+import com.google.cloud.sql.ConnectionConfig;
 import com.google.cloud.sql.CredentialFactory;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -68,9 +68,8 @@ public class DefaultConnectionInfoCacheConcurrencyTest {
     for (int i = 0; i < instanceCount; i++) {
       caches.add(
           new DefaultConnectionInfoCache(
-              "a:b:instance" + i,
+              new ConnectionConfig.Builder().withCloudSqlInstance("a:b:instance" + i).build(),
               supplier,
-              AuthType.PASSWORD,
               new TestCredentialFactory(),
               executor,
               keyPairFuture,

--- a/core/src/test/java/com/google/cloud/sql/core/DefaultConnectionInfoCacheTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/DefaultConnectionInfoCacheTest.java
@@ -18,6 +18,7 @@ package com.google.cloud.sql.core;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.cloud.sql.AuthType;
+import com.google.cloud.sql.ConnectionConfig;
 import com.google.cloud.sql.IpType;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.Futures;
@@ -68,9 +69,8 @@ public class DefaultConnectionInfoCacheTest {
     // initialize connectionInfoCache after mocks are set up
     DefaultConnectionInfoCache connectionInfoCache =
         new DefaultConnectionInfoCache(
-            "project:region:instance",
+            new ConnectionConfig.Builder().withCloudSqlInstance("project:region:instance").build(),
             instanceDataSupplier,
-            AuthType.PASSWORD,
             stubCredentialFactory,
             executorService,
             keyPairFuture,
@@ -98,9 +98,8 @@ public class DefaultConnectionInfoCacheTest {
     // initialize connectionInfoCache after mocks are set up
     DefaultConnectionInfoCache connectionInfoCache =
         new DefaultConnectionInfoCache(
-            "project:region:instance",
+            new ConnectionConfig.Builder().withCloudSqlInstance("project:region:instance").build(),
             connectionInfoRepository,
-            AuthType.PASSWORD,
             stubCredentialFactory,
             executorService,
             keyPairFuture,
@@ -129,9 +128,8 @@ public class DefaultConnectionInfoCacheTest {
     // initialize connectionInfoCache after mocks are set up
     DefaultConnectionInfoCache connectionInfoCache =
         new DefaultConnectionInfoCache(
-            "project:region:instance",
+            new ConnectionConfig.Builder().withCloudSqlInstance("project:region:instance").build(),
             connectionInfoRepository,
-            AuthType.PASSWORD,
             stubCredentialFactory,
             executorService,
             keyPairFuture,
@@ -150,7 +148,7 @@ public class DefaultConnectionInfoCacheTest {
 
     DefaultConnectionInfoCache connectionInfoCache =
         new DefaultConnectionInfoCache(
-            "project:region:instance",
+            new ConnectionConfig.Builder().withCloudSqlInstance("project:region:instance").build(),
             (instanceName, accessTokenSupplier, authType, executor, keyPair) -> {
               int c = refreshCount.get();
               // Allow the first execution to complete immediately.
@@ -161,7 +159,6 @@ public class DefaultConnectionInfoCacheTest {
               refreshCount.incrementAndGet();
               return Futures.immediateFuture(connectionInfo);
             },
-            AuthType.PASSWORD,
             stubCredentialFactory,
             executorService,
             keyPairFuture,
@@ -196,7 +193,7 @@ public class DefaultConnectionInfoCacheTest {
 
     DefaultConnectionInfoCache connectionInfoCache =
         new DefaultConnectionInfoCache(
-            "project:region:instance",
+            new ConnectionConfig.Builder().withCloudSqlInstance("project:region:instance").build(),
             (instanceName, accessTokenSupplier, authType, executor, keyPair) -> {
               int c = refreshCount.get();
               refreshCount.incrementAndGet();
@@ -205,7 +202,6 @@ public class DefaultConnectionInfoCacheTest {
               }
               return Futures.immediateFuture(connectionInfo);
             },
-            AuthType.PASSWORD,
             stubCredentialFactory,
             executorService,
             keyPairFuture,
@@ -241,7 +237,7 @@ public class DefaultConnectionInfoCacheTest {
 
     DefaultConnectionInfoCache connectionInfoCache =
         new DefaultConnectionInfoCache(
-            "project:region:instance",
+            new ConnectionConfig.Builder().withCloudSqlInstance("project:region:instance").build(),
             (instanceName, accessTokenSupplier, authType, executor, keyPair) -> {
               int c = refreshCount.get();
               ConnectionInfo refreshResult = info;
@@ -259,7 +255,6 @@ public class DefaultConnectionInfoCacheTest {
               refreshCount.incrementAndGet();
               return Futures.immediateFuture(refreshResult);
             },
-            AuthType.PASSWORD,
             stubCredentialFactory,
             executorService,
             keyPairFuture,
@@ -299,7 +294,7 @@ public class DefaultConnectionInfoCacheTest {
 
     DefaultConnectionInfoCache connectionInfoCache =
         new DefaultConnectionInfoCache(
-            "project:region:instance",
+            new ConnectionConfig.Builder().withCloudSqlInstance("project:region:instance").build(),
             (instanceName, accessTokenSupplier, authType, executor, keyPair) -> {
               int c = refreshCount.get();
               ConnectionInfo refreshResult = info;
@@ -315,7 +310,6 @@ public class DefaultConnectionInfoCacheTest {
               refreshCount.incrementAndGet();
               return Futures.immediateFuture(refreshResult);
             },
-            AuthType.PASSWORD,
             stubCredentialFactory,
             executorService,
             keyPairFuture,
@@ -360,7 +354,7 @@ public class DefaultConnectionInfoCacheTest {
 
     DefaultConnectionInfoCache connectionInfoCache =
         new DefaultConnectionInfoCache(
-            "project:region:instance",
+            new ConnectionConfig.Builder().withCloudSqlInstance("project:region:instance").build(),
             (instanceName, accessTokenSupplier, authType, executor, keyPair) -> {
               int c = refreshCount.get();
               switch (c) {
@@ -375,7 +369,6 @@ public class DefaultConnectionInfoCacheTest {
                   return Futures.immediateFuture(info);
               }
             },
-            AuthType.PASSWORD,
             stubCredentialFactory,
             executorService,
             keyPairFuture,
@@ -418,7 +411,7 @@ public class DefaultConnectionInfoCacheTest {
 
     DefaultConnectionInfoCache connectionInfoCache =
         new DefaultConnectionInfoCache(
-            "project:region:instance",
+            new ConnectionConfig.Builder().withCloudSqlInstance("project:region:instance").build(),
             (instanceName, accessTokenSupplier, authType, executor, keyPair) -> {
               int c = refreshCount.get();
               switch (c) {
@@ -439,7 +432,6 @@ public class DefaultConnectionInfoCacheTest {
                   return Futures.immediateFuture(info);
               }
             },
-            AuthType.PASSWORD,
             stubCredentialFactory,
             executorService,
             keyPairFuture,
@@ -502,9 +494,8 @@ public class DefaultConnectionInfoCacheTest {
     // initialize connectionInfoCache after mocks are set up
     DefaultConnectionInfoCache connectionInfoCache =
         new DefaultConnectionInfoCache(
-            "project:region:instance",
+            new ConnectionConfig.Builder().withCloudSqlInstance("project:region:instance").build(),
             connectionInfoRepository,
-            AuthType.PASSWORD,
             stubCredentialFactory,
             executorService,
             keyPairFuture,
@@ -551,9 +542,8 @@ public class DefaultConnectionInfoCacheTest {
     // initialize connectionInfoCache after mocks are set up
     DefaultConnectionInfoCache connectionInfoCache =
         new DefaultConnectionInfoCache(
-            "project:region:instance",
+            new ConnectionConfig.Builder().withCloudSqlInstance("project:region:instance").build(),
             connectionInfoRepository,
-            AuthType.PASSWORD,
             stubCredentialFactory,
             executorService,
             keyPairFuture,

--- a/core/src/test/java/com/google/cloud/sql/core/InternalConnectorRegistryTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/InternalConnectorRegistryTest.java
@@ -66,7 +66,7 @@ public class InternalConnectorRegistryTest extends CloudSqlCoreTestingBase {
         new InternalConnectorRegistry(
             clientKeyPair, factory, credentialFactory, 3307, TEST_MAX_REFRESH_MS, defaultExecutor);
     try {
-      internalConnectorRegistry.createSslSocket(
+      internalConnectorRegistry.connect(
           new ConnectionConfig.Builder()
               .withCloudSqlInstance("myProject")
               .withIpTypes("PRIMARY")
@@ -77,7 +77,7 @@ public class InternalConnectorRegistryTest extends CloudSqlCoreTestingBase {
     }
 
     try {
-      internalConnectorRegistry.createSslSocket(
+      internalConnectorRegistry.connect(
           new ConnectionConfig.Builder()
               .withCloudSqlInstance("myProject:myRegion")
               .withIpTypes("PRIMARY")
@@ -98,7 +98,7 @@ public class InternalConnectorRegistryTest extends CloudSqlCoreTestingBase {
         new InternalConnectorRegistry(
             clientKeyPair, factory, credentialFactory, 3307, TEST_MAX_REFRESH_MS, defaultExecutor);
     try {
-      internalConnectorRegistry.createSslSocket(
+      internalConnectorRegistry.connect(
           new ConnectionConfig.Builder()
               .withCloudSqlInstance("myProject:notMyRegion:myInstance")
               .withIpTypes("PRIMARY")
@@ -128,7 +128,7 @@ public class InternalConnectorRegistryTest extends CloudSqlCoreTestingBase {
         new InternalConnectorRegistry(
             clientKeyPair, factory, credentialFactory, port, TEST_MAX_REFRESH_MS, defaultExecutor);
     Socket socket =
-        internalConnectorRegistry.createSslSocket(
+        internalConnectorRegistry.connect(
             new ConnectionConfig.Builder()
                 .withCloudSqlInstance("myProject:myRegion:myInstance")
                 .withIpTypes("PRIVATE")
@@ -149,7 +149,7 @@ public class InternalConnectorRegistryTest extends CloudSqlCoreTestingBase {
             clientKeyPair, factory, credentialFactory, port, TEST_MAX_REFRESH_MS, defaultExecutor);
     try {
 
-      internalConnectorRegistry.createSslSocket(
+      internalConnectorRegistry.connect(
           new ConnectionConfig.Builder()
               .withCloudSqlInstance("myProject:myRegion:myInstance")
               .withIpTypes("PRIMARY")
@@ -173,7 +173,7 @@ public class InternalConnectorRegistryTest extends CloudSqlCoreTestingBase {
             clientKeyPair, factory, credentialFactory, port, TEST_MAX_REFRESH_MS, defaultExecutor);
 
     Socket socket =
-        internalConnectorRegistry.createSslSocket(
+        internalConnectorRegistry.connect(
             new ConnectionConfig.Builder()
                 .withCloudSqlInstance("myProject:myRegion:myInstance")
                 .withIpTypes("PRIMARY")
@@ -193,7 +193,7 @@ public class InternalConnectorRegistryTest extends CloudSqlCoreTestingBase {
         new InternalConnectorRegistry(
             clientKeyPair, factory, credentialFactory, port, TEST_MAX_REFRESH_MS, defaultExecutor);
     Socket socket =
-        internalConnectorRegistry.createSslSocket(
+        internalConnectorRegistry.connect(
             new ConnectionConfig.Builder()
                 .withCloudSqlInstance("example.com:myProject:myRegion:myInstance")
                 .withIpTypes("PRIMARY")
@@ -210,7 +210,7 @@ public class InternalConnectorRegistryTest extends CloudSqlCoreTestingBase {
             clientKeyPair, factory, credentialFactory, 3307, TEST_MAX_REFRESH_MS, defaultExecutor);
     try {
       // Use a different project to get Api Not Enabled Error.
-      internalConnectorRegistry.createSslSocket(
+      internalConnectorRegistry.connect(
           new ConnectionConfig.Builder()
               .withCloudSqlInstance("NotMyProject:myRegion:myInstance")
               .withIpTypes("PRIMARY")
@@ -235,7 +235,7 @@ public class InternalConnectorRegistryTest extends CloudSqlCoreTestingBase {
             clientKeyPair, factory, credentialFactory, 3307, TEST_MAX_REFRESH_MS, defaultExecutor);
     try {
       // Use a different instance to simulate incorrect permissions.
-      internalConnectorRegistry.createSslSocket(
+      internalConnectorRegistry.connect(
           new ConnectionConfig.Builder()
               .withCloudSqlInstance("myProject:myRegion:NotMyInstance")
               .withIpTypes("PRIMARY")
@@ -273,7 +273,7 @@ public class InternalConnectorRegistryTest extends CloudSqlCoreTestingBase {
             TEST_MAX_REFRESH_MS,
             defaultExecutor);
     Socket socket =
-        internalConnectorRegistry.createSslSocket(
+        internalConnectorRegistry.connect(
             new ConnectionConfig.Builder()
                 .withCloudSqlInstance("myProject:myRegion:myInstance")
                 .withIpTypes("PRIMARY")
@@ -302,7 +302,7 @@ public class InternalConnectorRegistryTest extends CloudSqlCoreTestingBase {
             TEST_MAX_REFRESH_MS,
             defaultExecutor);
     Socket socket =
-        internalConnectorRegistry.createSslSocket(
+        internalConnectorRegistry.connect(
             new ConnectionConfig.Builder()
                 .withCloudSqlInstance("myProject:myRegion:myInstance")
                 .withIpTypes("PRIMARY")
@@ -340,7 +340,7 @@ public class InternalConnectorRegistryTest extends CloudSqlCoreTestingBase {
     assertThrows(
         RuntimeException.class,
         () ->
-            internalConnectorRegistry.createSslSocket(
+            internalConnectorRegistry.connect(
                 new ConnectionConfig.Builder()
                     .withCloudSqlInstance("myProject:myRegion:myInstance")
                     .withIpTypes("PRIMARY")

--- a/jdbc/mariadb/src/main/java/com/google/cloud/sql/mariadb/SocketFactory.java
+++ b/jdbc/mariadb/src/main/java/com/google/cloud/sql/mariadb/SocketFactory.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.sql.mariadb;
 
+import com.google.cloud.sql.ConnectionConfig;
 import com.google.cloud.sql.core.InternalConnectorRegistry;
 import java.io.IOException;
 import java.net.InetAddress;
@@ -48,7 +49,8 @@ public class SocketFactory extends ConfigurableSocketFactory {
   @Override
   public Socket createSocket() throws IOException {
     try {
-      return InternalConnectorRegistry.connect(conf.nonMappedOptions());
+      return InternalConnectorRegistry.getInstance()
+          .connect(ConnectionConfig.fromConnectionProperties(conf.nonMappedOptions()));
     } catch (InterruptedException e) {
       throw new RuntimeException(e);
     }

--- a/jdbc/mysql-j-8/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
+++ b/jdbc/mysql-j-8/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.sql.mysql;
 
+import com.google.cloud.sql.ConnectionConfig;
 import com.google.cloud.sql.core.InternalConnectorRegistry;
 import com.mysql.cj.conf.PropertySet;
 import com.mysql.cj.protocol.ServerSession;
@@ -56,7 +57,10 @@ public class SocketFactory implements com.mysql.cj.protocol.SocketFactory {
       String host, int portNumber, Properties props, int loginTimeout)
       throws IOException, InterruptedException {
     @SuppressWarnings("unchecked")
-    T socket = (T) InternalConnectorRegistry.connect(props);
+    T socket =
+        (T)
+            InternalConnectorRegistry.getInstance()
+                .connect(ConnectionConfig.fromConnectionProperties(props));
     return socket;
   }
 

--- a/jdbc/postgres/src/main/java/com/google/cloud/sql/postgres/SocketFactory.java
+++ b/jdbc/postgres/src/main/java/com/google/cloud/sql/postgres/SocketFactory.java
@@ -76,7 +76,8 @@ public class SocketFactory extends javax.net.SocketFactory {
   @Override
   public Socket createSocket() throws IOException {
     try {
-      return InternalConnectorRegistry.connect(props);
+      return InternalConnectorRegistry.getInstance()
+          .connect(ConnectionConfig.fromConnectionProperties(props));
     } catch (InterruptedException e) {
       throw new RuntimeException(e);
     }

--- a/jdbc/sqlserver/src/main/java/com/google/cloud/sql/sqlserver/SocketFactory.java
+++ b/jdbc/sqlserver/src/main/java/com/google/cloud/sql/sqlserver/SocketFactory.java
@@ -74,7 +74,8 @@ public class SocketFactory extends javax.net.SocketFactory {
   @Override
   public Socket createSocket() throws IOException {
     try {
-      return InternalConnectorRegistry.connect(props);
+      return InternalConnectorRegistry.getInstance()
+          .connect(ConnectionConfig.fromConnectionProperties(props));
     } catch (InterruptedException e) {
       throw new RuntimeException(e);
     }


### PR DESCRIPTION
Introduce the `Connector` class, which can create mTLS connections to a database instance. `ConnectorKey` is used to identify the `Connector` for a `ConnectionConfig`

Part of #1226 
