### PR TITLE
chore(deps): Update deps guava and google-api-client to the latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,12 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>33.0.0-android</version>
+        <version>33.1.0-android</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.j2objc</groupId>
+        <artifactId>j2objc-annotations</artifactId>
+        <version>3.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
@@ -139,7 +144,7 @@
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client</artifactId>
-        <version>2.3.0</version>
+        <version>2.4.0</version>
       </dependency>
       <dependency>
         <groupId>com.google.apis</groupId>


### PR DESCRIPTION
Updated the following dependencies:

* `com.google.guava:guava` to `v33.1.0-android`
* `com.google.api-client:google-api-client` to `v2.4.0`

Added `com.google.j2objc:j2objc-annotations` to `<dependencyManagement>` to use the newest version to fix this error:

```
Error:  Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.4.1:enforce (enforce) on project jdbc-socket-factory-core: 
Error:  Rule 0: org.apache.maven.enforcer.rules.dependency.DependencyConvergence failed with message:
Error:  Failed while enforcing releasability.
Error:  
Error:  Dependency convergence error for com.google.j2objc:j2objc-annotations:jar:2.8 paths to dependency are:
Error:  +-com.google.cloud.sql:jdbc-socket-factory-core:jar:1.17.1-SNAPSHOT
Error:    +-com.google.http-client:google-http-client:jar:1.44.1:compile
Error:      +-com.google.j2objc:j2objc-annotations:jar:2.8:compile
Error:  and
Error:  +-com.google.cloud.sql:jdbc-socket-factory-core:jar:1.17.1-SNAPSHOT
Error:    +-com.google.guava:guava:jar:33.1.0-android:compile
Error:      +-com.google.j2objc:j2objc-annotations:jar:3.0.0:compile
Error:  
Error:  Rule 3: org.apache.maven.enforcer.rules.dependency.RequireUpperBoundDeps failed with message:
Error:  Failed while enforcing RequireUpperBoundDeps. The error(s) are [
Error:  Require upper bound dependencies error for com.google.j2objc:j2objc-annotations:2.8 paths to dependency are:
Error:  +-com.google.cloud.sql:jdbc-socket-factory-core:1.17.1-SNAPSHOT
Error:    +-com.google.http-client:google-http-client:1.44.1
Error:      +-com.google.j2objc:j2objc-annotations:2.8
Error:  and
Error:  +-com.google.cloud.sql:jdbc-socket-factory-core:1.17.1-SNAPSHOT
Error:    +-com.google.guava:guava:33.1.0-android
Error:      +-com.google.j2objc:j2objc-annotations:3.0.0
Error:  ]
```