### PR TITLE
chore: Relocate maven artifacts and continue to support old names.

### DIFF
--- a/.kokoro/release/publish_javadoc.sh
+++ b/.kokoro/release/publish_javadoc.sh
@@ -33,7 +33,7 @@ python3 -m pip install --require-hashes -r .kokoro/requirements.txt
 # compile all packages
 mvn clean install -B -q -DskipTests=true
 
-export NAME=jdbc-socket-factory-parent
+export NAME=cloud-sql-connector-parent
 export VERSION=$(grep ${NAME}: versions.txt | cut -d: -f3)
 
 # build the docs

--- a/.kokoro/release/publish_javadoc11.cfg
+++ b/.kokoro/release/publish_javadoc11.cfg
@@ -14,7 +14,7 @@ env_vars: {
 
 env_vars: {
   key: "TRAMPOLINE_BUILD_FILE"
-  value: "github/jdbc-socket-factory-parent/.kokoro/release/publish_javadoc11.sh"
+  value: "github/cloud-sql-connector-parent/.kokoro/release/publish_javadoc11.sh"
 }
 
 before_action {

--- a/.kokoro/release/publish_javadoc11.sh
+++ b/.kokoro/release/publish_javadoc11.sh
@@ -33,7 +33,7 @@ python3 -m pip install --require-hashes -r .kokoro/requirements.txt
 # compile all packages
 mvn clean install -B -q -DskipTests=true
 
-export NAME=jdbc-socket-factory-parent
+export NAME=cloud-sql-connector-parent
 export VERSION=$(grep ${NAME}: versions.txt | cut -d: -f3)
 
 # cloud RAD generation

--- a/.kokoro/release/snapshot.cfg
+++ b/.kokoro/release/snapshot.cfg
@@ -2,13 +2,13 @@
 
 env_vars: {
   key: "TRAMPOLINE_BUILD_FILE"
-  value: "github/jdbc-socket-factory-parent/.kokoro/release/snapshot.sh"
+  value: "github/cloud-sql-connector-parent/.kokoro/release/snapshot.sh"
 }
 
 
 action {
   define_artifacts {
-    regex: "github/jdbc-socket-factory-parent/.*/target/.*\.jar"
-    strip_prefix: "github/jdbc-socket-factory-parent"
+    regex: "github/cloud-sql-connector-parent/.*/target/.*\.jar"
+    strip_prefix: "github/cloud-sql-connector-parent"
   }
 }

--- a/.kokoro/release/stage.cfg
+++ b/.kokoro/release/stage.cfg
@@ -2,22 +2,22 @@
 
 env_vars: {
   key: "TRAMPOLINE_BUILD_FILE"
-  value: "github/jdbc-socket-factory-parent/.kokoro/release/stage.sh"
+  value: "github/cloud-sql-connector-parent/.kokoro/release/stage.sh"
 }
 
 # Need to save the properties file
 action {
   define_artifacts {
-    regex: "github/jdbc-socket-factory-parent/target/nexus-staging/staging/*.properties"
-    strip_prefix: "github/jdbc-socket-factory-parent"
+    regex: "github/cloud-sql-connector-parent/target/nexus-staging/staging/*.properties"
+    strip_prefix: "github/cloud-sql-connector-parent"
   }
 }
 
 # Save jar artifacts for SBOM generation
 action {
   define_artifacts {
-    regex: "github/jdbc-socket-factory-parent/.*/target/.*\.jar"
-    strip_prefix: "github/jdbc-socket-factory-parent"
+    regex: "github/cloud-sql-connector-parent/.*/target/.*\.jar"
+    strip_prefix: "github/cloud-sql-connector-parent"
   }
 }
 

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -6,7 +6,7 @@
   "language": "java",
   "repo": "GoogleCloudPlatform/cloud-sql-jdbc-socket-factory",
   "repo_short": "cloud-sql-jdbc-socket-factory",
-  "distribution_name": "com.google.cloud.sql:jdbc-socket-factory-parent",
+  "distribution_name": "com.google.cloud:cloud-sql-connector-parent",
   "api_id": "sqladmin.googleapis.com",
   "library_type": "OTHER",
   "codeowner_team": "@GoogleCloudPlatform/infra-db-sdk"

--- a/README.md
+++ b/README.md
@@ -34,10 +34,14 @@ To build a fat JAR containing the JDBC driver with the bundles Socket Factory de
 This will create a *target* sub-folder within each of the module directories. Within these target directories you'll find the JDBC driver files.
 
 Example:
+<!-- {x-version-update-start:cloud-sql-connector-jdbc-mysql:released} -->
 ```
-mysql-socket-factory-connector-j-8–1.8.0-jar-with-dependencies.jar
-postgres-socket-factory-1.8.0-jar-with-dependencies.jar
+cloud-sql-connector-jdbc-mariadb-1.16.0-jar-with-dependencies.jar
+cloud-sql-connector-jdbc-mysql–1.16.0-jar-with-dependencies.jar
+cloud-sql-connector-jdbc-postgres-1.16.0-jar-with-dependencies.jar
+cloud-sql-connector-jdbc-sqlserver-1.16.0-jar-with-dependencies.jar
 ```
+<!-- {x-version-update-end} -->
 
 ---
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -21,19 +21,20 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>com.google.cloud.sql</groupId>
-    <artifactId>jdbc-socket-factory-parent</artifactId>
-    <version>1.16.1-SNAPSHOT</version><!-- {x-version-update:jdbc-socket-factory-parent:current} -->
+    <groupId>com.google.cloud</groupId>
+    <artifactId>cloud-sql-connector-parent</artifactId>
+    <version>1.16.1-SNAPSHOT</version><!-- {x-version-update:cloud-sql-connector-parent:current} -->
   </parent>
-  <artifactId>jdbc-socket-factory-core</artifactId>
-  <version>1.16.1-SNAPSHOT</version><!-- {x-version-update:jdbc-socket-factory-core:current} -->
+  <artifactId>cloud-sql-connector-core</artifactId>
+  <version>1.16.1-SNAPSHOT</version><!-- {x-version-update:cloud-sql-connector-core:current} -->
   <packaging>jar</packaging>
 
-  <name>Cloud SQL Core Socket Factory (Core Library, don't depend on this directly)</name>
+  <name>Google Cloud SQL Java Connector (Core Library, don't depend on this directly)</name>
   <description>
     Core library for establishing secure connections. End users should depend on the
     driver-specific socket factory artifacts.
   </description>
+  <url>https://github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory</url>
 
   <properties>
     <assembly.skipAssembly>false</assembly.skipAssembly>

--- a/docs/jdbc.md
+++ b/docs/jdbc.md
@@ -9,13 +9,13 @@ or in `build.gradle` if your project uses Gradle.
 
 ##### MySQL
 
-<!-- {x-version-update-start:mysql-socket-factory-connector-j-8:released} -->
+<!-- {x-version-update-start:cloud-sql-connector-jdbc-mysql:released} -->
 Maven
 
 ```maven-pom
 <dependency>
-    <groupId>com.google.cloud.sql</groupId>
-    <artifactId>mysql-socket-factory-connector-j-8</artifactId>
+    <groupId>com.google.cloud</groupId>
+    <artifactId>cloud-sql-connector-jdbc-mysql</artifactId>
     <version>1.16.0</version>
 </dependency>
 ```
@@ -23,20 +23,20 @@ Maven
 Gradle
 
 ```gradle
-compile 'com.google.cloud.sql:mysql-socket-factory-connector-j-8:1.16.0'
+compile 'com.google.cloud:cloud-sql-connector-jdbc-mysql:1.16.0'
 ```
 
 <!-- {x-version-update-end} -->
 
 ##### Maria DB
 
-<!-- {x-version-update-start:mariadb-socket-factory:released} -->
+<!-- {x-version-update-start:cloud-sql-connector-jdbc-mariadb:released} -->
 Maven
 
 ```maven-pom
 <dependency>
-    <groupId>com.google.cloud.sql</groupId>
-    <artifactId>mariadb-socket-factory</artifactId>
+    <groupId>com.google.cloud</groupId>
+    <artifactId>cloud-sql-connector-jdbc-mariadb</artifactId>
     <version>1.16.0</version>
 </dependency>
 ```
@@ -44,7 +44,7 @@ Maven
 Gradle
 
 ```gradle
-compile 'com.google.cloud.sql:mariadb-socket-factory:1.16.0'
+compile 'com.google.cloud:cloud-sql-connector-jdbc-mariadb:1.16.0'
 ```
 
 **Note:** Also include the JDBC Driver for
@@ -53,13 +53,13 @@ MariaDB, `org.mariadb.jdbc:mariadb-java-client:<LATEST-VERSION>`
 
 ##### Postgres
 
-<!-- {x-version-update-start:postgres-socket-factory:released} -->
+<!-- {x-version-update-start:cloud-sql-connector-jdbc-postgres:released} -->
 Maven
 
 ```maven-pom
 <dependency>
-    <groupId>com.google.cloud.sql</groupId>
-    <artifactId>postgres-socket-factory</artifactId>
+    <groupId>com.google.cloud</groupId>
+    <artifactId>cloud-sql-connector-jdbc-postgres</artifactId>
     <version>1.16.0</version>
 </dependency>
 ```
@@ -67,7 +67,7 @@ Maven
 Gradle
 
 ```gradle
-compile 'com.google.cloud.sql:postgres-socket-factory:1.16.0'
+compile 'com.google.cloud:cloud-sql-connector-jdbc-postgres:1.16.0'
 ```
 
 **Note:**  Also include the JDBC Driver for
@@ -81,8 +81,8 @@ Maven
 
 ```maven-pom
 <dependency>
-    <groupId>com.google.cloud.sql</groupId>
-    <artifactId>postgres-socket-factory</artifactId>
+    <groupId>com.google.cloud</groupId>
+    <artifactId>cloud-sql-connector-jdbc-sqlserver</artifactId>
     <version>1.16.0</version>
 </dependency>
 ```
@@ -90,7 +90,7 @@ Maven
 Gradle
 
 ```gradle
-compile 'com.google.cloud.sql:cloud-sql-connector-jdbc-sqlserver:1.16.0'
+compile 'com.google.cloud:cloud-sql-connector-jdbc-sqlserver:1.16.0'
 ```
 
 **Note:**  Also include the JDBC Driver for SQL

--- a/docs/r2dbc.md
+++ b/docs/r2dbc.md
@@ -16,7 +16,7 @@ Maven
 
 ```maven-pom
 <dependency>
-  <groupId>com.google.cloud.sql</groupId>
+  <groupId>com.google.cloud</groupId>
   <artifactId>cloud-sql-connector-r2dbc-mysql</artifactId>
   <version>1.16.0</version>
 </dependency>
@@ -25,7 +25,7 @@ Maven
 Gradle
 
 ```gradle
-compile 'com.google.cloud.sql:cloud-sql-connector-r2dbc-mysql:1.16.0'
+compile 'com.google.cloud:cloud-sql-connector-r2dbc-mysql:1.16.0'
 ```
 
 **Note:** Also include the R2DBC Driver for
@@ -61,7 +61,7 @@ Maven
 
 ```maven-pom
 <dependency>
-  <groupId>com.google.cloud.sql</groupId>
+  <groupId>com.google.cloud</groupId>
   <artifactId>cloud-sql-connector-r2dbc-postgres</artifactId>
   <version>1.16.0</version>
 </dependency>
@@ -70,7 +70,7 @@ Maven
 Gradle
 
 ```gradle
-compile 'com.google.cloud.sql:cloud-sql-connector-r2dbc-postgres:1.16.0'
+compile 'com.google.cloud:cloud-sql-connector-r2dbc-postgres:1.16.0'
 ```
 
 **Note:** Also include the R2DBC Driver for
@@ -84,7 +84,7 @@ Maven
 
 ```maven-pom
 <dependency>
-  <groupId>com.google.cloud.sql</groupId>
+  <groupId>com.google.cloud</groupId>
   <artifactId>cloud-sql-connector-r2dbc-sqlserver</artifactId>
   <version>1.16.0</version>
 </dependency>
@@ -93,7 +93,7 @@ Maven
 Gradle
 
 ```gradle
-compile 'com.google.cloud.sql:cloud-sql-connector-r2dbc-sqlserver:1.16.0'
+compile 'com.google.cloud:cloud-sql-connector-r2dbc-sqlserver:1.16.0'
 ```
 
 **Note:** Also include the R2DBC Driver for SQL

--- a/jdbc/mariadb/src/main/java/com/google/cloud/sql/mariadb/SocketFactory.java
+++ b/jdbc/mariadb/src/main/java/com/google/cloud/sql/mariadb/SocketFactory.java
@@ -33,7 +33,7 @@ import org.mariadb.jdbc.util.ConfigurableSocketFactory;
 public class SocketFactory extends ConfigurableSocketFactory {
 
   static {
-    InternalConnectorRegistry.addArtifactId("mariadb-socket-factory");
+    InternalConnectorRegistry.addArtifactId("cloud-sql-connector-jdbc-mariadb");
   }
 
   private Configuration conf;

--- a/jdbc/mysql-j-8/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
+++ b/jdbc/mysql-j-8/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
@@ -34,7 +34,7 @@ import java.util.Properties;
 public class SocketFactory implements com.mysql.cj.protocol.SocketFactory {
 
   static {
-    InternalConnectorRegistry.addArtifactId("mysql-socket-factory-connector-j-8");
+    InternalConnectorRegistry.addArtifactId("cloud-sql-connector-jdbc-mysql");
   }
 
   @Override

--- a/jdbc/postgres/src/main/java/com/google/cloud/sql/postgres/SocketFactory.java
+++ b/jdbc/postgres/src/main/java/com/google/cloud/sql/postgres/SocketFactory.java
@@ -41,7 +41,7 @@ public class SocketFactory extends javax.net.SocketFactory {
   private final Properties props;
 
   static {
-    InternalConnectorRegistry.addArtifactId("postgres-socket-factory");
+    InternalConnectorRegistry.addArtifactId("cloud-sql-connector-jdbc-postgres");
   }
 
   /**

--- a/jdbc/sqlserver/pom.xml
+++ b/jdbc/sqlserver/pom.xml
@@ -20,21 +20,22 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>com.google.cloud.sql</groupId>
-    <artifactId>jdbc-socket-factory-parent</artifactId>
-    <version>1.16.1-SNAPSHOT</version><!-- {x-version-update:jdbc-socket-factory-parent:current} -->
+    <groupId>com.google.cloud</groupId>
+    <artifactId>cloud-sql-connector-parent</artifactId>
+    <version>1.16.1-SNAPSHOT</version><!-- {x-version-update:cloud-sql-connector-parent:current} -->
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>cloud-sql-connector-jdbc-sqlserver</artifactId>
     <version>1.16.1-SNAPSHOT</version><!-- {x-version-update:cloud-sql-connector-jdbc-sqlserver:current} -->
   <packaging>jar</packaging>
 
-  <name>Cloud SQL JDBC Connector for SQL Server</name>
+  <name>Google Cloud SQL JDBC Connector for SQL Server</name>
   <description>
-    Socket factory for the Microsoft JDBC Driver for SQL Server that allows a user with the
-    appropriate permissions to connect to a Cloud SQL database without having to deal with IP
-    allowlisting or SSL certificates manually.
+    The Cloud SQL JDBC Connector provides a socket factory for the SQL Server JDBC driver. 
+    The socket factory provides an mTLS 1.3 connection to any specified Cloud SQL 
+    SQL Server instance without requiring any manually configured TLS certificates.
   </description>
+  <url>https://github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory</url>
 
   <properties>
     <assembly.skipAssembly>false</assembly.skipAssembly>
@@ -42,8 +43,8 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.cloud.sql</groupId>
-      <artifactId>jdbc-socket-factory-core</artifactId>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>cloud-sql-connector-core</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -333,10 +333,12 @@
     <module>r2dbc/sqlserver</module>
 
     <!-- These modules serve as wrappers for artifacts to be published with the old names -->
+    <module>wrapper/core</module>
     <module>wrapper/jdbc/mariadb</module>
     <module>wrapper/jdbc/mysql</module>
     <module>wrapper/jdbc/postgres</module>
     <module>wrapper/jdbc/sqlserver</module>
+    <module>wrapper/r2dbc/core</module>
     <module>wrapper/r2dbc/mysql</module>
     <module>wrapper/r2dbc/postgres</module>
     <module>wrapper/r2dbc/sqlserver</module>

--- a/pom.xml
+++ b/pom.xml
@@ -18,10 +18,10 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>com.google.cloud.sql</groupId>
-  <artifactId>jdbc-socket-factory-parent</artifactId>
+  <groupId>com.google.cloud</groupId>
+  <artifactId>cloud-sql-connector-parent</artifactId>
   <packaging>pom</packaging>
-  <version>1.16.1-SNAPSHOT</version><!-- {x-version-update:jdbc-socket-factory-parent:current} -->
+  <version>1.16.1-SNAPSHOT</version><!-- {x-version-update:cloud-sql-connector-parent:current} -->
 
   <parent>
     <groupId>com.google.cloud</groupId>
@@ -29,13 +29,13 @@
     <version>1.7.2</version>
   </parent>
 
-  <name>Cloud SQL JDBC Socket Factory</name>
+  <name>Google Cloud SQL Java Connector Parent</name>
   <description>
     Socket factories for MySQL/Postgres JDBC drivers that allows a user with the appropriate
     permissions to connect to a Cloud SQL database without having to deal with IP allowlisting
     or SSL certificates manually
   </description>
-  <url>https://github.com/GoogleCloudPlatform/cloud-sql-mysql-socket-factory</url>
+  <url>https://github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory</url>
 
   <licenses>
     <license>
@@ -58,12 +58,12 @@
 
   <scm>
     <connection>
-      scm:git:https://github.com/GoogleCloudPlatform/cloud-sql-mysql-socket-factory.git
+      scm:git:https://github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory.git
     </connection>
     <developerConnection>
-      scm:git:ssh://git@github.com/GoogleCloudPlatform/cloud-sql-mysql-socket-factory.git
+      scm:git:ssh://git@github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory.git
     </developerConnection>
-    <url>https://github.com/GoogleCloudPlatform/cloud-sql-mysql-socket-factory.git</url>
+    <url>https://github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory.git</url>
     <tag>HEAD</tag>
   </scm>
 
@@ -331,6 +331,15 @@
     <module>r2dbc/mysql</module>
     <module>r2dbc/postgres</module>
     <module>r2dbc/sqlserver</module>
+
+    <!-- These modules serve as wrappers for artifacts to be published with the old names -->
+    <module>wrapper/jdbc/mariadb</module>
+    <module>wrapper/jdbc/mysql</module>
+    <module>wrapper/jdbc/postgres</module>
+    <module>wrapper/jdbc/sqlserver</module>
+    <module>wrapper/r2dbc/mysql</module>
+    <module>wrapper/r2dbc/postgres</module>
+    <module>wrapper/r2dbc/sqlserver</module>
   </modules>
 
   <build>
@@ -576,9 +585,9 @@
 
                 Global test dependencies unused in r2dbc core:
                 junit:junit,com.google.truth:truth,org.bouncycastle:bcpkix-jdk15on
-                com.google.cloud.sql:jdbc-socket-factory-core:test-jar
+                com.google.cloud:cloud-sql-connector-core:test-jar
                 -->
-                org.ow2.asm:asm-util,com.github.jnr:jnr-unixsocket,org.postgresql:postgresql,junit:junit,com.google.truth:truth,com.microsoft.sqlserver:mssql-jdbc,com.google.guava:guava,org.bouncycastle:bcpkix-jdk15on,com.google.cloud.sql:jdbc-socket-factory-core:test-jar,com.google.auth:google-auth-library-credentials
+                org.ow2.asm:asm-util,com.github.jnr:jnr-unixsocket,org.postgresql:postgresql,junit:junit,com.google.truth:truth,com.microsoft.sqlserver:mssql-jdbc,com.google.guava:guava,org.bouncycastle:bcpkix-jdk15on,com.google.cloud:cloud-sql-connector-core:test-jar,com.google.auth:google-auth-library-credentials
               </ignoredDependencies>
             </configuration>
             <executions>

--- a/r2dbc/core/pom.xml
+++ b/r2dbc/core/pom.xml
@@ -19,20 +19,21 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>com.google.cloud.sql</groupId>
-    <artifactId>jdbc-socket-factory-parent</artifactId>
-    <version>1.16.1-SNAPSHOT</version><!-- {x-version-update:jdbc-socket-factory-parent:current} -->
+    <groupId>com.google.cloud</groupId>
+    <artifactId>cloud-sql-connector-parent</artifactId>
+    <version>1.16.1-SNAPSHOT</version><!-- {x-version-update:cloud-sql-connector-parent:current} -->
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>cloud-sql-connector-r2dbc-core</artifactId>
   <version>1.16.1-SNAPSHOT</version><!-- {x-version-update:cloud-sql-connector-r2dbc-core:current} -->
   <packaging>jar</packaging>
 
-  <name>Cloud SQL R2DBC Connection Factory (R2DBC Core Library, don't depend on this directly)</name>
+  <name>Google Cloud SQL R2DBC Connector (Core Library, don't depend on this directly)</name>
   <description>
-    R2DBC ConnectionFactory to connect to a Cloud SQL database without having to deal with IP allowlisting or SSL
-    certificates manually.
+    Core library for establishing secure connections. End users should depend on the
+    driver-specific socket factory artifacts.
   </description>
+  <url>https://github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory</url>
 
   <properties>
     <assembly.skipAssembly>false</assembly.skipAssembly>
@@ -40,8 +41,8 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.cloud.sql</groupId>
-      <artifactId>jdbc-socket-factory-core</artifactId>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>cloud-sql-connector-core</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
     <dependency>
@@ -72,8 +73,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.cloud.sql</groupId>
-      <artifactId>jdbc-socket-factory-core</artifactId>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>cloud-sql-connector-core</artifactId>
       <version>${project.parent.version}</version>
       <type>test-jar</type>
       <scope>test</scope>

--- a/r2dbc/mariadb/pom.xml
+++ b/r2dbc/mariadb/pom.xml
@@ -20,9 +20,9 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>com.google.cloud.sql</groupId>
-    <artifactId>jdbc-socket-factory-parent</artifactId>
-    <version>1.16.1-SNAPSHOT</version><!-- {x-version-update:jdbc-socket-factory-parent:current} -->
+    <groupId>com.google.cloud</groupId>
+    <artifactId>cloud-sql-connector-parent</artifactId>
+    <version>1.16.1-SNAPSHOT</version><!-- {x-version-update:cloud-sql-connector-parent:current} -->
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <groupId>com.google.cloud</groupId>
@@ -32,8 +32,8 @@
 
   <name>Google Cloud SQL R2DBC Connector for MariaDB</name>
   <description>
-    The Cloud SQL R2DBC Connector provides a socket factory for the MySQL R2DBC driver. 
-    The socket factory provides an mTLS 1.3 connection to any specified Cloud SQL MySQL 
+    The Cloud SQL R2DBC Connector provides a socket factory for the MariaDB R2DBC driver. 
+    The socket factory provides an mTLS 1.3 connection to any specified Cloud SQL MariaDB 
     instance without requiring any manually configured TLS certificates.
   </description>
   <url>https://github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory</url>
@@ -44,13 +44,13 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.cloud.sql</groupId>
+      <groupId>com.google.cloud</groupId>
       <artifactId>cloud-sql-connector-r2dbc-core</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.google.cloud.sql</groupId>
-      <artifactId>jdbc-socket-factory-core</artifactId>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>cloud-sql-connector-core</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
     <dependency>
@@ -102,8 +102,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.cloud.sql</groupId>
-      <artifactId>jdbc-socket-factory-core</artifactId>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>cloud-sql-connector-core</artifactId>
       <version>${project.parent.version}</version>
       <type>test-jar</type>
       <scope>test</scope>

--- a/r2dbc/mysql/pom.xml
+++ b/r2dbc/mysql/pom.xml
@@ -20,20 +20,22 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>com.google.cloud.sql</groupId>
-    <artifactId>jdbc-socket-factory-parent</artifactId>
-    <version>1.16.1-SNAPSHOT</version><!-- {x-version-update:jdbc-socket-factory-parent:current} -->
+    <groupId>com.google.cloud</groupId>
+    <artifactId>cloud-sql-connector-parent</artifactId>
+    <version>1.16.1-SNAPSHOT</version><!-- {x-version-update:cloud-sql-connector-parent:current} -->
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>cloud-sql-connector-r2dbc-mysql</artifactId>
   <version>1.16.1-SNAPSHOT</version><!-- {x-version-update:cloud-sql-connector-r2dbc-mysql:current} -->
   <packaging>jar</packaging>
 
-  <name>Cloud SQL R2DBC Connection Factory for MySQL</name>
+  <name>Google Cloud SQL R2DBC Connector for MySQL</name>
   <description>
-    R2DBC ConnectionFactory to connect to a Cloud SQL MySQL database without having to deal with IP allowlisting or SSL
-    certificates manually.
+    The Cloud SQL R2DBC Connector provides a socket factory for the MySQL R2DBC driver. 
+    The socket factory provides an mTLS 1.3 connection to any specified Cloud SQL 
+    MySQL instance without requiring any manually configured TLS certificates.
   </description>
+  <url>https://github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory</url>
 
   <properties>
     <assembly.skipAssembly>false</assembly.skipAssembly>
@@ -41,13 +43,13 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.cloud.sql</groupId>
+      <groupId>com.google.cloud</groupId>
       <artifactId>cloud-sql-connector-r2dbc-core</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.google.cloud.sql</groupId>
-      <artifactId>jdbc-socket-factory-core</artifactId>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>cloud-sql-connector-core</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
     <dependency>
@@ -105,8 +107,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.cloud.sql</groupId>
-      <artifactId>jdbc-socket-factory-core</artifactId>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>cloud-sql-connector-core</artifactId>
       <version>${project.parent.version}</version>
       <type>test-jar</type>
       <scope>test</scope>

--- a/r2dbc/postgres/pom.xml
+++ b/r2dbc/postgres/pom.xml
@@ -20,21 +20,22 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>com.google.cloud.sql</groupId>
-    <artifactId>jdbc-socket-factory-parent</artifactId>
-    <version>1.16.1-SNAPSHOT</version><!-- {x-version-update:jdbc-socket-factory-parent:current} -->
+    <groupId>com.google.cloud</groupId>
+    <artifactId>cloud-sql-connector-parent</artifactId>
+    <version>1.16.1-SNAPSHOT</version><!-- {x-version-update:cloud-sql-connector-parent:current} -->
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>cloud-sql-connector-r2dbc-postgres</artifactId>
   <version>1.16.1-SNAPSHOT</version><!-- {x-version-update:cloud-sql-connector-r2dbc-postgres:current} -->
   <packaging>jar</packaging>
 
-  <name>Cloud SQL R2DBC Connection Factory for Postgres</name>
+  <name>Google Cloud SQL R2DBC Connector for Postgres</name>
   <description>
-    R2DBC ConnectionFactory to connect to a Cloud SQL Postgres database without having to deal with IP allowlisting or
-    SSL
-    certificates manually.
+    The Cloud SQL R2DBC Connector provides a socket factory for the Postgres R2DBC driver. 
+    The socket factory provides an mTLS 1.3 connection to any specified Cloud SQL 
+    Postgres instance without requiring any manually configured TLS certificates.
   </description>
+  <url>https://github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory</url>
 
   <properties>
     <assembly.skipAssembly>false</assembly.skipAssembly>
@@ -42,13 +43,13 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.cloud.sql</groupId>
+      <groupId>com.google.cloud</groupId>
       <artifactId>cloud-sql-connector-r2dbc-core</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.google.cloud.sql</groupId>
-      <artifactId>jdbc-socket-factory-core</artifactId>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>cloud-sql-connector-core</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
     <dependency>
@@ -106,8 +107,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.cloud.sql</groupId>
-      <artifactId>jdbc-socket-factory-core</artifactId>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>cloud-sql-connector-core</artifactId>
       <version>${project.parent.version}</version>
       <type>test-jar</type>
       <scope>test</scope>

--- a/r2dbc/sqlserver/pom.xml
+++ b/r2dbc/sqlserver/pom.xml
@@ -20,21 +20,22 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>com.google.cloud.sql</groupId>
-    <artifactId>jdbc-socket-factory-parent</artifactId>
-    <version>1.16.1-SNAPSHOT</version><!-- {x-version-update:jdbc-socket-factory-parent:current} -->
+    <groupId>com.google.cloud</groupId>
+    <artifactId>cloud-sql-connector-parent</artifactId>
+    <version>1.16.1-SNAPSHOT</version><!-- {x-version-update:cloud-sql-connector-parent:current} -->
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>cloud-sql-connector-r2dbc-sqlserver</artifactId>
   <version>1.16.1-SNAPSHOT</version><!-- {x-version-update:cloud-sql-connector-r2dbc-sqlserver:current} -->
   <packaging>jar</packaging>
 
-  <name>Cloud SQL R2DBC Connection Factory for SQL Server</name>
+  <name>Google Cloud SQL R2DBC Connector for SQL Server</name>
   <description>
-    Connection Factory for the R2DBC Driver for SQL Server that allows a user with the
-    appropriate permissions to connect to a Cloud SQL database without having to deal with IP
-    allowlisting or SSL certificates manually.
+    The Cloud SQL R2DBC Connector provides a socket factory for the SQL Server R2DBC driver. 
+    The socket factory provides an mTLS 1.3 connection to any specified Cloud SQL 
+    SQL Server instance without requiring any manually configured TLS certificates.
   </description>
+  <url>https://github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory</url>
 
   <properties>
     <assembly.skipAssembly>false</assembly.skipAssembly>
@@ -42,13 +43,13 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.cloud.sql</groupId>
+      <groupId>com.google.cloud</groupId>
       <artifactId>cloud-sql-connector-r2dbc-core</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.google.cloud.sql</groupId>
-      <artifactId>jdbc-socket-factory-core</artifactId>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>cloud-sql-connector-core</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
     <dependency>
@@ -106,8 +107,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.cloud.sql</groupId>
-      <artifactId>jdbc-socket-factory-core</artifactId>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>cloud-sql-connector-core</artifactId>
       <version>${project.parent.version}</version>
       <type>test-jar</type>
       <scope>test</scope>

--- a/versions.txt
+++ b/versions.txt
@@ -1,12 +1,11 @@
 # Format:
 # module:released-version:current-version
 
-jdbc-socket-factory-parent:1.16.0:1.16.1-SNAPSHOT
-jdbc-socket-factory-core:1.16.0:1.16.1-SNAPSHOT
-mariadb-socket-factory:1.16.0:1.16.1-SNAPSHOT
-mysql-socket-factory:1.16.0:1.16.1-SNAPSHOT
-mysql-socket-factory-connector-j-8:1.16.0:1.16.1-SNAPSHOT
-postgres-socket-factory:1.16.0:1.16.1-SNAPSHOT
+cloud-sql-connector-parent:1.16.0:1.16.1-SNAPSHOT
+cloud-sql-connector-core:1.16.0:1.16.1-SNAPSHOT
+cloud-sql-connector-jdbc-mariadb:1.16.0:1.16.1-SNAPSHOT
+cloud-sql-connector-jdbc-mysql:1.16.0:1.16.1-SNAPSHOT
+cloud-sql-connector-jdbc-postgres:1.16.0:1.16.1-SNAPSHOT
 cloud-sql-connector-jdbc-sqlserver:1.16.0:1.16.1-SNAPSHOT
 cloud-sql-connector-r2dbc-core:1.16.0:1.16.1-SNAPSHOT
 cloud-sql-connector-r2dbc-mariadb:1.16.0:1.16.1-SNAPSHOT

--- a/wrapper/core/pom.xml
+++ b/wrapper/core/pom.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2024 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.google.cloud</groupId>
+    <artifactId>cloud-sql-connector-parent</artifactId>
+    <version>1.16.1-SNAPSHOT</version><!-- {x-version-update:cloud-sql-connector-parent:current} -->
+  </parent>
+  <groupId>com.google.cloud.sql</groupId>
+  <artifactId>jdbc-socket-factory-core</artifactId>
+  <version>1.16.1-SNAPSHOT</version><!-- {x-version-update:cloud-sql-connector-core:current} -->
+  <packaging>jar</packaging>
+
+  <distributionManagement>
+    <relocation>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>cloud-sql-connector-core</artifactId>
+      <version>1.16.1-SNAPSHOT</version><!-- {x-version-update:cloud-sql-connector-core:current} -->
+      <message>Please use the new artifact.</message>
+    </relocation>
+  </distributionManagement>
+
+  <name>Cloud SQL Core Socket Factory (Core Library, don't depend on this directly)</name>
+  <description>
+    Core library for establishing secure connections. End users should depend on the
+    driver-specific socket factory artifacts.
+  </description>
+
+  <properties>
+    <assembly.skipAssembly>false</assembly.skipAssembly>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>cloud-sql-connector-core</artifactId>
+      <version>${project.parent.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.3.0</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <usedDependencies>
+            <!-- This dependency is not used at compile-time. -->
+            <dependency>com.google.cloud:cloud-sql-connector-core</dependency>
+          </usedDependencies>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/wrapper/core/pom.xml
+++ b/wrapper/core/pom.xml
@@ -24,6 +24,7 @@
     <groupId>com.google.cloud</groupId>
     <artifactId>cloud-sql-connector-parent</artifactId>
     <version>1.16.1-SNAPSHOT</version><!-- {x-version-update:cloud-sql-connector-parent:current} -->
+    <relativePath>../../pom.xml</relativePath>
   </parent>
   <groupId>com.google.cloud.sql</groupId>
   <artifactId>jdbc-socket-factory-core</artifactId>

--- a/wrapper/jdbc/mariadb/pom.xml
+++ b/wrapper/jdbc/mariadb/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- Copyright 2023 Google LLC
+ Copyright 2024 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -23,61 +23,39 @@
     <groupId>com.google.cloud</groupId>
     <artifactId>cloud-sql-connector-parent</artifactId>
     <version>1.16.1-SNAPSHOT</version><!-- {x-version-update:cloud-sql-connector-parent:current} -->
-    <relativePath>../../pom.xml</relativePath>
+    <relativePath>../../../pom.xml</relativePath>
   </parent>
-  <artifactId>cloud-sql-connector-jdbc-mariadb</artifactId>
+  <groupId>com.google.cloud.sql</groupId>
+  <artifactId>mariadb-socket-factory</artifactId>
   <version>1.16.1-SNAPSHOT</version><!-- {x-version-update:cloud-sql-connector-jdbc-mariadb:current} -->
   <packaging>jar</packaging>
 
-  <name>Google Cloud SQL JDBC Connector for MariaDB</name>
+  <distributionManagement>
+    <relocation>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>cloud-sql-connector-jdbc-mariadb</artifactId>
+      <version>1.16.1-SNAPSHOT</version><!-- {x-version-update:cloud-sql-connector-jdbc-mariadb:current} -->
+      <message>Please use the new artifact.</message>
+    </relocation>
+  </distributionManagement>
+
+  <name>Cloud SQL MariaDB Socket Factory</name>
   <description>
-    The Cloud SQL JDBC Connector provides a socket factory for the MariaDB JDBC driver. 
-    The socket factory provides an mTLS 1.3 connection to any specified Cloud SQL 
-    MariaDB instance without requiring any manually configured TLS certificates.
+    Socket factory for the MariaDB JDBC driver that allows a user with the appropriate permissions
+    to connect to a Cloud SQL database without having to deal with IP allowlisting or SSL
+    certificates manually.
   </description>
-  <url>https://github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory</url>
 
   <properties>
     <assembly.skipAssembly>false</assembly.skipAssembly>
+    <mariadb.version>3.3.3</mariadb.version>
   </properties>
 
   <dependencies>
     <dependency>
       <groupId>com.google.cloud</groupId>
-      <artifactId>cloud-sql-connector-core</artifactId>
+      <artifactId>cloud-sql-connector-jdbc-mariadb</artifactId>
       <version>${project.parent.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.mariadb.jdbc</groupId>
-      <artifactId>mariadb-java-client</artifactId>
-      <version>3.3.3</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-api</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.truth</groupId>
-      <artifactId>truth</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.zaxxer</groupId>
-      <artifactId>HikariCP</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <!-- Logging -->
-    <dependency> 
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-classic</artifactId>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 
@@ -88,21 +66,17 @@
         <dependency>
           <groupId>org.mariadb.jdbc</groupId>
           <artifactId>mariadb-java-client</artifactId>
-          <version>3.3.3</version>
+          <version>${mariadb.version}</version>
         </dependency>
       </dependencies>
     </profile>
-    <!-- Upgrading to v0.9.12 of the native maven plugin leaves
-        provided scope dependencies out of the classpath, so adding these
-        drivers back in for the native profile is a workaround.
-    -->
     <profile>
       <id>native</id>
       <dependencies>
         <dependency>
           <groupId>org.mariadb.jdbc</groupId>
           <artifactId>mariadb-java-client</artifactId>
-          <version>3.3.3</version>
+          <version>${mariadb.version}</version>
         </dependency>
       </dependencies>
     </profile>
@@ -116,7 +90,7 @@
         <configuration>
           <usedDependencies>
             <!-- This dependency is not used at compile-time. -->
-            <dependency>ch.qos.logback:logback-classic</dependency>
+            <dependency>com.google.cloud:cloud-sql-connector-jdbc-mariadb</dependency>
           </usedDependencies>
         </configuration>
       </plugin>

--- a/wrapper/jdbc/mysql/pom.xml
+++ b/wrapper/jdbc/mysql/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- Copyright 2021 Google LLC
+ Copyright 2024 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -15,8 +15,7 @@
  limitations under the License.
 -->
 
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns="http://maven.apache.org/POM/4.0.0"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
@@ -24,57 +23,41 @@
     <groupId>com.google.cloud</groupId>
     <artifactId>cloud-sql-connector-parent</artifactId>
     <version>1.16.1-SNAPSHOT</version><!-- {x-version-update:cloud-sql-connector-parent:current} -->
-    <relativePath>../../pom.xml</relativePath>
+    <relativePath>../../../pom.xml</relativePath>
   </parent>
-
-  <artifactId>cloud-sql-connector-jdbc-mysql</artifactId>
+  <groupId>com.google.cloud.sql</groupId>
+  <artifactId>mysql-socket-factory-connector-j-8</artifactId>
   <version>1.16.1-SNAPSHOT</version><!-- {x-version-update:cloud-sql-connector-jdbc-mysql:current} -->
   <packaging>jar</packaging>
 
-  <name>Google Cloud SQL JDBC Connector for MySQL</name>
+  <distributionManagement>
+    <relocation>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>cloud-sql-connector-jdbc-mysql</artifactId>
+      <version>1.16.1-SNAPSHOT</version><!-- {x-version-update:cloud-sql-connector-jdbc-mysql:current} -->
+      <message>Please use the new artifact.</message>
+    </relocation>
+  </distributionManagement>
+
+  <name>Cloud SQL MySQL Socket Factory (for Connector/J 8.x)</name>
   <description>
-    The Cloud SQL JDBC Connector provides a socket factory for the MySQL JDBC driver. 
-    The socket factory provides an mTLS 1.3 connection to any specified Cloud SQL 
-    MySQL instance without requiring any manually configured TLS certificates.
+    Socket factory for the MySQL JDBC driver (version 8.x) that allows a user
+    with the appropriate
+    permissions to connect to a Cloud SQL database without having to deal with
+    IP allowlisting or
+    SSL certificates manually.
   </description>
-  <url>https://github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory</url>
 
   <properties>
     <assembly.skipAssembly>false</assembly.skipAssembly>
+    <mysql.version>8.3.0</mysql.version>
   </properties>
 
   <dependencies>
     <dependency>
       <groupId>com.google.cloud</groupId>
-      <artifactId>cloud-sql-connector-core</artifactId>
+      <artifactId>cloud-sql-connector-jdbc-mysql</artifactId>
       <version>${project.parent.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.mysql</groupId>
-      <artifactId>mysql-connector-j</artifactId>
-      <version>8.3.0</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.truth</groupId>
-      <artifactId>truth</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.zaxxer</groupId>
-      <artifactId>HikariCP</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <!-- Logging -->
-    <dependency> 
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-classic</artifactId>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 
@@ -85,21 +68,17 @@
         <dependency>
           <groupId>com.mysql</groupId>
           <artifactId>mysql-connector-j</artifactId>
-          <version>8.3.0</version>
+          <version>${mysql.version}</version>
         </dependency>
       </dependencies>
     </profile>
-    <!-- Upgrading to v0.9.12 of the native maven plugin leaves 
-        provided scope dependencies out of the classpath, so adding these
-        drivers back in for the native profile is a workaround.
-      -->
     <profile>
       <id>native</id>
       <dependencies>
         <dependency>
           <groupId>com.mysql</groupId>
           <artifactId>mysql-connector-j</artifactId>
-          <version>8.3.0</version>
+          <version>${mysql.version}</version>
         </dependency>
       </dependencies>
     </profile>
@@ -113,7 +92,7 @@
         <configuration>
           <usedDependencies>
             <!-- This dependency is not used at compile-time. -->
-            <dependency>ch.qos.logback:logback-classic</dependency>
+            <dependency>com.google.cloud:cloud-sql-connector-jdbc-mysql</dependency>
           </usedDependencies>
         </configuration>
       </plugin>

--- a/wrapper/jdbc/postgres/pom.xml
+++ b/wrapper/jdbc/postgres/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- Copyright 2021 Google LLC
+ Copyright 2024 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -16,67 +16,46 @@
 -->
 
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>cloud-sql-connector-parent</artifactId>
     <version>1.16.1-SNAPSHOT</version><!-- {x-version-update:cloud-sql-connector-parent:current} -->
-    <relativePath>../../pom.xml</relativePath>
+    <relativePath>../../../pom.xml</relativePath>
   </parent>
-  <artifactId>cloud-sql-connector-jdbc-postgres</artifactId>
+  <groupId>com.google.cloud.sql</groupId>
+  <artifactId>postgres-socket-factory</artifactId>
   <version>1.16.1-SNAPSHOT</version><!-- {x-version-update:cloud-sql-connector-jdbc-postgres:current} -->
   <packaging>jar</packaging>
 
-  <name>Google Cloud SQL JDBC Connector for Postgres</name>
+  <distributionManagement>
+    <relocation>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>cloud-sql-connector-jdbc-postgres</artifactId>
+      <version>1.16.1-SNAPSHOT</version><!-- {x-version-update:cloud-sql-connector-jdbc-postgres:current} -->
+      <message>Please use the new artifact.</message>
+    </relocation>
+  </distributionManagement>
+
+  <name>Cloud SQL Postgres Socket Factory</name>
   <description>
-    The Cloud SQL JDBC Connector provides a socket factory for the Postgres JDBC driver. 
-    The socket factory provides an mTLS 1.3 connection to any specified Cloud SQL 
-    Postgres instance without requiring any manually configured TLS certificates.
+    Socket factory for the Postgres JDBC driver that allows a user with the appropriate permissions
+    to connect to a Cloud SQL database without having to deal with IP allowlisting or SSL
+    certificates manually.
   </description>
-  <url>https://github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory</url>
 
   <properties>
     <assembly.skipAssembly>false</assembly.skipAssembly>
+    <postgres.version>42.7.2</postgres.version>
   </properties>
 
   <dependencies>
     <dependency>
       <groupId>com.google.cloud</groupId>
-      <artifactId>cloud-sql-connector-core</artifactId>
+      <artifactId>cloud-sql-connector-jdbc-postgres</artifactId>
       <version>${project.parent.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.postgresql</groupId>
-      <artifactId>postgresql</artifactId>
-      <version>42.7.2</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.truth</groupId>
-      <artifactId>truth</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.zaxxer</groupId>
-      <artifactId>HikariCP</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <!-- Logging -->
-    <dependency> 
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-    </dependency>
-    <dependency> 
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-classic</artifactId>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 
@@ -87,21 +66,17 @@
         <dependency>
           <groupId>org.postgresql</groupId>
           <artifactId>postgresql</artifactId>
-          <version>42.7.2</version>
+          <version>${postgres.version}</version>
         </dependency>
       </dependencies>
     </profile>
-    <!-- Upgrading to v0.9.12 of the native maven plugin leaves 
-        provided scope dependencies out of the classpath, so adding these
-        drivers back in for the native profile is a workaround.
-    -->
     <profile>
       <id>native</id>
       <dependencies>
         <dependency>
           <groupId>org.postgresql</groupId>
           <artifactId>postgresql</artifactId>
-          <version>42.7.2</version>
+          <version>${postgres.version}</version>
         </dependency>
       </dependencies>
     </profile>
@@ -115,7 +90,7 @@
         <configuration>
           <usedDependencies>
             <!-- This dependency is not used at compile-time. -->
-            <dependency>ch.qos.logback:logback-classic</dependency>
+            <dependency>com.google.cloud:cloud-sql-connector-jdbc-postgres</dependency>
           </usedDependencies>
         </configuration>
       </plugin>

--- a/wrapper/jdbc/sqlserver/pom.xml
+++ b/wrapper/jdbc/sqlserver/pom.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2024 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.google.cloud</groupId>
+    <artifactId>cloud-sql-connector-parent</artifactId>
+    <version>1.16.1-SNAPSHOT</version><!-- {x-version-update:cloud-sql-connector-parent:current} -->
+    <relativePath>../../../pom.xml</relativePath>
+  </parent>
+  <groupId>com.google.cloud.sql</groupId>
+  <artifactId>cloud-sql-connector-jdbc-sqlserver</artifactId>
+  <version>1.16.1-SNAPSHOT</version><!-- {x-version-update:cloud-sql-connector-jdbc-sqlserver:current} -->
+  <packaging>jar</packaging>
+
+  <distributionManagement>
+    <relocation>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>cloud-sql-connector-jdbc-sqlserver</artifactId>
+      <version>1.16.1-SNAPSHOT</version><!-- {x-version-update:cloud-sql-connector-jdbc-sqlserver:current} -->
+      <message>Please use the new artifact.</message>
+    </relocation>
+  </distributionManagement>
+
+  <name>Cloud SQL JDBC Connector for SQL Server</name>
+  <description>
+    Socket factory for the Microsoft JDBC Driver for SQL Server that allows a user with the
+    appropriate permissions to connect to a Cloud SQL database without having to deal with IP
+    allowlisting or SSL certificates manually.
+  </description>
+
+  <properties>
+    <assembly.skipAssembly>false</assembly.skipAssembly>
+    <sqlserver.version>12.6.1.jre8</sqlserver.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>cloud-sql-connector-jdbc-sqlserver</artifactId>
+      <version>${project.parent.version}</version>
+    </dependency>
+  </dependencies>
+
+  <profiles>
+    <profile>
+      <id>jar-with-driver-and-dependencies</id>
+      <dependencies>
+        <dependency>
+          <groupId>com.microsoft.sqlserver</groupId>
+          <artifactId>mssql-jdbc</artifactId>
+          <version>${sqlserver.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>native</id>
+      <dependencies>
+        <dependency>
+          <groupId>com.microsoft.sqlserver</groupId>
+          <artifactId>mssql-jdbc</artifactId>
+          <version>${sqlserver.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <usedDependencies>
+            <!-- This dependency is not used at compile-time. -->
+            <dependency>com.google.cloud:cloud-sql-connector-jdbc-sqlserver</dependency>
+          </usedDependencies>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/wrapper/r2dbc/core/pom.xml
+++ b/wrapper/r2dbc/core/pom.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2024 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.google.cloud</groupId>
+    <artifactId>cloud-sql-connector-parent</artifactId>
+    <version>1.16.1-SNAPSHOT</version><!-- {x-version-update:cloud-sql-connector-parent:current} -->
+    <relativePath>../../../pom.xml</relativePath>
+  </parent>
+  <groupId>com.google.cloud.sql</groupId>
+  <artifactId>cloud-sql-connector-r2dbc-core</artifactId>
+  <version>1.16.1-SNAPSHOT</version><!-- {x-version-update:cloud-sql-connector-r2dbc-core:current} -->
+  <packaging>jar</packaging>
+
+  <distributionManagement>
+    <relocation>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>cloud-sql-connector-r2dbc-core</artifactId>
+      <version>1.16.1-SNAPSHOT</version><!-- {x-version-update:cloud-sql-connector-r2dbc-core:current} -->
+      <message>Please use the new artifact.</message>
+    </relocation>
+  </distributionManagement>
+
+  <name>Cloud SQL R2DBC Connection Factory (R2DBC Core Library, don't depend on this directly)</name>
+  <description>
+    R2DBC ConnectionFactory to connect to a Cloud SQL database without having to deal with IP allowlisting or SSL
+    certificates manually.
+  </description>
+
+  <properties>
+    <assembly.skipAssembly>false</assembly.skipAssembly>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>cloud-sql-connector-r2dbc-core</artifactId>
+      <version>${project.parent.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+   <plugins>
+     <plugin>
+       <groupId>org.apache.maven.plugins</groupId>
+       <artifactId>maven-jar-plugin</artifactId>
+       <version>3.3.0</version>
+       <executions>
+         <execution>
+           <goals>
+             <goal>test-jar</goal>
+           </goals>
+         </execution>
+       </executions>
+     </plugin>
+     <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <usedDependencies>
+            <!-- This dependency is not used at compile-time. -->
+            <dependency>com.google.cloud:cloud-sql-connector-r2dbc-core</dependency>
+          </usedDependencies>
+        </configuration>
+      </plugin>
+   </plugins>
+  </build>
+
+  <repositories>
+    <repository>
+      <id>oss-sonatype-snapshots</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+
+</project>

--- a/wrapper/r2dbc/mysql/pom.xml
+++ b/wrapper/r2dbc/mysql/pom.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2024 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.google.cloud</groupId>
+    <artifactId>cloud-sql-connector-parent</artifactId>
+    <version>1.16.1-SNAPSHOT</version><!-- {x-version-update:cloud-sql-connector-parent:current} -->
+    <relativePath>../../../pom.xml</relativePath>
+  </parent>
+  <groupId>com.google.cloud.sql</groupId>
+  <artifactId>cloud-sql-connector-r2dbc-mysql</artifactId>
+  <version>1.16.1-SNAPSHOT</version><!-- {x-version-update:cloud-sql-connector-r2dbc-mysql:current} -->
+  <packaging>jar</packaging>
+
+  <distributionManagement>
+    <relocation>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>cloud-sql-connector-r2dbc-mysql</artifactId>
+      <version>1.16.1-SNAPSHOT</version><!-- {x-version-update:cloud-sql-connector-r2dbc-mysql:current} -->
+      <message>Please use the new artifact.</message>
+    </relocation>
+  </distributionManagement>
+
+  <name>Cloud SQL R2DBC Connection Factory for MySQL</name>
+  <description>
+    R2DBC ConnectionFactory to connect to a Cloud SQL MySQL database without having to deal with IP allowlisting or SSL
+    certificates manually.
+  </description>
+
+  <properties>
+    <assembly.skipAssembly>false</assembly.skipAssembly>
+    <mysql.version>1.1.1</mysql.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>cloud-sql-connector-r2dbc-mysql</artifactId>
+      <version>${project.parent.version}</version>
+    </dependency>
+  </dependencies>
+
+  <profiles>
+    <profile>
+      <id>jar-with-driver-and-dependencies</id>
+      <dependencies>
+        <dependency>
+          <groupId>io.asyncer</groupId>
+          <artifactId>r2dbc-mysql</artifactId>
+          <version>${mysql.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <usedDependencies>
+            <!-- This dependency is not used at compile-time. -->
+            <dependency>com.google.cloud:cloud-sql-connector-r2dbc-mysql</dependency>
+          </usedDependencies>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/wrapper/r2dbc/postgres/pom.xml
+++ b/wrapper/r2dbc/postgres/pom.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2024 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.google.cloud</groupId>
+    <artifactId>cloud-sql-connector-parent</artifactId>
+    <version>1.16.1-SNAPSHOT</version><!-- {x-version-update:cloud-sql-connector-parent:current} -->
+    <relativePath>../../../pom.xml</relativePath>
+  </parent>
+  <groupId>com.google.cloud.sql</groupId>
+  <artifactId>cloud-sql-connector-r2dbc-postgres</artifactId>
+  <version>1.16.1-SNAPSHOT</version><!-- {x-version-update:cloud-sql-connector-r2dbc-postgres:current} -->
+  <packaging>jar</packaging>
+
+  <distributionManagement>
+    <relocation>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>cloud-sql-connector-r2dbc-postgres</artifactId>
+      <version>1.16.1-SNAPSHOT</version><!-- {x-version-update:cloud-sql-connector-r2dbc-postgres:current} -->
+      <message>Please use the new artifact.</message>
+    </relocation>
+  </distributionManagement>
+
+  <name>Cloud SQL R2DBC Connection Factory for Postgres</name>
+  <description>
+    R2DBC ConnectionFactory to connect to a Cloud SQL Postgres database without having to deal with IP allowlisting or
+    SSL
+    certificates manually.
+  </description>
+
+  <properties>
+    <assembly.skipAssembly>false</assembly.skipAssembly>
+    <postgres.version>1.0.4.RELEASE</postgres.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>cloud-sql-connector-r2dbc-postgres</artifactId>
+      <version>${project.parent.version}</version>
+    </dependency>
+  </dependencies>
+
+  <profiles>
+    <profile>
+      <id>jar-with-driver-and-dependencies</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.postgresql</groupId>
+          <artifactId>r2dbc-postgresql</artifactId>
+          <version>${postgres.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <usedDependencies>
+            <!-- This dependency is not used at compile-time. -->
+            <dependency>com.google.cloud:cloud-sql-connector-r2dbc-postgres</dependency>
+          </usedDependencies>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/wrapper/r2dbc/sqlserver/pom.xml
+++ b/wrapper/r2dbc/sqlserver/pom.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2024 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.google.cloud</groupId>
+    <artifactId>cloud-sql-connector-parent</artifactId>
+    <version>1.16.1-SNAPSHOT</version><!-- {x-version-update:cloud-sql-connector-parent:current} -->
+    <relativePath>../../../pom.xml</relativePath>
+  </parent>
+  <groupId>com.google.cloud.sql</groupId>
+  <artifactId>cloud-sql-connector-r2dbc-sqlserver</artifactId>
+  <version>1.16.1-SNAPSHOT</version><!-- {x-version-update:cloud-sql-connector-r2dbc-sqlserver:current} -->
+  <packaging>jar</packaging>
+
+  <distributionManagement>
+    <relocation>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>cloud-sql-connector-r2dbc-sqlserver</artifactId>
+      <version>1.16.1-SNAPSHOT</version><!-- {x-version-update:cloud-sql-connector-r2dbc-sqlserver:current} -->
+      <message>Please use the new artifact.</message>
+    </relocation>
+  </distributionManagement>
+
+  <name>Cloud SQL R2DBC Connection Factory for SQL Server</name>
+  <description>
+    Connection Factory for the R2DBC Driver for SQL Server that allows a user with the
+    appropriate permissions to connect to a Cloud SQL database without having to deal with IP
+    allowlisting or SSL certificates manually.
+  </description>
+
+  <properties>
+    <assembly.skipAssembly>false</assembly.skipAssembly>
+    <sqlserver.version>1.0.2.RELEASE</sqlserver.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>cloud-sql-connector-r2dbc-sqlserver</artifactId>
+      <version>${project.parent.version}</version>
+    </dependency>
+  </dependencies>
+
+  <profiles>
+    <profile>
+      <id>jar-with-driver-and-dependencies</id>
+      <dependencies>
+        <dependency>
+          <groupId>io.r2dbc</groupId>
+          <artifactId>r2dbc-mssql</artifactId>
+          <version>${sqlserver.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <usedDependencies>
+            <!-- This dependency is not used at compile-time. -->
+            <dependency>com.google.cloud:cloud-sql-connector-r2dbc-sqlserver</dependency>
+          </usedDependencies>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>


### PR DESCRIPTION
We are renaming the Maven artifacts to establish a consistent and memorable naming convention for our libraries, making it easier for customers to remember and associate with our libraries.

Example:

```
<groupId>com.google.cloud</groupId>
<artifactId>cloud-sql-connector-jdbc-postgres</artifactId>
```

We will continue to publish artifacts with the old names that include a warning to change to the new artifact name. This way we won't leave any customers behind as part of this process. 

Example:

```
[WARNING] The artifact com.google.cloud.sql:postgres-socket-factory:jar:1.17.0 has been relocated to com.google.cloud:cloud-sql-connector-jdbc-postgres:jar:1.17.0: Please use the new artifact.
```

Fixes #1728