### PR TITLE
feat: Set the GoogleCredentials to use on a connector

### DIFF
--- a/core/src/main/java/com/google/cloud/sql/ConnectorConfig.java
+++ b/core/src/main/java/com/google/cloud/sql/ConnectorConfig.java
@@ -160,6 +160,23 @@ public class ConnectorConfig {
 
     /** Builds a new instance of {@code ConnectionConfig}. */
     public ConnectorConfig build() {
+      // validate only one GoogleCredentials configuration field set
+      int googleCredsCount = 0;
+      if (googleCredentials != null) {
+        googleCredsCount++;
+      }
+      if (googleCredentialsPath != null) {
+        googleCredsCount++;
+      }
+      if (googleCredentialsSupplier != null) {
+        googleCredsCount++;
+      }
+      if (googleCredsCount > 1) {
+        throw new IllegalStateException(
+            "Invalid configuration, more than one GoogleCredentials field has a value "
+                + "(googleCredentials, googleCredentialsPath, googleCredentialsSupplier)");
+      }
+
       return new ConnectorConfig(
           targetPrincipal,
           delegates,

--- a/core/src/main/java/com/google/cloud/sql/ConnectorConfig.java
+++ b/core/src/main/java/com/google/cloud/sql/ConnectorConfig.java
@@ -16,8 +16,10 @@
 
 package com.google.cloud.sql;
 
+import com.google.auth.oauth2.GoogleCredentials;
 import com.google.common.base.Objects;
 import java.util.List;
+import java.util.function.Supplier;
 
 /**
  * ConnectorConfig is an immutable configuration value object that holds the entire configuration of
@@ -30,16 +32,25 @@ public class ConnectorConfig {
   private final List<String> delegates;
   private final String adminRootUrl;
   private final String adminServicePath;
+  private final Supplier<GoogleCredentials> googleCredentialsSupplier;
+  private final GoogleCredentials googleCredentials;
+  private final String googleCredentialsPath;
 
   private ConnectorConfig(
       String targetPrincipal,
       List<String> delegates,
       String adminRootUrl,
-      String adminServicePath) {
+      String adminServicePath,
+      Supplier<GoogleCredentials> googleCredentialsSupplier,
+      GoogleCredentials googleCredentials,
+      String googleCredentialsPath) {
     this.targetPrincipal = targetPrincipal;
     this.delegates = delegates;
     this.adminRootUrl = adminRootUrl;
     this.adminServicePath = adminServicePath;
+    this.googleCredentialsSupplier = googleCredentialsSupplier;
+    this.googleCredentials = googleCredentials;
+    this.googleCredentialsPath = googleCredentialsPath;
   }
 
   @Override
@@ -54,12 +65,22 @@ public class ConnectorConfig {
     return Objects.equal(targetPrincipal, that.targetPrincipal)
         && Objects.equal(delegates, that.delegates)
         && Objects.equal(adminRootUrl, that.adminRootUrl)
-        && Objects.equal(adminServicePath, that.adminServicePath);
+        && Objects.equal(adminServicePath, that.adminServicePath)
+        && Objects.equal(googleCredentialsSupplier, that.googleCredentialsSupplier)
+        && Objects.equal(googleCredentials, that.googleCredentials)
+        && Objects.equal(googleCredentialsPath, that.googleCredentialsPath);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(targetPrincipal, delegates, adminRootUrl, adminServicePath);
+    return Objects.hashCode(
+        targetPrincipal,
+        delegates,
+        adminRootUrl,
+        adminServicePath,
+        googleCredentialsSupplier,
+        googleCredentials,
+        googleCredentialsPath);
   }
 
   public String getTargetPrincipal() {
@@ -78,6 +99,18 @@ public class ConnectorConfig {
     return adminServicePath;
   }
 
+  public Supplier<GoogleCredentials> getGoogleCredentialsSupplier() {
+    return googleCredentialsSupplier;
+  }
+
+  public GoogleCredentials getGoogleCredentials() {
+    return googleCredentials;
+  }
+
+  public String getGoogleCredentialsPath() {
+    return googleCredentialsPath;
+  }
+
   /** The builder for the ConnectionConfig. */
   public static class Builder {
 
@@ -85,9 +118,28 @@ public class ConnectorConfig {
     private List<String> delegates;
     private String adminRootUrl;
     private String adminServicePath;
+    private Supplier<GoogleCredentials> googleCredentialsSupplier;
+    private GoogleCredentials googleCredentials;
+    private String googleCredentialsPath;
 
     public Builder withTargetPrincipal(String targetPrincipal) {
       this.targetPrincipal = targetPrincipal;
+      return this;
+    }
+
+    public Builder withGoogleCredentialsSupplier(
+        Supplier<GoogleCredentials> googleCredentialsSupplier) {
+      this.googleCredentialsSupplier = googleCredentialsSupplier;
+      return this;
+    }
+
+    public Builder withGoogleCredentials(GoogleCredentials googleCredentials) {
+      this.googleCredentials = googleCredentials;
+      return this;
+    }
+
+    public Builder withGoogleCredentialsPath(String googleCredentialsPath) {
+      this.googleCredentialsPath = googleCredentialsPath;
       return this;
     }
 
@@ -108,7 +160,14 @@ public class ConnectorConfig {
 
     /** Builds a new instance of {@code ConnectionConfig}. */
     public ConnectorConfig build() {
-      return new ConnectorConfig(targetPrincipal, delegates, adminRootUrl, adminServicePath);
+      return new ConnectorConfig(
+          targetPrincipal,
+          delegates,
+          adminRootUrl,
+          adminServicePath,
+          googleCredentialsSupplier,
+          googleCredentials,
+          googleCredentialsPath);
     }
   }
 }

--- a/core/src/main/java/com/google/cloud/sql/core/ConnectionConfig.java
+++ b/core/src/main/java/com/google/cloud/sql/core/ConnectionConfig.java
@@ -49,6 +49,7 @@ public class ConnectionConfig {
   public static final String DEFAULT_IP_TYPES = "PUBLIC,PRIVATE";
   public static final List<IpType> DEFAULT_IP_TYPE_LIST =
       Arrays.asList(IpType.PUBLIC, IpType.PRIVATE);
+  public static final String CLOUD_SQL_GOOGLE_CREDENTIALS_PATH = "cloudSqlGoogleCredentialsPath";
 
   private final ConnectorConfig connectorConfig;
   private final String cloudSqlInstance;
@@ -89,6 +90,8 @@ public class ConnectionConfig {
         props.getProperty(ConnectionConfig.CLOUD_SQL_ADMIN_SERVICE_PATH_PROPERTY);
     final String unixSocketPathSuffix =
         props.getProperty(ConnectionConfig.UNIX_SOCKET_PATH_SUFFIX_PROPERTY);
+    final String googleCredentialsPath =
+        props.getProperty(ConnectionConfig.CLOUD_SQL_GOOGLE_CREDENTIALS_PATH);
     return new ConnectionConfig(
         csqlInstanceName,
         namedConnection,
@@ -101,6 +104,7 @@ public class ConnectionConfig {
             .withDelegates(delegates)
             .withAdminRootUrl(adminRootUrl)
             .withAdminServicePath(adminServicePath)
+            .withGoogleCredentialsPath(googleCredentialsPath)
             .build());
   }
 

--- a/core/src/main/java/com/google/cloud/sql/core/Connector.java
+++ b/core/src/main/java/com/google/cloud/sql/core/Connector.java
@@ -48,7 +48,7 @@ class Connector {
 
   Connector(
       ConnectorConfig config,
-      DefaultConnectionInfoRepository adminApi,
+      ConnectionInfoRepositoryFactory connectionInfoRepositoryFactory,
       CredentialFactory instanceCredentialFactory,
       ListeningScheduledExecutorService executor,
       ListenableFuture<KeyPair> localKeyPair,
@@ -56,7 +56,9 @@ class Connector {
       long refreshTimeoutMs,
       int serverProxyPort) {
     this.config = config;
-    this.adminApi = adminApi;
+
+    this.adminApi =
+        connectionInfoRepositoryFactory.create(instanceCredentialFactory.create(), config);
     this.instanceCredentialFactory = instanceCredentialFactory;
     this.executor = executor;
     this.localKeyPair = localKeyPair;

--- a/core/src/main/java/com/google/cloud/sql/core/ConstantCredentialFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/core/ConstantCredentialFactory.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.sql.core;
+
+import com.google.api.client.http.HttpRequestInitializer;
+import com.google.auth.http.HttpCredentialsAdapter;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.sql.CredentialFactory;
+
+class ConstantCredentialFactory implements CredentialFactory {
+
+  private final GoogleCredentials credentials;
+
+  public ConstantCredentialFactory(GoogleCredentials credentials) {
+    this.credentials = credentials;
+  }
+
+  @Override
+  public HttpRequestInitializer create() {
+    return new HttpCredentialsAdapter(getCredentials());
+  }
+
+  @Override
+  public GoogleCredentials getCredentials() {
+    return credentials;
+  }
+}

--- a/core/src/main/java/com/google/cloud/sql/core/CredentialFactoryProvider.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CredentialFactoryProvider.java
@@ -25,8 +25,22 @@ import com.google.cloud.sql.CredentialFactory;
  */
 class CredentialFactoryProvider {
 
+  private final CredentialFactory defaultCredentialFactory;
+
+  CredentialFactoryProvider() {
+    this.defaultCredentialFactory = createDefaultCredentialFactory();
+  }
+
+  CredentialFactoryProvider(CredentialFactory defaultCredentialFactory) {
+    this.defaultCredentialFactory = defaultCredentialFactory;
+  }
+
+  CredentialFactory getDefaultCredentialFactory() {
+    return defaultCredentialFactory;
+  }
+
   /** Returns a CredentialFactory instance based on whether CREDENTIAL_FACTORY_PROPERTY is set. */
-  static CredentialFactory getCredentialFactory() {
+  private static CredentialFactory createDefaultCredentialFactory() {
     String userCredentialFactoryClassName =
         System.getProperty(CredentialFactory.CREDENTIAL_FACTORY_PROPERTY);
 
@@ -47,8 +61,7 @@ class CredentialFactoryProvider {
     return credentialFactory;
   }
 
-  static CredentialFactory getInstanceCredentialFactory(
-      CredentialFactory defaultCredentialFactory, ConnectorConfig config) {
+  CredentialFactory getInstanceCredentialFactory(ConnectorConfig config) {
 
     CredentialFactory instanceCredentialFactory;
     if (config.getGoogleCredentialsSupplier() != null) {
@@ -59,7 +72,7 @@ class CredentialFactoryProvider {
     } else if (config.getGoogleCredentialsPath() != null) {
       instanceCredentialFactory = new FileCredentialFactory(config.getGoogleCredentialsPath());
     } else {
-      instanceCredentialFactory = defaultCredentialFactory;
+      instanceCredentialFactory = getDefaultCredentialFactory();
     }
 
     // Validate targetPrincipal and delegates

--- a/core/src/main/java/com/google/cloud/sql/core/FileCredentialFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/core/FileCredentialFactory.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.sql.core;
+
+import com.google.api.client.http.HttpRequestInitializer;
+import com.google.auth.http.HttpCredentialsAdapter;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.sql.CredentialFactory;
+import java.io.FileInputStream;
+import java.io.IOException;
+
+class FileCredentialFactory implements CredentialFactory {
+  private final String path;
+
+  FileCredentialFactory(String path) {
+    this.path = path;
+  }
+
+  @Override
+  public HttpRequestInitializer create() {
+    return new HttpCredentialsAdapter(getCredentials());
+  }
+
+  @Override
+  public GoogleCredentials getCredentials() {
+    try {
+      return GoogleCredentials.fromStream(new FileInputStream(path));
+    } catch (IOException e) {
+      throw new IllegalStateException("Unable to load GoogleCredentials from file " + path, e);
+    }
+  }
+}

--- a/core/src/main/java/com/google/cloud/sql/core/SupplierCredentialFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/core/SupplierCredentialFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.sql.core;
+
+import com.google.api.client.http.HttpRequestInitializer;
+import com.google.auth.http.HttpCredentialsAdapter;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.sql.CredentialFactory;
+import java.util.function.Supplier;
+
+class SupplierCredentialFactory implements CredentialFactory {
+
+  private final Supplier<GoogleCredentials> supplier;
+
+  public SupplierCredentialFactory(Supplier<GoogleCredentials> supplier) {
+    this.supplier = supplier;
+  }
+
+  @Override
+  public HttpRequestInitializer create() {
+    return new HttpCredentialsAdapter(getCredentials());
+  }
+
+  @Override
+  public GoogleCredentials getCredentials() {
+    return supplier.get();
+  }
+}

--- a/core/src/test/java/com/google/cloud/sql/ConnectorConfigTest.java
+++ b/core/src/test/java/com/google/cloud/sql/ConnectorConfigTest.java
@@ -17,7 +17,9 @@
 package com.google.cloud.sql;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
 
+import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
 import java.util.Arrays;
 import java.util.Collections;
@@ -32,29 +34,83 @@ public class ConnectorConfigTest {
     final List<String> wantDelegates = Arrays.asList("test1@example.com", "test2@example.com");
     final String wantAdminRootUrl = "https://googleapis.example.com/";
     final String wantAdminServicePath = "sqladmin/";
-    final String wantGoogleCredentialsPath = "/path/to/credentials";
-    final Supplier<GoogleCredentials> wantGoogleCredentialSupplier =
-        () -> GoogleCredentials.create(null);
-    final GoogleCredentials wantGoogleCredentials = GoogleCredentials.create(null);
-
     ConnectorConfig cc =
         new ConnectorConfig.Builder()
             .withTargetPrincipal(wantTargetPrincipal)
             .withDelegates(wantDelegates)
             .withAdminRootUrl(wantAdminRootUrl)
             .withAdminServicePath(wantAdminServicePath)
-            .withGoogleCredentialsSupplier(wantGoogleCredentialSupplier)
-            .withGoogleCredentials(wantGoogleCredentials)
-            .withGoogleCredentialsPath(wantGoogleCredentialsPath)
             .build();
 
     assertThat(cc.getTargetPrincipal()).isEqualTo(wantTargetPrincipal);
     assertThat(cc.getDelegates()).isEqualTo(wantDelegates);
     assertThat(cc.getAdminRootUrl()).isEqualTo(wantAdminRootUrl);
     assertThat(cc.getAdminServicePath()).isEqualTo(wantAdminServicePath);
-    assertThat(cc.getGoogleCredentialsSupplier()).isSameInstanceAs(wantGoogleCredentialSupplier);
-    assertThat(cc.getGoogleCredentials()).isSameInstanceAs(wantGoogleCredentials);
+  }
+
+  @Test
+  public void testBuild_withGoogleCredentialsPath() {
+    final String wantGoogleCredentialsPath = "/path/to/credentials";
+    ConnectorConfig cc =
+        new ConnectorConfig.Builder().withGoogleCredentialsPath(wantGoogleCredentialsPath).build();
     assertThat(cc.getGoogleCredentialsPath()).isEqualTo(wantGoogleCredentialsPath);
+  }
+
+  @Test
+  public void testBuild_withGoogleCredentials() {
+    final GoogleCredentials wantGoogleCredentials = GoogleCredentials.create(null);
+    ConnectorConfig cc =
+        new ConnectorConfig.Builder().withGoogleCredentials(wantGoogleCredentials).build();
+    assertThat(cc.getGoogleCredentials()).isSameInstanceAs(wantGoogleCredentials);
+  }
+
+  @Test
+  public void testBuild_withGoogleCredentialsSupplier() {
+    final Supplier<GoogleCredentials> wantGoogleCredentialSupplier =
+        () -> GoogleCredentials.create(null);
+    ConnectorConfig cc =
+        new ConnectorConfig.Builder()
+            .withGoogleCredentialsSupplier(wantGoogleCredentialSupplier)
+            .build();
+    assertThat(cc.getGoogleCredentialsSupplier()).isSameInstanceAs(wantGoogleCredentialSupplier);
+  }
+
+  @Test
+  public void testBuild_failsWhenManyGoogleCredentialFieldsSet() {
+    final Supplier<GoogleCredentials> wantGoogleCredentialSupplier =
+        () -> GoogleCredentials.create(null);
+    final GoogleCredentials wantGoogleCredentials = GoogleCredentials.create(null);
+    final String wantGoogleCredentialsPath = "/path/to/credentials";
+
+    assertThrows(
+        IllegalStateException.class,
+        () ->
+            new ConnectorConfig.Builder()
+                .withGoogleCredentials(wantGoogleCredentials)
+                .withGoogleCredentialsSupplier(wantGoogleCredentialSupplier)
+                .build());
+    assertThrows(
+        IllegalStateException.class,
+        () ->
+            new ConnectorConfig.Builder()
+                .withGoogleCredentialsPath(wantGoogleCredentialsPath)
+                .withGoogleCredentialsSupplier(wantGoogleCredentialSupplier)
+                .build());
+    assertThrows(
+        IllegalStateException.class,
+        () ->
+            new ConnectorConfig.Builder()
+                .withGoogleCredentialsPath(wantGoogleCredentialsPath)
+                .withGoogleCredentials(wantGoogleCredentials)
+                .build());
+    assertThrows(
+        IllegalStateException.class,
+        () ->
+            new ConnectorConfig.Builder()
+                .withGoogleCredentialsPath(wantGoogleCredentialsPath)
+                .withGoogleCredentials(wantGoogleCredentials)
+                .withGoogleCredentialsSupplier(wantGoogleCredentialSupplier)
+                .build());
   }
 
   @Test
@@ -148,6 +204,72 @@ public class ConnectorConfigTest {
         new ConnectorConfig.Builder()
             .withDelegates(Collections.singletonList("joe@example.com"))
             .build();
+
+    assertThat(k1).isEqualTo(k2);
+    assertThat(k1.hashCode()).isEqualTo(k2.hashCode());
+  }
+
+  @Test
+  public void testNotEqual_withGoogleCredentialsNotEqual() {
+    GoogleCredentials c1 = GoogleCredentials.create(new AccessToken("c1", null));
+    GoogleCredentials c2 = GoogleCredentials.create(new AccessToken("c2", null));
+    ConnectorConfig k1 = new ConnectorConfig.Builder().withGoogleCredentials(c1).build();
+    ConnectorConfig k2 = new ConnectorConfig.Builder().withGoogleCredentials(c2).build();
+
+    assertThat(k1).isNotEqualTo(k2);
+    assertThat(k1.hashCode()).isNotEqualTo(k2.hashCode());
+  }
+
+  @Test
+  public void testEqual_withGoogleCredentialsEqual() {
+    GoogleCredentials c1 = GoogleCredentials.create(new AccessToken("c1", null));
+    GoogleCredentials c2 = GoogleCredentials.create(new AccessToken("c1", null));
+    ConnectorConfig k1 = new ConnectorConfig.Builder().withGoogleCredentials(c1).build();
+    ConnectorConfig k2 = new ConnectorConfig.Builder().withGoogleCredentials(c2).build();
+
+    assertThat(k1).isEqualTo(k2);
+    assertThat(k1.hashCode()).isEqualTo(k2.hashCode());
+  }
+
+  @Test
+  public void testNotEqual_withGoogleCredentialsPathNotEqual() {
+    ConnectorConfig k1 =
+        new ConnectorConfig.Builder().withGoogleCredentialsPath("/path/1.json").build();
+    ConnectorConfig k2 =
+        new ConnectorConfig.Builder().withGoogleCredentialsPath("/path/2.json").build();
+
+    assertThat(k1).isNotEqualTo(k2);
+    assertThat(k1.hashCode()).isNotEqualTo(k2.hashCode());
+  }
+
+  @Test
+  public void testEqual_withGoogleCredentialsPathEqual() {
+    ConnectorConfig k1 =
+        new ConnectorConfig.Builder().withGoogleCredentialsPath("/path/1.json").build();
+    ConnectorConfig k2 =
+        new ConnectorConfig.Builder().withGoogleCredentialsPath("/path/1.json").build();
+
+    assertThat(k1).isEqualTo(k2);
+    assertThat(k1.hashCode()).isEqualTo(k2.hashCode());
+  }
+
+  @Test
+  public void testNotEqual_withGoogleCredentialsSupplierNotEqual() {
+    Supplier<GoogleCredentials> c1 = () -> GoogleCredentials.create(new AccessToken("c1", null));
+    Supplier<GoogleCredentials> c2 = () -> GoogleCredentials.create(new AccessToken("c2", null));
+
+    ConnectorConfig k1 = new ConnectorConfig.Builder().withGoogleCredentialsSupplier(c1).build();
+    ConnectorConfig k2 = new ConnectorConfig.Builder().withGoogleCredentialsSupplier(c2).build();
+
+    assertThat(k1).isNotEqualTo(k2);
+    assertThat(k1.hashCode()).isNotEqualTo(k2.hashCode());
+  }
+
+  @Test
+  public void testEqual_withGoogleCredentialsSupplierEqual() {
+    Supplier<GoogleCredentials> c1 = () -> GoogleCredentials.create(new AccessToken("c1", null));
+    ConnectorConfig k1 = new ConnectorConfig.Builder().withGoogleCredentialsSupplier(c1).build();
+    ConnectorConfig k2 = new ConnectorConfig.Builder().withGoogleCredentialsSupplier(c1).build();
 
     assertThat(k1).isEqualTo(k2);
     assertThat(k1.hashCode()).isEqualTo(k2.hashCode());

--- a/core/src/test/java/com/google/cloud/sql/ConnectorConfigTest.java
+++ b/core/src/test/java/com/google/cloud/sql/ConnectorConfigTest.java
@@ -18,8 +18,11 @@ package com.google.cloud.sql;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.auth.oauth2.GoogleCredentials;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.function.Supplier;
 import org.junit.Test;
 
 public class ConnectorConfigTest {
@@ -29,6 +32,10 @@ public class ConnectorConfigTest {
     final List<String> wantDelegates = Arrays.asList("test1@example.com", "test2@example.com");
     final String wantAdminRootUrl = "https://googleapis.example.com/";
     final String wantAdminServicePath = "sqladmin/";
+    final String wantGoogleCredentialsPath = "/path/to/credentials";
+    final Supplier<GoogleCredentials> wantGoogleCredentialSupplier =
+        () -> GoogleCredentials.create(null);
+    final GoogleCredentials wantGoogleCredentials = GoogleCredentials.create(null);
 
     ConnectorConfig cc =
         new ConnectorConfig.Builder()
@@ -36,12 +43,18 @@ public class ConnectorConfigTest {
             .withDelegates(wantDelegates)
             .withAdminRootUrl(wantAdminRootUrl)
             .withAdminServicePath(wantAdminServicePath)
+            .withGoogleCredentialsSupplier(wantGoogleCredentialSupplier)
+            .withGoogleCredentials(wantGoogleCredentials)
+            .withGoogleCredentialsPath(wantGoogleCredentialsPath)
             .build();
 
     assertThat(cc.getTargetPrincipal()).isEqualTo(wantTargetPrincipal);
     assertThat(cc.getDelegates()).isEqualTo(wantDelegates);
     assertThat(cc.getAdminRootUrl()).isEqualTo(wantAdminRootUrl);
     assertThat(cc.getAdminServicePath()).isEqualTo(wantAdminServicePath);
+    assertThat(cc.getGoogleCredentialsSupplier()).isSameInstanceAs(wantGoogleCredentialSupplier);
+    assertThat(cc.getGoogleCredentials()).isSameInstanceAs(wantGoogleCredentials);
+    assertThat(cc.getGoogleCredentialsPath()).isEqualTo(wantGoogleCredentialsPath);
   }
 
   @Test
@@ -113,9 +126,13 @@ public class ConnectorConfigTest {
   @Test
   public void testNotEqual_withDelegatesNotEqual() {
     ConnectorConfig k1 =
-        new ConnectorConfig.Builder().withDelegates(Arrays.asList("joe@example.com")).build();
+        new ConnectorConfig.Builder()
+            .withDelegates(Collections.singletonList("joe@example.com"))
+            .build();
     ConnectorConfig k2 =
-        new ConnectorConfig.Builder().withDelegates(Arrays.asList("steve@example.com")).build();
+        new ConnectorConfig.Builder()
+            .withDelegates(Collections.singletonList("steve@example.com"))
+            .build();
 
     assertThat(k1).isNotEqualTo(k2);
     assertThat(k1.hashCode()).isNotEqualTo(k2.hashCode());
@@ -124,9 +141,13 @@ public class ConnectorConfigTest {
   @Test
   public void testEqual_withDelegatesEqual() {
     ConnectorConfig k1 =
-        new ConnectorConfig.Builder().withDelegates(Arrays.asList("joe@example.com")).build();
+        new ConnectorConfig.Builder()
+            .withDelegates(Collections.singletonList("joe@example.com"))
+            .build();
     ConnectorConfig k2 =
-        new ConnectorConfig.Builder().withDelegates(Arrays.asList("joe@example.com")).build();
+        new ConnectorConfig.Builder()
+            .withDelegates(Collections.singletonList("joe@example.com"))
+            .build();
 
     assertThat(k1).isEqualTo(k2);
     assertThat(k1.hashCode()).isEqualTo(k2.hashCode());

--- a/core/src/test/java/com/google/cloud/sql/core/CloudSqlCoreTestingBase.java
+++ b/core/src/test/java/com/google/cloud/sql/core/CloudSqlCoreTestingBase.java
@@ -33,7 +33,6 @@ import com.google.api.services.sqladmin.model.ConnectSettings;
 import com.google.api.services.sqladmin.model.GenerateEphemeralCertResponse;
 import com.google.api.services.sqladmin.model.IpMapping;
 import com.google.api.services.sqladmin.model.SslCert;
-import com.google.cloud.sql.CredentialFactory;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -71,7 +70,8 @@ public class CloudSqlCoreTestingBase {
 
   static final String SERVER_MESSAGE = "HELLO";
 
-  final CredentialFactory credentialFactory = new StubCredentialFactory();
+  final CredentialFactoryProvider stubCredentialFactoryProvider =
+      new CredentialFactoryProvider(new StubCredentialFactory());
 
   ListenableFuture<KeyPair> clientKeyPair;
 

--- a/core/src/test/java/com/google/cloud/sql/core/ConnectionConfigTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/ConnectionConfigTest.java
@@ -44,6 +44,7 @@ public class ConnectionConfigTest {
     final String wantAdminRootUrl = "https://googleapis.example.com/";
     final String wantAdminServicePath = "sqladmin/";
     final String wantUnixSuffix = ".psql.5432";
+    final String wantPath = "my-path";
 
     Properties props = new Properties();
     props.setProperty(ConnectionConfig.CLOUD_SQL_INSTANCE_PROPERTY, wantCsqlInstance);
@@ -56,6 +57,7 @@ public class ConnectionConfigTest {
     props.setProperty(ConnectionConfig.CLOUD_SQL_ADMIN_ROOT_URL_PROPERTY, wantAdminRootUrl);
     props.setProperty(ConnectionConfig.CLOUD_SQL_ADMIN_SERVICE_PATH_PROPERTY, wantAdminServicePath);
     props.setProperty(ConnectionConfig.UNIX_SOCKET_PATH_SUFFIX_PROPERTY, wantUnixSuffix);
+    props.setProperty(ConnectionConfig.CLOUD_SQL_GOOGLE_CREDENTIALS_PATH, wantPath);
 
     ConnectionConfig c = ConnectionConfig.fromConnectionProperties(props);
 
@@ -68,6 +70,7 @@ public class ConnectionConfigTest {
     assertThat(c.getIpTypes()).isEqualTo(wantIpTypes);
     assertThat(c.getConnectorConfig().getAdminRootUrl()).isEqualTo(wantAdminRootUrl);
     assertThat(c.getConnectorConfig().getAdminServicePath()).isEqualTo(wantAdminServicePath);
+    assertThat(c.getConnectorConfig().getGoogleCredentialsPath()).isEqualTo(wantPath);
     assertThat(c.getUnixSocketPathSuffix()).isEqualTo(wantUnixSuffix);
   }
 

--- a/core/src/test/java/com/google/cloud/sql/core/ConnectorTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/ConnectorTest.java
@@ -104,7 +104,7 @@ public class ConnectorTest extends CloudSqlCoreTestingBase {
     Connector connector =
         new Connector(
             config,
-            factory.create(credentialFactory.create(), config),
+            factory,
             credentialFactory,
             defaultExecutor,
             clientKeyPair,

--- a/core/src/test/java/com/google/cloud/sql/core/ConnectorTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/ConnectorTest.java
@@ -105,7 +105,7 @@ public class ConnectorTest extends CloudSqlCoreTestingBase {
         new Connector(
             config,
             factory,
-            credentialFactory,
+            stubCredentialFactoryProvider.getInstanceCredentialFactory(config),
             defaultExecutor,
             clientKeyPair,
             10,

--- a/core/src/test/java/com/google/cloud/sql/core/ConstantCredentialsFactoryTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/ConstantCredentialsFactoryTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.sql.core;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import org.junit.Test;
+
+public class ConstantCredentialsFactoryTest {
+
+  @Test
+  public void testConstantCredentials() {
+    GoogleCredentials c = GoogleCredentials.create(null);
+    ConstantCredentialFactory f = new ConstantCredentialFactory(c);
+    assertThat(f.getCredentials()).isSameInstanceAs(c);
+  }
+}

--- a/core/src/test/java/com/google/cloud/sql/core/CredentialFactoryProviderTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/CredentialFactoryProviderTest.java
@@ -31,7 +31,7 @@ public class CredentialFactoryProviderTest {
 
   @Test
   public void returnsDefaultCredentialFactory() {
-    CredentialFactory factory = CredentialFactoryProvider.getCredentialFactory();
+    CredentialFactory factory = new CredentialFactoryProvider().getDefaultCredentialFactory();
     assertThat(factory).isInstanceOf(ApplicationDefaultCredentialFactory.class);
   }
 
@@ -39,30 +39,28 @@ public class CredentialFactoryProviderTest {
   public void returnsUserSpecifiedCredentialFactory() {
     System.setProperty(
         CredentialFactory.CREDENTIAL_FACTORY_PROPERTY, StubCredentialFactory.class.getName());
-    CredentialFactory factory = CredentialFactoryProvider.getCredentialFactory();
+    CredentialFactory factory = new CredentialFactoryProvider().getDefaultCredentialFactory();
     assertThat(factory).isInstanceOf(StubCredentialFactory.class);
     System.clearProperty(CredentialFactory.CREDENTIAL_FACTORY_PROPERTY);
   }
 
   @Test
   public void getInstanceCredentialFactory_returnsDefaultWithNoSettings() {
-    CredentialFactory wantFactory = CredentialFactoryProvider.getCredentialFactory();
     ConnectorConfig config = new ConnectorConfig.Builder().build();
 
-    CredentialFactory got =
-        CredentialFactoryProvider.getInstanceCredentialFactory(wantFactory, config);
+    CredentialFactoryProvider f = new CredentialFactoryProvider();
+    CredentialFactory got = f.getInstanceCredentialFactory(config);
 
-    assertThat(got).isSameInstanceAs(wantFactory);
+    assertThat(got).isSameInstanceAs(f.getDefaultCredentialFactory());
   }
 
   @Test
   public void getInstanceCredentialFactory_returnsFileCredentialFactory() {
     String path = FileCredentialFactoryTest.class.getResource("/sample-credentials.json").getFile();
-    CredentialFactory wantFactory = CredentialFactoryProvider.getCredentialFactory();
     ConnectorConfig config = new ConnectorConfig.Builder().withGoogleCredentialsPath(path).build();
 
-    CredentialFactory got =
-        CredentialFactoryProvider.getInstanceCredentialFactory(wantFactory, config);
+    CredentialFactoryProvider f = new CredentialFactoryProvider();
+    CredentialFactory got = f.getInstanceCredentialFactory(config);
 
     assertThat(got.getCredentials().getQuotaProjectId()).isEqualTo("sample");
   }
@@ -70,11 +68,10 @@ public class CredentialFactoryProviderTest {
   @Test
   public void getInstanceCredentialFactory_returnsConstantCredentialFactory() {
     GoogleCredentials c = GoogleCredentials.create(null);
-    CredentialFactory wantFactory = CredentialFactoryProvider.getCredentialFactory();
     ConnectorConfig config = new ConnectorConfig.Builder().withGoogleCredentials(c).build();
 
-    CredentialFactory got =
-        CredentialFactoryProvider.getInstanceCredentialFactory(wantFactory, config);
+    CredentialFactoryProvider f = new CredentialFactoryProvider();
+    CredentialFactory got = f.getInstanceCredentialFactory(config);
 
     assertThat(got.getCredentials()).isSameInstanceAs(c);
   }
@@ -82,12 +79,11 @@ public class CredentialFactoryProviderTest {
   @Test
   public void getInstanceCredentialFactory_returnsSupplierCredentialFactory() {
     GoogleCredentials c = GoogleCredentials.create(null);
-    CredentialFactory wantFactory = CredentialFactoryProvider.getCredentialFactory();
     ConnectorConfig config =
         new ConnectorConfig.Builder().withGoogleCredentialsSupplier(() -> c).build();
 
-    CredentialFactory got =
-        CredentialFactoryProvider.getInstanceCredentialFactory(wantFactory, config);
+    CredentialFactoryProvider f = new CredentialFactoryProvider();
+    CredentialFactory got = f.getInstanceCredentialFactory(config);
 
     assertThat(got.getCredentials()).isSameInstanceAs(c);
   }
@@ -95,15 +91,14 @@ public class CredentialFactoryProviderTest {
   @Test
   public void getInstanceCredentialFactory_returnsImpersonatingCredentialFactory() {
     GoogleCredentials c = new GoogleCredentials(null);
-    CredentialFactory wantFactory = CredentialFactoryProvider.getCredentialFactory();
     ConnectorConfig config =
         new ConnectorConfig.Builder()
             .withGoogleCredentials(c)
             .withTargetPrincipal("test@project.iam.googleapis.com")
             .build();
 
-    CredentialFactory got =
-        CredentialFactoryProvider.getInstanceCredentialFactory(wantFactory, config);
+    CredentialFactoryProvider f = new CredentialFactoryProvider();
+    CredentialFactory got = f.getInstanceCredentialFactory(config);
 
     assertThat(got).isInstanceOf(ServiceAccountImpersonatingCredentialFactory.class);
     ServiceAccountImpersonatingCredentialFactory impersonatedFactory =

--- a/core/src/test/java/com/google/cloud/sql/core/FileCredentialFactoryTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/FileCredentialFactoryTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.sql.core;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.*;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import org.junit.Test;
+
+public class FileCredentialFactoryTest {
+
+  @Test
+  public void getCredentials_failsWhenNoFileExists() {
+    FileCredentialFactory f = new FileCredentialFactory("nope");
+    assertThrows(IllegalStateException.class, f::getCredentials);
+  }
+
+  @Test
+  public void getCredentials_loadsFromFilePath() {
+    String path = FileCredentialFactoryTest.class.getResource("/sample-credentials.json").getFile();
+    FileCredentialFactory f = new FileCredentialFactory(path);
+    GoogleCredentials c = f.getCredentials();
+    assertThat(c.getQuotaProjectId()).isEqualTo("sample");
+  }
+}

--- a/core/src/test/java/com/google/cloud/sql/core/SupplierCredentialFactoryTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/SupplierCredentialFactoryTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.sql.core;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import org.junit.Test;
+
+public class SupplierCredentialFactoryTest {
+
+  @Test
+  public void getCredentials() {
+    GoogleCredentials c = GoogleCredentials.create(null);
+    SupplierCredentialFactory f = new SupplierCredentialFactory(() -> c);
+    assertThat(f.getCredentials()).isSameInstanceAs(c);
+  }
+}

--- a/core/src/test/resources/sample-credentials.json
+++ b/core/src/test/resources/sample-credentials.json
@@ -1,0 +1,8 @@
+{
+  "client_id": "sample.apps.googleusercontent.com",
+  "client_secret": "sample",
+  "quota_project_id": "sample",
+  "refresh_token": "sample",
+  "access_token": "sample",
+  "type": "authorized_user"
+}

--- a/r2dbc/core/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProvider.java
+++ b/r2dbc/core/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProvider.java
@@ -47,6 +47,8 @@ public abstract class GcpConnectionFactoryProvider implements ConnectionFactoryP
   public static final Option<String> TARGET_PRINCIPAL = Option.valueOf("TARGET_PRINCIPAL");
   public static final Option<String> ADMIN_ROOT_URL = Option.valueOf("ADMIN_ROOT_URL");
   public static final Option<String> ADMIN_SERVICE_PATH = Option.valueOf("ADMIN_SERVICE_PATH");
+  public static final Option<String> GOOGLE_CREDENTIALS_PATH =
+      Option.valueOf("GOOGLE_CREDENTIALS_PATH");
 
   /**
    * Creates a ConnectionFactory that creates an SSL connection over a TCP socket, using
@@ -107,6 +109,8 @@ public abstract class GcpConnectionFactoryProvider implements ConnectionFactoryP
 
     final String adminRootUrl = (String) connectionFactoryOptions.getValue(ADMIN_ROOT_URL);
     final String adminServicePath = (String) connectionFactoryOptions.getValue(ADMIN_SERVICE_PATH);
+    final String googleCredentialsPath =
+        (String) connectionFactoryOptions.getValue(GOOGLE_CREDENTIALS_PATH);
 
     Builder optionBuilder = createBuilder(connectionFactoryOptions);
     String cloudSqlInstance = (String) connectionFactoryOptions.getRequiredValue(HOST);
@@ -122,6 +126,7 @@ public abstract class GcpConnectionFactoryProvider implements ConnectionFactoryP
                     .withDelegates(delegates)
                     .withAdminRootUrl(adminRootUrl)
                     .withAdminServicePath(adminServicePath)
+                    .withGoogleCredentialsPath(googleCredentialsPath)
                     .build())
             .build();
     // Precompute SSL Data to trigger the initial refresh to happen immediately,

--- a/r2dbc/core/src/test/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderTest.java
+++ b/r2dbc/core/src/test/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderTest.java
@@ -29,7 +29,6 @@ import com.google.api.services.sqladmin.model.ConnectSettings;
 import com.google.api.services.sqladmin.model.GenerateEphemeralCertResponse;
 import com.google.api.services.sqladmin.model.IpMapping;
 import com.google.api.services.sqladmin.model.SslCert;
-import com.google.cloud.sql.CredentialFactory;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -63,7 +62,8 @@ public class GcpConnectionFactoryProviderTest {
 
   static final String PUBLIC_IP = "127.0.0.1";
   static final String PRIVATE_IP = "10.0.0.1";
-  private final CredentialFactory credentialFactory = new StubCredentialFactory();
+  final CredentialFactoryProvider stubCredentialFactoryProvider =
+      new CredentialFactoryProvider(new StubCredentialFactory());
   ListeningScheduledExecutorService defaultExecutor;
   ListenableFuture<KeyPair> clientKeyPair;
   InternalConnectorRegistry internalConnectorRegistryStub;
@@ -181,7 +181,7 @@ public class GcpConnectionFactoryProviderTest {
         new InternalConnectorRegistry(
             clientKeyPair,
             repo,
-            credentialFactory,
+            stubCredentialFactoryProvider,
             3307,
             InternalConnectorRegistry.DEFAULT_MAX_REFRESH_MS,
             defaultExecutor);


### PR DESCRIPTION
Provides new configuration fields ConnectorConfig that allow the user to connectors use a specific GoogleCredential. users may set one of these three fields: 
- `Supplier<GoogleCredentials> googleCredentialsSupplier` - a supplier to provide GoogleCredentials instances to the connector. 
- `GoogleCredentials googleCredentials` - an instance of GoogleCredentials to use for all requests. 
- `String googleCredentialsPath` - path to file containing GoogleCredentials json. 

Adds a JDBC Connection Property `cloudSqlGoogleCredentialsPath` to set the googleCredentialsPath field.

Fixes #1670