### PR TITLE
deps: Update com.google.auth dependencies to v1.21.0

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -204,13 +204,13 @@
     <dependency>
       <groupId>com.google.auth</groupId>
       <artifactId>google-auth-library-credentials</artifactId>
-      <version>1.20.0</version>
+      <version>1.21.0</version>
     </dependency>
 
     <dependency>
       <groupId>com.google.auth</groupId>
       <artifactId>google-auth-library-oauth2-http</artifactId>
-      <version>1.20.0</version>
+      <version>1.21.0</version>
     </dependency>
 
     <dependency>

--- a/core/src/main/java/com/google/cloud/sql/CredentialFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/CredentialFactory.java
@@ -64,7 +64,7 @@ public interface CredentialFactory {
                   ? Date.from(Instant.ofEpochMilli(credential.getExpirationTimeMilliseconds()))
                   : null);
 
-      return new GoogleCredentials(accessToken) {
+      return new GoogleCredentials(GoogleCredentials.newBuilder().setAccessToken(accessToken)) {
         @Override
         public AccessToken refreshAccessToken() throws IOException {
           credential.refreshToken();

--- a/core/src/test/java/com/google/cloud/sql/ConnectorConfigTest.java
+++ b/core/src/test/java/com/google/cloud/sql/ConnectorConfigTest.java
@@ -211,8 +211,16 @@ public class ConnectorConfigTest {
 
   @Test
   public void testNotEqual_withGoogleCredentialsNotEqual() {
-    GoogleCredentials c1 = GoogleCredentials.create(new AccessToken("c1", null));
-    GoogleCredentials c2 = GoogleCredentials.create(new AccessToken("c2", null));
+    GoogleCredentials c1 =
+        GoogleCredentials.newBuilder()
+            .setAccessToken(new AccessToken("c1", null))
+            .setQuotaProjectId("project1")
+            .build();
+    GoogleCredentials c2 =
+        GoogleCredentials.newBuilder()
+            .setAccessToken(new AccessToken("c2", null))
+            .setQuotaProjectId("project2")
+            .build();
     ConnectorConfig k1 = new ConnectorConfig.Builder().withGoogleCredentials(c1).build();
     ConnectorConfig k2 = new ConnectorConfig.Builder().withGoogleCredentials(c2).build();
 

--- a/core/src/test/java/com/google/cloud/sql/CredentialFactoryTest.java
+++ b/core/src/test/java/com/google/cloud/sql/CredentialFactoryTest.java
@@ -39,7 +39,8 @@ public class CredentialFactoryTest {
 
   @Test
   public void testDefaultGetCredentialsWorksForGoogleCredentials() {
-    GoogleCredentials googleCredentials = new GoogleCredentials(new AccessToken("my-token", null));
+    GoogleCredentials googleCredentials =
+        GoogleCredentials.create(new AccessToken("my-token", null));
     CredentialFactory factory = new GoogleCredentialsFactory(googleCredentials);
 
     // Expected behavior from old implementation before getCredential()

--- a/core/src/test/java/com/google/cloud/sql/core/CredentialFactoryProviderTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/CredentialFactoryProviderTest.java
@@ -90,7 +90,7 @@ public class CredentialFactoryProviderTest {
 
   @Test
   public void getInstanceCredentialFactory_returnsImpersonatingCredentialFactory() {
-    GoogleCredentials c = new GoogleCredentials(null);
+    GoogleCredentials c = GoogleCredentials.create(null);
     ConnectorConfig config =
         new ConnectorConfig.Builder()
             .withGoogleCredentials(c)

--- a/core/src/test/java/com/google/cloud/sql/core/DefaultAccessTokenSupplierTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/DefaultAccessTokenSupplierTest.java
@@ -62,7 +62,9 @@ public class DefaultAccessTokenSupplierTest {
 
     // Scoped credentials can't be refreshed.
     scopedCredentials =
-        new GoogleCredentials(new AccessToken("my-scoped-token", null)) {
+        new GoogleCredentials(
+            GoogleCredentials.newBuilder()
+                .setAccessToken(new AccessToken("my-scoped-token", null))) {
           @Override
           public AccessToken refreshAccessToken() throws IOException {
             refreshCounter.incrementAndGet();
@@ -82,7 +84,9 @@ public class DefaultAccessTokenSupplierTest {
   public void testWithValidToken() throws Exception {
     // Google credentials can be refreshed
     GoogleCredentials googleCredentials =
-        new GoogleCredentials(new AccessToken("my-token", Date.from(future))) {
+        new GoogleCredentials(
+            GoogleCredentials.newBuilder()
+                .setAccessToken(new AccessToken("my-token", Date.from(future)))) {
           @Override
           public GoogleCredentials createScoped(String... scopes) {
             return scopedCredentials;
@@ -133,7 +137,9 @@ public class DefaultAccessTokenSupplierTest {
   public void testThrowsOnExpiredTokenRefreshNotSupported() throws Exception {
 
     GoogleCredentials expiredGoogleCredentials =
-        new GoogleCredentials(new AccessToken("my-expired-token", Date.from(past))) {
+        new GoogleCredentials(
+            GoogleCredentials.newBuilder()
+                .setAccessToken(new AccessToken("my-expired-token", Date.from(past)))) {
           @Override
           public GoogleCredentials createScoped(String... scopes) {
             return scopedCredentials;
@@ -158,7 +164,9 @@ public class DefaultAccessTokenSupplierTest {
   public void testThrowsOnExpiredTokenRefreshStillExpired() throws Exception {
 
     GoogleCredentials refreshGetsExpiredToken =
-        new GoogleCredentials(new AccessToken("my-expired-token", Date.from(past))) {
+        new GoogleCredentials(
+            GoogleCredentials.newBuilder()
+                .setAccessToken(new AccessToken("my-expired-token", Date.from(past)))) {
           @Override
           public GoogleCredentials createScoped(String... scopes) {
             return scopedCredentials;
@@ -182,7 +190,9 @@ public class DefaultAccessTokenSupplierTest {
   @Test
   public void testValidOnRefreshSucceeded() throws Exception {
     GoogleCredentials refreshableCredentials =
-        new GoogleCredentials(new AccessToken("my-expired-token", Date.from(past))) {
+        new GoogleCredentials(
+            GoogleCredentials.newBuilder()
+                .setAccessToken(new AccessToken("my-expired-token", Date.from(past)))) {
           @Override
           public GoogleCredentials createScoped(String... scopes) {
             return scopedCredentials;
@@ -209,7 +219,9 @@ public class DefaultAccessTokenSupplierTest {
   @Test
   public void testValidOnRefreshFailsSometimes() throws Exception {
     GoogleCredentials refreshableCredentials =
-        new GoogleCredentials(new AccessToken("my-expired-token", Date.from(past))) {
+        new GoogleCredentials(
+            GoogleCredentials.newBuilder()
+                .setAccessToken(new AccessToken("my-expired-token", Date.from(past)))) {
           @Override
           public GoogleCredentials createScoped(String... scopes) {
             return scopedCredentials;
@@ -241,7 +253,9 @@ public class DefaultAccessTokenSupplierTest {
   public void downscopesGoogleCredentials() {
     // Google credentials can be refreshed
     GoogleCredentials googleCredentials =
-        new GoogleCredentials(new AccessToken("my-token", Date.from(future))) {
+        new GoogleCredentials(
+            GoogleCredentials.newBuilder()
+                .setAccessToken(new AccessToken("my-token", Date.from(future)))) {
           @Override
           public GoogleCredentials createScoped(String... scopes) {
             return scopedCredentials;
@@ -269,7 +283,8 @@ public class DefaultAccessTokenSupplierTest {
   @Test
   public void throwsErrorForEmptyAccessToken() {
     GoogleCredentials creds =
-        new GoogleCredentials(new AccessToken("", Date.from(future))) {
+        new GoogleCredentials(
+            GoogleCredentials.newBuilder().setAccessToken(new AccessToken("", Date.from(future)))) {
           @Override
           public GoogleCredentials createScoped(String... scopes) {
             return scopedCredentials;
@@ -286,7 +301,9 @@ public class DefaultAccessTokenSupplierTest {
   @Test
   public void throwsErrorForExpiredAccessToken() {
     GoogleCredentials refreshableCredentials =
-        new GoogleCredentials(new AccessToken("my-expired-token", Date.from(past))) {
+        new GoogleCredentials(
+            GoogleCredentials.newBuilder()
+                .setAccessToken(new AccessToken("my-expired-token", Date.from(past)))) {
           @Override
           public GoogleCredentials createScoped(String... scopes) {
             return scopedCredentials;

--- a/core/src/test/java/com/google/cloud/sql/core/StubCredentialFactory.java
+++ b/core/src/test/java/com/google/cloud/sql/core/StubCredentialFactory.java
@@ -59,7 +59,7 @@ public class StubCredentialFactory implements CredentialFactory {
     private final OAuth2Credentials oauth2;
 
     RefreshGoogleCredentials(OAuth2Credentials oauth2) {
-      super(oauth2.getAccessToken());
+      super(GoogleCredentials.newBuilder().setAccessToken(oauth2.getAccessToken()));
       this.oauth2 = oauth2;
     }
 


### PR DESCRIPTION
* Update the `com.google.auth` dependencies to `v1.21.0`
* Switch from the deprecated  constructor `GoogleCredentials(AccessToken)` to the  constructor `GoogleCredentials(Builder builder)`.