### PR TITLE
fix: Set Artifact ID using the static method.

### DIFF
--- a/core/src/main/java/com/google/cloud/sql/ConnectorRegistry.java
+++ b/core/src/main/java/com/google/cloud/sql/ConnectorRegistry.java
@@ -64,6 +64,6 @@ public final class ConnectorRegistry {
    * @throws IllegalStateException if the SQLAdmin client has already been initialized
    */
   public static void addArtifactId(String artifactId) {
-    InternalConnectorRegistry.getInstance().addArtifactId(artifactId);
+    InternalConnectorRegistry.addArtifactId(artifactId, false);
   }
 }

--- a/core/src/main/java/com/google/cloud/sql/core/InternalConnectorRegistry.java
+++ b/core/src/main/java/com/google/cloud/sql/core/InternalConnectorRegistry.java
@@ -231,14 +231,31 @@ public final class InternalConnectorRegistry {
    * Internal use only: Sets the default string which is appended to the SQLAdmin API client
    * User-Agent header.
    *
-   * <p>This is used by the specific database connector socket factory implementations to append
-   * their database name to the user agent.
+   * @param artifactId is the Artifact ID.
+   * @param addVersion whether the version should be appended to the ID.
    */
-  public static void addArtifactId(String artifactId) {
-    String userAgent = artifactId + "/" + version;
+  public static void addArtifactId(String artifactId, boolean addVersion) {
+    String userAgent = artifactId;
+
+    if (addVersion) {
+      userAgent += "/" + version;
+    }
     if (!userAgents.contains(userAgent)) {
       userAgents.add(userAgent);
     }
+  }
+
+  /**
+   * Internal use only: Sets the default string which is appended to the SQLAdmin API client
+   * User-Agent header.
+   *
+   * <p>This is used by the specific database connector socket factory implementations to append
+   * their database name to the user agent. The version is appended to the ID.
+   *
+   * @param artifactId is the Artifact ID.
+   */
+  public static void addArtifactId(String artifactId) {
+    addArtifactId(artifactId, true);
   }
 
   /** Resets the values of User Agent fields for unit tests. */


### PR DESCRIPTION
The following issue was reported in https://github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/2773:

the warning `Application name is not set. Call Builder#setApplicationName.` is logged by `com.google.api.client.googleapis.services.AbstractGoogleClient` when `using com.google.cloud:spring-cloud-gcp-starter-sql-postgresql`

The issue was caused by setting the Artifact ID using the instance method instead of the static one. Additionally, the library version was added to the Artifact ID by default, resulting in user agents like `spring-cloud-gcp-sql/5.1.2/1.17.2-SNAPSHOT mysql-socket-factory-connector-j-8/1.17.2-SNAPSHOT`. This issue has been fixed.
