### PR TITLE
chore: pare down test size

### DIFF
--- a/.github/scripts/run_tests.sh
+++ b/.github/scripts/run_tests.sh
@@ -16,11 +16,6 @@
 # `-e` enables the script to automatically fail when a command fails
 set -e
 
-function setJava() {
-  export JAVA_HOME=$1
-  export PATH=${JAVA_HOME}/bin:$PATH
-}
-
 if [[ $OSTYPE == 'darwin'* ]]; then
   # Add alias for 127.0.0.2 to be used as a loopback address
   # https://superuser.com/questions/458875/how-do-you-get-loopback-addresses-other-than-127-0-0-1-to-work-on-os-x
@@ -28,35 +23,27 @@ if [[ $OSTYPE == 'darwin'* ]]; then
 fi
 
 echo -e "******************** Running tests... ********************\n"
-# unit-e2e-java8 uses both JDK 11 and JDK 8. GraalVM dependencies require JDK 11 to
-# compile the classes touching GraalVM classes.
-if [ ! -z "${JAVA11_HOME}" ]; then
-  setJava "${JAVA11_HOME}"
-fi
-
-echo "Compiling using Java:"
-java -version
-echo
-
-mvn clean install -e -B  -ntp -DskipTests -Dcheckstyle.skip
-
-# We ensure the generated class files are compatible with Java 8
-if [ ! -z "${JAVA8_HOME}" ]; then
-  setJava "${JAVA8_HOME}"
-fi
-
-if [ "${GITHUB_JOB}" == "units-java8" ]; then
-  java -version 2>&1 | grep -q 'openjdk version "1.8.'
-  MATCH=$? # 0 if the output has the match
-  if [ "$MATCH" != "0" ]; then
-    echo "Please specify JDK 8 for Java 8 tests"
-    exit 1
-  fi
-fi
-
 echo "Running tests using Java:"
 java -version
 
 echo "Maven version: $(mvn --version)"
-mvn -e -B  -ntp  verify -P e2e -P coverage -Dcheckstyle.skip
+
+echo "Job type: ${JOB_TYPE}"
+
+RETURN_CODE=0
+set +e
+
+case ${JOB_TYPE} in
+test)
+    mvn -e -B clean -ntp test -P coverage -Dcheckstyle.skip
+    RETURN_CODE=$?
+    ;;
+integration)
+    mvn -e -B clean -ntp verify -P e2e -P coverage -Dcheckstyle.skip
+    RETURN_CODE=$?
+    ;;
+esac
+
 echo -e "******************** Tests complete.  ********************\n"
+echo "exiting with ${RETURN_CODE}"
+exit ${RETURN_CODE}

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -41,11 +41,17 @@ branchProtectionRules:
   requiresStrictStatusChecks: true
   # List of required status check contexts that must pass for commits to be accepted to matching branches.
   requiredStatusCheckContexts:
-  - "dependencies (11)"
   - "lint"
-  - "units (8)"
-  - "units (11)"
-  - "units + e2e"
+  - "unit tests (macos-latest, 8)"
+  - "unit tests (macos-latest, 11)"
+  - "unit tests (macos-latest, 17)"
+  - "unit tests (windows-latest, 8)"
+  - "unit tests (windows-latest, 11)"
+  - "unit tests (windows-latest, 17)"
+  - "unit tests (ubuntu-latest, 8)"
+  - "unit tests (ubuntu-latest, 11)"
+  - "unit tests (ubuntu-latest, 17)"
+  - "units + e2e (ubuntu-latest, 17)"
   - "cla/google"
   # Wait until we make the repo public before bringing this back
   # - "OwlBot Post Processor"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,15 +27,15 @@ on:
 permissions: read-all
 
 jobs:
-  unit-e2e:
+  units:
     # run job on proper workflow event triggers (skip job for pull_request event from forks and only run pull_request_target for "tests: run" label)
     if: "${{ (github.event.action != 'labeled' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name) || github.event.label.name == 'tests: run' }}"
-    name: unit + e2e
+    name: unit tests
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ macos-latest, windows-latest, ubuntu-latest ]
-        java-version: [ "11", "17" ]
+        java-version: [ "8", "11", "17" ]
       fail-fast: false
     permissions:
       contents: 'read'
@@ -122,6 +122,7 @@ jobs:
         SQLSERVER_DB: '${{ steps.secrets.outputs.SQLSERVER_DB }}'
         IMPERSONATED_USER: '${{ steps.secrets.outputs.IMPERSONATED_USER }}'
         QUOTA_PROJECT: '${{ steps.secrets.outputs.QUOTA_PROJECT }}'
+        JOB_TYPE: test
       run: ./.github/scripts/run_tests.sh
       shell: bash
     - name: Check Coverage
@@ -147,14 +148,15 @@ jobs:
         curl https://github.com/googleapis/repo-automation-bots/releases/download/flakybot-1.1.0/flakybot-darwin-amd64 -o flakybot -s -L
         chmod +x ./flakybot
         ./flakybot --repo ${{github.repository}} --commit_hash ${{github.sha}} --build_url https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
-  unit-e2e-java8:
+  unit-e2e:
     # run job on proper workflow event triggers (skip job for pull_request event from forks and only run pull_request_target for "tests: run" label)
     if: "${{ (github.event.action != 'labeled' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name) || github.event.label.name == 'tests: run' }}"
-    name: unit + e2e java8
+    name: units + e2e
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ macos-latest, windows-latest, ubuntu-latest ]
+        os: [ ubuntu-latest ]
+        java-version: [ "17" ]
       fail-fast: false
     permissions:
       contents: 'read'
@@ -184,23 +186,11 @@ jobs:
         ref: ${{ github.event.pull_request.head.sha }}
         repository: ${{ github.event.pull_request.head.repo.full_name }}
 
-    # Set up Java 8 for testing
-    - name: Set up JDK 8
+    - name: Set up JDK
       uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
       with:
         distribution: 'zulu'
-        java-version: '8'
-    - run: echo "JAVA8_HOME=${JAVA_HOME}" >> $GITHUB_ENV
-      shell: bash
-
-    # Set up Java 11 for compilation
-    - name: Set up JDK 11
-      uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
-      with:
-        distribution: 'zulu'
-        java-version: '11'
-    - run: echo "JAVA11_HOME=${JAVA_HOME}" >> $GITHUB_ENV
-      shell: bash
+        java-version: ${{matrix.java-version}}
 
     - id: 'auth'
       name: Authenticate to Google Cloud
@@ -253,6 +243,7 @@ jobs:
         SQLSERVER_DB: '${{ steps.secrets.outputs.SQLSERVER_DB }}'
         IMPERSONATED_USER: '${{ steps.secrets.outputs.IMPERSONATED_USER }}'
         QUOTA_PROJECT: '${{ steps.secrets.outputs.QUOTA_PROJECT }}'
+        JOB_TYPE: integration
       run: ./.github/scripts/run_tests.sh
       shell: bash
     - name: Check Coverage

--- a/pom.xml
+++ b/pom.xml
@@ -683,6 +683,10 @@
                   -J-Xbootclasspath/p:${settings.localRepository}/com/google/errorprone/javac/${javac.version}/javac-${javac.version}.jar
                 </arg>
               </compilerArgs>
+              <excludes>
+                <!-- Native image does not support Java 8 -->
+                <exclude>com/google/cloud/sql/nativeimage/*</exclude>
+              </excludes>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION
Integration runs on latest Java version on Linux. Units run on Java 8, 11, 17 versions on Linux, Windows, and macOS. We don't have integration test support for multiple OSes, so we lean on unit tests there.

Fixes #1877