### PR TITLE
chore: increase test timeout to 80 seconds

### DIFF
--- a/jdbc/mariadb/src/test/java/com/google/cloud/sql/mariadb/JdbcMariaDBIamAuthIntegrationTests.java
+++ b/jdbc/mariadb/src/test/java/com/google/cloud/sql/mariadb/JdbcMariaDBIamAuthIntegrationTests.java
@@ -43,7 +43,7 @@ public class JdbcMariaDBIamAuthIntegrationTests {
   private static final String DB_USER = System.getenv("MYSQL_IAM_USER");
   private static final ImmutableList<String> requiredEnvVars =
       ImmutableList.of("MYSQL_IAM_CONNECTION_NAME", "MYSQL_DB", "MYSQL_IAM_USER");
-  @Rule public Timeout globalTimeout = new Timeout(60, TimeUnit.SECONDS);
+  @Rule public Timeout globalTimeout = new Timeout(80, TimeUnit.SECONDS);
 
   private HikariDataSource connectionPool;
 

--- a/jdbc/mariadb/src/test/java/com/google/cloud/sql/mariadb/JdbcMariaDBIntegrationTests.java
+++ b/jdbc/mariadb/src/test/java/com/google/cloud/sql/mariadb/JdbcMariaDBIntegrationTests.java
@@ -45,7 +45,7 @@ public class JdbcMariaDBIntegrationTests {
   private static final ImmutableList<String> requiredEnvVars =
       ImmutableList.of("MYSQL_USER", "MYSQL_PASS", "MYSQL_DB", "MYSQL_CONNECTION_NAME");
 
-  @Rule public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
+  @Rule public Timeout globalTimeout = new Timeout(80, TimeUnit.SECONDS);
 
   private HikariDataSource connectionPool;
 

--- a/jdbc/mysql-j-8/src/test/java/com/google/cloud/sql/mysql/JdbcMysqlJ8IamAuthIntegrationTests.java
+++ b/jdbc/mysql-j-8/src/test/java/com/google/cloud/sql/mysql/JdbcMysqlJ8IamAuthIntegrationTests.java
@@ -44,7 +44,7 @@ public class JdbcMysqlJ8IamAuthIntegrationTests {
 
   private static final ImmutableList<String> requiredEnvVars =
       ImmutableList.of("MYSQL_IAM_USER", "MYSQL_DB", "MYSQL_IAM_CONNECTION_NAME");
-  @Rule public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
+  @Rule public Timeout globalTimeout = new Timeout(80, TimeUnit.SECONDS);
   private HikariDataSource connectionPool;
 
   @BeforeClass

--- a/jdbc/mysql-j-8/src/test/java/com/google/cloud/sql/mysql/JdbcMysqlJ8IntegrationTests.java
+++ b/jdbc/mysql-j-8/src/test/java/com/google/cloud/sql/mysql/JdbcMysqlJ8IntegrationTests.java
@@ -44,7 +44,7 @@ public class JdbcMysqlJ8IntegrationTests {
   private static final String DB_PASSWORD = System.getenv("MYSQL_PASS");
   private static final ImmutableList<String> requiredEnvVars =
       ImmutableList.of("MYSQL_USER", "MYSQL_PASS", "MYSQL_DB", "MYSQL_CONNECTION_NAME");
-  @Rule public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
+  @Rule public Timeout globalTimeout = new Timeout(80, TimeUnit.SECONDS);
   private HikariDataSource connectionPool;
 
   @BeforeClass

--- a/jdbc/mysql-j-8/src/test/java/com/google/cloud/sql/mysql/JdbcMysqlJ8ServiceAccountImpersonationIntegrationTests.java
+++ b/jdbc/mysql-j-8/src/test/java/com/google/cloud/sql/mysql/JdbcMysqlJ8ServiceAccountImpersonationIntegrationTests.java
@@ -50,7 +50,7 @@ public class JdbcMysqlJ8ServiceAccountImpersonationIntegrationTests {
   private static final ImmutableList<String> requiredEnvVars =
       ImmutableList.of(
           "MYSQL_USER", "MYSQL_PASS", "MYSQL_DB", "MYSQL_CONNECTION_NAME", "IMPERSONATED_USER");
-  @Rule public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
+  @Rule public Timeout globalTimeout = new Timeout(80, TimeUnit.SECONDS);
   private HikariDataSource connectionPool;
 
   @BeforeClass

--- a/jdbc/postgres/src/test/java/com/google/cloud/sql/postgres/JdbcPostgresIamAuthIntegrationTests.java
+++ b/jdbc/postgres/src/test/java/com/google/cloud/sql/postgres/JdbcPostgresIamAuthIntegrationTests.java
@@ -45,7 +45,7 @@ public class JdbcPostgresIamAuthIntegrationTests {
   // [END cloud_sql_connector_postgres_jdbc_iam_auth]
   private static final ImmutableList<String> requiredEnvVars =
       ImmutableList.of("POSTGRES_IAM_USER", "POSTGRES_DB", "POSTGRES_IAM_CONNECTION_NAME");
-  @Rule public Timeout globalTimeout = new Timeout(60, TimeUnit.SECONDS);
+  @Rule public Timeout globalTimeout = new Timeout(80, TimeUnit.SECONDS);
 
   private HikariDataSource connectionPool;
 

--- a/jdbc/postgres/src/test/java/com/google/cloud/sql/postgres/JdbcPostgresIntegrationTests.java
+++ b/jdbc/postgres/src/test/java/com/google/cloud/sql/postgres/JdbcPostgresIntegrationTests.java
@@ -44,7 +44,7 @@ public class JdbcPostgresIntegrationTests {
   private static final String DB_PASSWORD = System.getenv("POSTGRES_PASS");
   private static final ImmutableList<String> requiredEnvVars =
       ImmutableList.of("POSTGRES_USER", "POSTGRES_PASS", "POSTGRES_DB", "POSTGRES_CONNECTION_NAME");
-  @Rule public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
+  @Rule public Timeout globalTimeout = new Timeout(80, TimeUnit.SECONDS);
 
   private HikariDataSource connectionPool;
 

--- a/jdbc/postgres/src/test/java/com/google/cloud/sql/postgres/JdbcPostgresNamedConnectorIntegrationTests.java
+++ b/jdbc/postgres/src/test/java/com/google/cloud/sql/postgres/JdbcPostgresNamedConnectorIntegrationTests.java
@@ -49,7 +49,7 @@ public class JdbcPostgresNamedConnectorIntegrationTests {
   private static final String DB_USER = System.getenv("POSTGRES_IAM_USER");
   private static final ImmutableList<String> requiredEnvVars =
       ImmutableList.of("POSTGRES_IAM_USER", "POSTGRES_DB", "POSTGRES_IAM_CONNECTION_NAME");
-  @Rule public Timeout globalTimeout = new Timeout(60, TimeUnit.SECONDS);
+  @Rule public Timeout globalTimeout = new Timeout(80, TimeUnit.SECONDS);
 
   private HikariDataSource connectionPool;
 

--- a/jdbc/sqlserver/src/test/java/com/google/cloud/sql/sqlserver/JdbcSqlServerIntegrationTests.java
+++ b/jdbc/sqlserver/src/test/java/com/google/cloud/sql/sqlserver/JdbcSqlServerIntegrationTests.java
@@ -44,7 +44,7 @@ public class JdbcSqlServerIntegrationTests {
   private static final ImmutableList<String> requiredEnvVars =
       ImmutableList.of(
           "SQLSERVER_USER", "SQLSERVER_PASS", "SQLSERVER_DB", "SQLSERVER_CONNECTION_NAME");
-  @Rule public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
+  @Rule public Timeout globalTimeout = new Timeout(80, TimeUnit.SECONDS);
 
   private HikariDataSource connectionPool;
 

--- a/r2dbc/mysql/src/test/java/com/google/cloud/sql/core/R2dbcMysqlIamAuthIntegrationTests.java
+++ b/r2dbc/mysql/src/test/java/com/google/cloud/sql/core/R2dbcMysqlIamAuthIntegrationTests.java
@@ -52,7 +52,7 @@ public class R2dbcMysqlIamAuthIntegrationTests {
   private static final String DB_NAME = System.getenv("MYSQL_DB");
   private static final String DB_USER = System.getenv("MYSQL_IAM_USER");
 
-  @Rule public Timeout globalTimeout = new Timeout(20, TimeUnit.SECONDS);
+  @Rule public Timeout globalTimeout = new Timeout(80, TimeUnit.SECONDS);
 
   private ConnectionPool connectionPool;
 

--- a/r2dbc/mysql/src/test/java/com/google/cloud/sql/core/R2dbcMysqlIntegrationTests.java
+++ b/r2dbc/mysql/src/test/java/com/google/cloud/sql/core/R2dbcMysqlIntegrationTests.java
@@ -46,7 +46,7 @@ public class R2dbcMysqlIntegrationTests {
   private static final String DB_USER = System.getenv("MYSQL_USER");
   private static final String DB_PASSWORD = System.getenv("MYSQL_PASS");
 
-  @Rule public Timeout globalTimeout = new Timeout(20, TimeUnit.SECONDS);
+  @Rule public Timeout globalTimeout = new Timeout(80, TimeUnit.SECONDS);
 
   private ConnectionPool connectionPool;
 

--- a/r2dbc/postgres/src/test/java/com/google/cloud/sql/core/R2dbcPostgresIamAuthIntegrationTests.java
+++ b/r2dbc/postgres/src/test/java/com/google/cloud/sql/core/R2dbcPostgresIamAuthIntegrationTests.java
@@ -54,7 +54,7 @@ public class R2dbcPostgresIamAuthIntegrationTests {
   private static final ImmutableList<String> requiredEnvVars =
       ImmutableList.of(
           "POSTGRES_USER", "POSTGRES_PASS", "POSTGRES_DB", "POSTGRES_IAM_CONNECTION_NAME");
-  @Rule public Timeout globalTimeout = new Timeout(20, TimeUnit.SECONDS);
+  @Rule public Timeout globalTimeout = new Timeout(80, TimeUnit.SECONDS);
 
   private ConnectionFactory connectionPool;
 

--- a/r2dbc/postgres/src/test/java/com/google/cloud/sql/core/R2dbcPostgresIntegrationTests.java
+++ b/r2dbc/postgres/src/test/java/com/google/cloud/sql/core/R2dbcPostgresIntegrationTests.java
@@ -44,7 +44,7 @@ public class R2dbcPostgresIntegrationTests {
   private static final String DB_PASSWORD = System.getenv("POSTGRES_PASS");
   private static final ImmutableList<String> requiredEnvVars =
       ImmutableList.of("POSTGRES_USER", "POSTGRES_PASS", "POSTGRES_DB", "POSTGRES_CONNECTION_NAME");
-  @Rule public Timeout globalTimeout = new Timeout(20, TimeUnit.SECONDS);
+  @Rule public Timeout globalTimeout = new Timeout(80, TimeUnit.SECONDS);
 
   private ConnectionFactory connectionPool;
 

--- a/r2dbc/sqlserver/src/test/java/com/google/cloud/sql/core/R2dbcSqlserverIntegrationTests.java
+++ b/r2dbc/sqlserver/src/test/java/com/google/cloud/sql/core/R2dbcSqlserverIntegrationTests.java
@@ -46,7 +46,7 @@ public class R2dbcSqlserverIntegrationTests {
   private static final String DB_USER = System.getenv("SQLSERVER_USER");
   private static final String DB_PASSWORD = System.getenv("SQLSERVER_PASS");
 
-  @Rule public Timeout globalTimeout = new Timeout(20, TimeUnit.SECONDS);
+  @Rule public Timeout globalTimeout = new Timeout(80, TimeUnit.SECONDS);
 
   private ConnectionPool connectionPool;
 


### PR DESCRIPTION
As discussed the test integration timeout should be increased to `80 seconds` to allow for token refresh if needed.