### PR TITLE
chore: Update GAX dependency scope to provided.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -132,11 +132,12 @@
     </dependency>
     <!-- GAX provides native-image metadata for core Google libraries, such as
       Google API Client and Google HTTP Client. Users' GraalVM native image
-      compilation needs the metadata. Therefore, this is not part of a profile
-      or provided-scope. -->
+      compilation needs the metadata. The provided-scope dependencies do not add
+      additional dependencies to library users. -->
     <dependency>
       <groupId>com.google.api</groupId>
       <artifactId>gax</artifactId>
+      <scope>provided</scope>
       <exclusions>
         <!-- Native image users only need GAX's native-image metadata. GAX's
         dependencies are unnecessary for normal users and native image users -->


### PR DESCRIPTION
Update GAX dependency scope to `provided` as it is only required for GraalVM support.

Related to #1921 