### PR TITLE
chore: fix JDBC readme SQL Server dependency

### DIFF
--- a/docs/jdbc.md
+++ b/docs/jdbc.md
@@ -82,7 +82,7 @@ Maven
 ```maven-pom
 <dependency>
     <groupId>com.google.cloud.sql</groupId>
-    <artifactId>postgres-socket-factory</artifactId>
+    <artifactId>cloud-sql-connector-jdbc-sqlserver</artifactId>
     <version>1.17.1</version>
 </dependency>
 ```


### PR DESCRIPTION
JDBC README shows incorrect dependency for SQL Server usage.

I believe it should be `cloud-sql-connector-jdbc-sqlserver`?