### PR TITLE
deps: Update dependency com.mysql:mysql-connector-j to v8.3.0

### DIFF
--- a/jdbc/mysql-j-8/pom.xml
+++ b/jdbc/mysql-j-8/pom.xml
@@ -51,9 +51,9 @@
       <version>${project.parent.version}</version>
     </dependency>
     <dependency>
-      <groupId>mysql</groupId>
-      <artifactId>mysql-connector-java</artifactId>
-      <version>8.0.28</version>
+      <groupId>com.mysql</groupId>
+      <artifactId>mysql-connector-j</artifactId>
+      <version>8.3.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -89,9 +89,9 @@
       <id>jar-with-driver-and-dependencies</id>
       <dependencies>
         <dependency>
-          <groupId>mysql</groupId>
-          <artifactId>mysql-connector-java</artifactId>
-          <version>8.0.28</version>
+          <groupId>com.mysql</groupId>
+          <artifactId>mysql-connector-j</artifactId>
+          <version>8.3.0</version>
         </dependency>
       </dependencies>
     </profile>
@@ -103,9 +103,9 @@
       <id>native</id>
       <dependencies>
         <dependency>
-          <groupId>mysql</groupId>
-          <artifactId>mysql-connector-java</artifactId>
-          <version>8.0.28</version>
+          <groupId>com.mysql</groupId>
+          <artifactId>mysql-connector-j</artifactId>
+          <version>8.3.0</version>
         </dependency>
       </dependencies>
     </profile>


### PR DESCRIPTION
Note: Maven artifact moved from https://mvnrepository.com/artifact/mysql/mysql-connector-java to https://mvnrepository.com/artifact/com.mysql/mysql-connector-j

Fixes #1831