### PR TITLE
fix: ensure cert refresh recovers from sleep

### DIFF
--- a/core/src/main/java/com/google/cloud/sql/core/DefaultConnectionInfoCache.java
+++ b/core/src/main/java/com/google/cloud/sql/core/DefaultConnectionInfoCache.java
@@ -136,6 +136,10 @@ class DefaultConnectionInfoCache {
     this.refresher.forceRefresh();
   }
 
+  void refreshIfExpired() {
+    this.refresher.refreshIfExpired();
+  }
+
   ListenableFuture<ConnectionInfo> getNext() {
     return refresher.getNext();
   }

--- a/core/src/test/java/com/google/cloud/sql/core/RefresherTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/RefresherTest.java
@@ -448,6 +448,45 @@ public class RefresherTest {
     assertThat(r.getNext().isCancelled()).isTrue();
   }
 
+  @Test
+  public void testCloudSqlRefreshesTokenIfExpired() throws Exception {
+    ExampleData initialData = new ExampleData(Instant.now().minus(2, ChronoUnit.SECONDS));
+    ExampleData data = new ExampleData(Instant.now().plus(1, ChronoUnit.HOURS));
+
+    AtomicInteger refreshCount = new AtomicInteger();
+    final PauseCondition refresh1 = new PauseCondition();
+
+    Refresher r =
+        new Refresher(
+            "RefresherTest.testCloudSqlRefreshesTokenIfExpired",
+            executorService,
+            () -> {
+              int c = refreshCount.get();
+              ExampleData refreshResult = data;
+              switch (c) {
+                case 0:
+                  // refresh 0 should return initialData immediately
+                  refreshResult = initialData;
+                  break;
+              }
+              // refresh 2 and on should return data immediately
+              refreshCount.incrementAndGet();
+              return Futures.immediateFuture(refreshResult);
+            },
+            rateLimiter,
+            false);
+
+    // Get the first data that is about to expire
+    refresh1.waitForCondition(() -> r.getConnectionInfo(TEST_TIMEOUT_MS) == initialData, 1000L);
+    assertThat(refreshCount.get()).isEqualTo(1);
+
+    r.refreshIfExpired();
+
+    // getConnectionInfo again, and assert the refresh operation completed.
+    refresh1.waitForCondition(() -> r.getConnectionInfo(TEST_TIMEOUT_MS) == data, 1000L);
+    assertThat(refreshCount.get()).isEqualTo(2);
+  }
+
   private static class ExampleData extends ConnectionInfo {
 
     ExampleData(Instant expiration) {


### PR DESCRIPTION
When a computer wakes from sleep after more than ~1 hour and a client tries to connect, the internal certificate cache will have an expired certificate. As a result, clients who tried to connect after sleep would see bad certificate errors which would resolve only once the remaining refresh duration expired (sleep time + remaining duration).

This commit adds code to check if the client certificate is expired and immediately triggers a blocking refresh if it is. This means that in the case where a cached certificate has expired, it will be discarded and a new one will be retrieved before continuing with the connection.

Fixes https://github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory/issues/1558