### PR TITLE
fix: Add scope for Credentials defined by a JSON file

### DIFF
--- a/core/src/main/java/com/google/cloud/sql/core/FileCredentialFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/core/FileCredentialFactory.java
@@ -17,11 +17,13 @@
 package com.google.cloud.sql.core;
 
 import com.google.api.client.http.HttpRequestInitializer;
+import com.google.api.services.sqladmin.SQLAdminScopes;
 import com.google.auth.http.HttpCredentialsAdapter;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.sql.CredentialFactory;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.util.Arrays;
 
 class FileCredentialFactory implements CredentialFactory {
   private final String path;
@@ -37,10 +39,19 @@ class FileCredentialFactory implements CredentialFactory {
 
   @Override
   public GoogleCredentials getCredentials() {
+    GoogleCredentials credentials;
     try {
-      return GoogleCredentials.fromStream(new FileInputStream(path));
+      credentials = GoogleCredentials.fromStream(new FileInputStream(path));
     } catch (IOException e) {
       throw new IllegalStateException("Unable to load GoogleCredentials from file " + path, e);
     }
+
+    if (credentials.createScopedRequired()) {
+      credentials =
+          credentials.createScoped(
+              Arrays.asList(SQLAdminScopes.SQLSERVICE_ADMIN, SQLAdminScopes.CLOUD_PLATFORM));
+    }
+
+    return credentials;
   }
 }


### PR DESCRIPTION
The OAuth scopes for [Cloud SQL Admin API](https://developers.google.com/identity/protocols/oauth2/scopes#sqladmin) should be set for the credentials defined by a JSON file as we do for the [Default Credentials](https://github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory/blob/main/core/src/main/java/com/google/cloud/sql/core/ApplicationDefaultCredentialFactory.java#L49).

Fixes #1904