### PR TITLE
chore: Introduce ConnectionMetadata for R2DBC factories

### DIFF
--- a/core/src/main/java/com/google/cloud/sql/core/ConnectionInfo.java
+++ b/core/src/main/java/com/google/cloud/sql/core/ConnectionInfo.java
@@ -24,13 +24,13 @@ import javax.net.ssl.SSLContext;
 /** Represents the results of a certificate and metadata refresh operation. */
 class ConnectionInfo {
 
-  private final Metadata metadata;
+  private final InstanceMetadata instanceMetadata;
   private final SSLContext sslContext;
   private final SslData sslData;
   private final Instant expiration;
 
-  ConnectionInfo(Metadata metadata, SslData sslData, Instant expiration) {
-    this.metadata = metadata;
+  ConnectionInfo(InstanceMetadata instanceMetadata, SslData sslData, Instant expiration) {
+    this.instanceMetadata = instanceMetadata;
     this.sslData = sslData;
     this.sslContext = sslData.getSslContext();
     this.expiration = expiration;
@@ -45,7 +45,7 @@ class ConnectionInfo {
   }
 
   Map<IpType, String> getIpAddrs() {
-    return metadata.getIpAddrs();
+    return instanceMetadata.getIpAddrs();
   }
 
   SslData getSslData() {

--- a/core/src/main/java/com/google/cloud/sql/core/ConnectionMetadata.java
+++ b/core/src/main/java/com/google/cloud/sql/core/ConnectionMetadata.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.sql.core;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.TrustManagerFactory;
+
+/**
+ * A value object containing configuration needed to set up an mTLS connection to a Cloud SQL
+ * instance.
+ */
+public class ConnectionMetadata {
+  private final String preferredIpAddress;
+  private final KeyManagerFactory keyManagerFactory;
+  private final TrustManagerFactory trustManagerFactory;
+
+  /** Construct an immutable ConnectionMetadata. */
+  public ConnectionMetadata(
+      String preferredIpAddress,
+      KeyManagerFactory keyManagerFactory,
+      TrustManagerFactory trustManagerFactory) {
+
+    this.preferredIpAddress = preferredIpAddress;
+    this.keyManagerFactory = keyManagerFactory;
+    this.trustManagerFactory = trustManagerFactory;
+  }
+
+  public String getPreferredIpAddress() {
+    return preferredIpAddress;
+  }
+
+  public KeyManagerFactory getKeyManagerFactory() {
+    return keyManagerFactory;
+  }
+
+  public TrustManagerFactory getTrustManagerFactory() {
+    return trustManagerFactory;
+  }
+}

--- a/core/src/main/java/com/google/cloud/sql/core/Connector.java
+++ b/core/src/main/java/com/google/cloud/sql/core/Connector.java
@@ -107,7 +107,7 @@ class Connector {
       socket.setKeepAlive(true);
       socket.setTcpNoDelay(true);
 
-      String instanceIp = instance.getPreferredIp(config.getIpTypes(), refreshTimeoutMs);
+      String instanceIp = instance.getConnectionMetadata(refreshTimeoutMs).getPreferredIpAddress();
 
       socket.connect(new InetSocketAddress(instanceIp, serverProxyPort));
       socket.startHandshake();

--- a/core/src/main/java/com/google/cloud/sql/core/DefaultConnectionInfoRepository.java
+++ b/core/src/main/java/com/google/cloud/sql/core/DefaultConnectionInfoRepository.java
@@ -101,7 +101,7 @@ class DefaultConnectionInfoRepository implements ConnectionInfoRepository {
     ListenableFuture<Optional<AccessToken>> token = executor.submit(accessTokenSupplier::get);
 
     // Fetch the metadata
-    ListenableFuture<Metadata> metadataFuture =
+    ListenableFuture<InstanceMetadata> metadataFuture =
         executor.submit(() -> fetchMetadata(instanceName, authType));
 
     // Fetch the ephemeral certificates
@@ -168,7 +168,7 @@ class DefaultConnectionInfoRepository implements ConnectionInfoRepository {
   }
 
   /** Fetches the latest version of the instance's metadata using the Cloud SQL Admin API. */
-  private Metadata fetchMetadata(CloudSqlInstanceName instanceName, AuthType authType) {
+  private InstanceMetadata fetchMetadata(CloudSqlInstanceName instanceName, AuthType authType) {
     try {
       ConnectSettings instanceMetadata =
           apiClient
@@ -228,7 +228,7 @@ class DefaultConnectionInfoRepository implements ConnectionInfoRepository {
 
         logger.fine(String.format("[%s] METADATA DONE", instanceName));
 
-        return new Metadata(ipAddrs, instanceCaCertificate);
+        return new InstanceMetadata(ipAddrs, instanceCaCertificate);
       } catch (CertificateException ex) {
         throw new RuntimeException(
             String.format(
@@ -310,7 +310,7 @@ class DefaultConnectionInfoRepository implements ConnectionInfoRepository {
    */
   private SslData createSslData(
       KeyPair keyPair,
-      Metadata metadata,
+      InstanceMetadata instanceMetadata,
       Certificate ephemeralCertificate,
       CloudSqlInstanceName instanceName,
       AuthType authType) {
@@ -326,7 +326,7 @@ class DefaultConnectionInfoRepository implements ConnectionInfoRepository {
 
       KeyStore trustedKeyStore = KeyStore.getInstance(KeyStore.getDefaultType());
       trustedKeyStore.load(null, null);
-      trustedKeyStore.setCertificateEntry("instance", metadata.getInstanceCaCertificate());
+      trustedKeyStore.setCertificateEntry("instance", instanceMetadata.getInstanceCaCertificate());
       TrustManagerFactory tmf = TrustManagerFactory.getInstance("X.509");
       tmf.init(trustedKeyStore);
       SSLContext sslContext;

--- a/core/src/main/java/com/google/cloud/sql/core/InstanceMetadata.java
+++ b/core/src/main/java/com/google/cloud/sql/core/InstanceMetadata.java
@@ -21,12 +21,12 @@ import java.security.cert.Certificate;
 import java.util.Map;
 
 /** Represents the results of @link #fetchMetadata(). */
-class Metadata {
+class InstanceMetadata {
 
   private final Map<IpType, String> ipAddrs;
   private final Certificate instanceCaCertificate;
 
-  Metadata(Map<IpType, String> ipAddrs, Certificate instanceCaCertificate) {
+  InstanceMetadata(Map<IpType, String> ipAddrs, Certificate instanceCaCertificate) {
     this.ipAddrs = ipAddrs;
     this.instanceCaCertificate = instanceCaCertificate;
   }

--- a/core/src/main/java/com/google/cloud/sql/core/InternalConnectorRegistry.java
+++ b/core/src/main/java/com/google/cloud/sql/core/InternalConnectorRegistry.java
@@ -145,22 +145,8 @@ public final class InternalConnectorRegistry {
     return getConnector(config).connect(config);
   }
 
-  /** Returns data that can be used to establish Cloud SQL SSL connection. */
-  public static SslData getSslData(ConnectionConfig config) throws IOException {
-    InternalConnectorRegistry instance = getInstance();
-    return instance
-        .getConnector(config)
-        .getConnection(config)
-        .getSslData(instance.refreshTimeoutMs);
-  }
-
-  /** Returns preferred ip address that can be used to establish Cloud SQL connection. */
-  public static String getHostIp(ConnectionConfig config) throws IOException {
-    InternalConnectorRegistry instance = getInstance();
-    return instance
-        .getConnector(config)
-        .getConnection(config)
-        .getPreferredIp(config.getIpTypes(), instance.refreshTimeoutMs);
+  public ConnectionMetadata getConnectionMetadata(ConnectionConfig config) throws IOException {
+    return getConnector(config).getConnection(config).getConnectionMetadata(refreshTimeoutMs);
   }
 
   private static KeyPair generateRsaKeyPair() {

--- a/core/src/test/java/com/google/cloud/sql/core/DefaultConnectionInfoCacheConcurrencyTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/DefaultConnectionInfoCacheConcurrencyTest.java
@@ -77,7 +77,7 @@ public class DefaultConnectionInfoCacheConcurrencyTest {
     }
 
     // Get SSL Data for each instance, forcing the first refresh to complete.
-    caches.forEach((inst) -> inst.getSslData(2000L));
+    caches.forEach((inst) -> inst.getConnectionMetadata(2000L));
 
     assertThat(supplier.counter.get()).isEqualTo(instanceCount);
 
@@ -116,7 +116,7 @@ public class DefaultConnectionInfoCacheConcurrencyTest {
               connectionInfoCache.forceRefresh();
               connectionInfoCache.forceRefresh();
               Thread.sleep(0);
-              connectionInfoCache.getSslData(2000L);
+              connectionInfoCache.getConnectionMetadata(2000L);
             } catch (Exception e) {
               logger.info("Exception in force refresh loop.");
             }

--- a/core/src/test/java/com/google/cloud/sql/core/RefresherTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/RefresherTest.java
@@ -394,7 +394,7 @@ public class RefresherTest {
   private static class ExampleData extends ConnectionInfo {
 
     ExampleData(Instant expiration) {
-      super(new Metadata(null, null), new SslData(null, null, null), expiration);
+      super(new InstanceMetadata(null, null), new SslData(null, null, null), expiration);
     }
   }
 

--- a/core/src/test/java/com/google/cloud/sql/core/TestDataSupplier.java
+++ b/core/src/test/java/com/google/cloud/sql/core/TestDataSupplier.java
@@ -22,10 +22,12 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import java.security.KeyPair;
+import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
+import javax.net.ssl.KeyManagerFactory;
 
 class TestDataSupplier implements ConnectionInfoRepository {
 
@@ -35,14 +37,22 @@ class TestDataSupplier implements ConnectionInfoRepository {
   final AtomicInteger successCounter = new AtomicInteger();
   final ConnectionInfo response =
       new ConnectionInfo(
-          new Metadata(
+          new InstanceMetadata(
               ImmutableMap.of(
                   IpType.PUBLIC, "10.1.2.3",
                   IpType.PRIVATE, "10.10.10.10",
                   IpType.PSC, "abcde.12345.us-central1.sql.goog"),
               null),
-          new SslData(null, null, null),
+          new SslData(null, createKeyManagerFactory(), null),
           Instant.now().plus(1, ChronoUnit.HOURS));
+
+  private static KeyManagerFactory createKeyManagerFactory() {
+    try {
+      return KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+    } catch (NoSuchAlgorithmException e) {
+      throw new RuntimeException(e);
+    }
+  }
 
   TestDataSupplier(boolean flaky) {
     this.flaky = flaky;

--- a/r2dbc/core/src/main/java/com/google/cloud/sql/core/CloudSqlConnectionFactory.java
+++ b/r2dbc/core/src/main/java/com/google/cloud/sql/core/CloudSqlConnectionFactory.java
@@ -52,7 +52,10 @@ public class CloudSqlConnectionFactory implements ConnectionFactory {
   @NonNull
   public Publisher<? extends Connection> create() {
     try {
-      String hostIp = InternalConnectorRegistry.getHostIp(config);
+      String hostIp =
+          InternalConnectorRegistry.getInstance()
+              .getConnectionMetadata(config)
+              .getPreferredIpAddress();
       builder.option(HOST, hostIp).option(PORT, SERVER_PROXY_PORT);
       return supplier.get().create(builder.build()).create();
     } catch (IOException e) {
@@ -64,7 +67,10 @@ public class CloudSqlConnectionFactory implements ConnectionFactory {
   @NonNull
   public ConnectionFactoryMetadata getMetadata() {
     try {
-      String hostIp = InternalConnectorRegistry.getHostIp(config);
+      String hostIp =
+          InternalConnectorRegistry.getInstance()
+              .getConnectionMetadata(config)
+              .getPreferredIpAddress();
       builder.option(HOST, hostIp).option(PORT, SERVER_PROXY_PORT);
       return supplier.get().create(builder.build()).getMetadata();
     } catch (IOException e) {


### PR DESCRIPTION
Make a single internal public method to be used by R2DBC drivers to get the metadata needed
to make a connection to a Cloud SQL instance: the TLS config, and the IP address. 