### PR TITLE
chore: update GraalVM CI build to run only on set schedule

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -45,7 +45,6 @@ branchProtectionRules:
   - "lint"
   - "units (8)"
   - "units (11)"
-  - "graalvm17"
   - "units + e2e"
   - "cla/google"
   # Wait until we make the repo public before bringing this back

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -275,8 +275,8 @@ jobs:
         chmod +x ./flakybot
         ./flakybot --repo ${{github.repository}} --commit_hash ${{github.sha}} --build_url https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
   graalvm:
-    # run job on proper workflow event triggers (skip job for pull_request event from forks and only run pull_request_target for "tests: run" label)
-    if: "${{ (github.event.action != 'labeled' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name) || github.event.label.name == 'tests: run' }}"
+    # run job on periodic (schedule) event
+    if: "${{ github.event_name == 'schedule' }}"
     name: graalvm native / linux
     runs-on: ubuntu-latest
     permissions:

--- a/pom.xml
+++ b/pom.xml
@@ -511,6 +511,7 @@
               <buildArgs>
                 <buildArg>--no-fallback</buildArg>
                 <buildArg>--no-server</buildArg>
+                <buildArg>-Ob</buildArg>
               </buildArgs>
             </configuration>
           </plugin>


### PR DESCRIPTION
Added the quick build mode flag (`-Ob`) to reduce the native build time.

As discussed the GraalVM job will run on periodic (schedule) event as it takes from 7 to 10min to finish.