### PR TITLE
fix: Adjust default timeouts to allow more retries with the Cloud SQL API. 

### DIFF
--- a/core/src/test/java/com/google/cloud/sql/core/ConnectorTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/ConnectorTest.java
@@ -62,14 +62,14 @@ public class ConnectorTest extends CloudSqlCoreTestingBase {
 
     Connector c = newConnector(config.getConnectorConfig(), DEFAULT_SERVER_PROXY_PORT);
     try {
-      c.connect(config);
+      c.connect(config, TEST_MAX_REFRESH_MS);
       fail();
     } catch (IllegalArgumentException e) {
       assertThat(e).hasMessageThat().contains("Cloud SQL connection name is invalid");
     }
 
     try {
-      c.connect(config2);
+      c.connect(config2, TEST_MAX_REFRESH_MS);
       fail();
     } catch (IllegalArgumentException e) {
       assertThat(e).hasMessageThat().contains("Cloud SQL connection name is invalid");
@@ -93,7 +93,7 @@ public class ConnectorTest extends CloudSqlCoreTestingBase {
 
     Connector connector = newConnector(config.getConnectorConfig(), port);
 
-    Socket socket = connector.connect(config);
+    Socket socket = connector.connect(config, TEST_MAX_REFRESH_MS);
 
     assertThat(readLine(socket)).isEqualTo(SERVER_MESSAGE);
   }

--- a/r2dbc/core/src/test/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderTest.java
+++ b/r2dbc/core/src/test/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderTest.java
@@ -183,7 +183,7 @@ public class GcpConnectionFactoryProviderTest {
             repo,
             stubCredentialFactoryProvider,
             3307,
-            InternalConnectorRegistry.DEFAULT_MAX_REFRESH_MS,
+            InternalConnectorRegistry.DEFAULT_CONNECT_TIMEOUT_MS,
             defaultExecutor);
   }
 }


### PR DESCRIPTION
Set the default connect timeout to 45 seconds. This allows the Refresher to retry at least once after 
a failed refresh attempt. (Refresher delay between failed attempts is 30 sec.)

Rename and restructure connect timeout variables to make the code easier to understand.

Fixes #1695.