### PR TITLE
chore: Add refreshStrategy connector configuration (part of #992)

### DIFF
--- a/core/src/main/java/com/google/cloud/sql/ConnectorConfig.java
+++ b/core/src/main/java/com/google/cloud/sql/ConnectorConfig.java
@@ -38,6 +38,8 @@ public class ConnectorConfig {
   private final String adminQuotaProject;
   private final String universeDomain;
 
+  private final RefreshStrategy refreshStrategy;
+
   private ConnectorConfig(
       String targetPrincipal,
       List<String> delegates,
@@ -47,7 +49,8 @@ public class ConnectorConfig {
       GoogleCredentials googleCredentials,
       String googleCredentialsPath,
       String adminQuotaProject,
-      String universeDomain) {
+      String universeDomain,
+      RefreshStrategy refreshStrategy) {
     this.targetPrincipal = targetPrincipal;
     this.delegates = delegates;
     this.adminRootUrl = adminRootUrl;
@@ -57,6 +60,7 @@ public class ConnectorConfig {
     this.googleCredentialsPath = googleCredentialsPath;
     this.adminQuotaProject = adminQuotaProject;
     this.universeDomain = universeDomain;
+    this.refreshStrategy = refreshStrategy;
   }
 
   @Override
@@ -76,7 +80,8 @@ public class ConnectorConfig {
         && Objects.equal(googleCredentials, that.googleCredentials)
         && Objects.equal(googleCredentialsPath, that.googleCredentialsPath)
         && Objects.equal(adminQuotaProject, that.adminQuotaProject)
-        && Objects.equal(universeDomain, that.universeDomain);
+        && Objects.equal(universeDomain, that.universeDomain)
+        && Objects.equal(refreshStrategy, that.refreshStrategy);
   }
 
   @Override
@@ -90,7 +95,8 @@ public class ConnectorConfig {
         googleCredentials,
         googleCredentialsPath,
         adminQuotaProject,
-        universeDomain);
+        universeDomain,
+        refreshStrategy);
   }
 
   public String getTargetPrincipal() {
@@ -129,6 +135,10 @@ public class ConnectorConfig {
     return universeDomain;
   }
 
+  public RefreshStrategy getRefreshStrategy() {
+    return refreshStrategy;
+  }
+
   /** The builder for the ConnectionConfig. */
   public static class Builder {
 
@@ -141,6 +151,7 @@ public class ConnectorConfig {
     private String googleCredentialsPath;
     private String adminQuotaProject;
     private String universeDomain;
+    private RefreshStrategy refreshStrategy = RefreshStrategy.BACKGROUND;
 
     public Builder withTargetPrincipal(String targetPrincipal) {
       this.targetPrincipal = targetPrincipal;
@@ -188,6 +199,11 @@ public class ConnectorConfig {
       return this;
     }
 
+    public Builder withRefreshStrategy(RefreshStrategy refreshStrategy) {
+      this.refreshStrategy = refreshStrategy;
+      return this;
+    }
+
     /** Builds a new instance of {@code ConnectionConfig}. */
     public ConnectorConfig build() {
       // validate only one GoogleCredentials configuration field set
@@ -221,7 +237,8 @@ public class ConnectorConfig {
           googleCredentials,
           googleCredentialsPath,
           adminQuotaProject,
-          universeDomain);
+          universeDomain,
+          refreshStrategy);
     }
   }
 }

--- a/core/src/main/java/com/google/cloud/sql/RefreshStrategy.java
+++ b/core/src/main/java/com/google/cloud/sql/RefreshStrategy.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.sql;
+
+/** Enum for supported refresh strategies. */
+public enum RefreshStrategy {
+  BACKGROUND,
+  LAZY
+}

--- a/core/src/main/java/com/google/cloud/sql/core/ConnectionConfig.java
+++ b/core/src/main/java/com/google/cloud/sql/core/ConnectionConfig.java
@@ -19,6 +19,7 @@ package com.google.cloud.sql.core;
 import com.google.cloud.sql.AuthType;
 import com.google.cloud.sql.ConnectorConfig;
 import com.google.cloud.sql.IpType;
+import com.google.cloud.sql.RefreshStrategy;
 import com.google.common.base.Splitter;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -41,6 +42,7 @@ public class ConnectionConfig {
   public static final String CLOUD_SQL_TARGET_PRINCIPAL_PROPERTY = "cloudSqlTargetPrincipal";
   public static final String CLOUD_SQL_ADMIN_ROOT_URL_PROPERTY = "cloudSqlAdminRootUrl";
   public static final String CLOUD_SQL_ADMIN_SERVICE_PATH_PROPERTY = "cloudSqlAdminServicePath";
+  public static final String CLOUD_SQL_REFRESH_STRATEGY_PROPERTY = "cloudSqlRefreshStrategy";
   public static final String UNIX_SOCKET_PROPERTY = "unixSocketPath";
   public static final String UNIX_SOCKET_PATH_SUFFIX_PROPERTY = "cloudSqlUnixSocketPathSuffix";
   public static final String ENABLE_IAM_AUTH_PROPERTY = "enableIamAuth";
@@ -97,6 +99,12 @@ public class ConnectionConfig {
     final String adminQuotaProject =
         props.getProperty(ConnectionConfig.CLOUD_SQL_ADMIN_QUOTA_PROJECT_PROPERTY);
     final String universeDomain = props.getProperty(ConnectionConfig.CLOUD_SQL_UNIVERSE_DOMAIN);
+    final String refreshStrategyStr =
+        props.getProperty(ConnectionConfig.CLOUD_SQL_REFRESH_STRATEGY_PROPERTY);
+    final RefreshStrategy refreshStrategy =
+        "lazy".equalsIgnoreCase(refreshStrategyStr)
+            ? RefreshStrategy.LAZY
+            : RefreshStrategy.BACKGROUND;
 
     return new ConnectionConfig(
         csqlInstanceName,
@@ -113,6 +121,7 @@ public class ConnectionConfig {
             .withGoogleCredentialsPath(googleCredentialsPath)
             .withAdminQuotaProject(adminQuotaProject)
             .withUniverseDomain(universeDomain)
+            .withRefreshStrategy(refreshStrategy)
             .build());
   }
 

--- a/core/src/test/java/com/google/cloud/sql/ConnectorConfigTest.java
+++ b/core/src/test/java/com/google/cloud/sql/ConnectorConfigTest.java
@@ -88,6 +88,26 @@ public class ConnectorConfigTest {
   }
 
   @Test
+  public void testBuild_withRefreshStrategyDefault() {
+    ConnectorConfig cc = new ConnectorConfig.Builder().build();
+    assertThat(cc.getRefreshStrategy()).isEqualTo(RefreshStrategy.BACKGROUND);
+  }
+
+  @Test
+  public void testBuild_withRefreshStrategyBackground() {
+    ConnectorConfig cc =
+        new ConnectorConfig.Builder().withRefreshStrategy(RefreshStrategy.BACKGROUND).build();
+    assertThat(cc.getRefreshStrategy()).isEqualTo(RefreshStrategy.BACKGROUND);
+  }
+
+  @Test
+  public void testBuild_withRefreshStrategyLazy() {
+    ConnectorConfig cc =
+        new ConnectorConfig.Builder().withRefreshStrategy(RefreshStrategy.LAZY).build();
+    assertThat(cc.getRefreshStrategy()).isEqualTo(RefreshStrategy.LAZY);
+  }
+
+  @Test
   public void testBuild_failsWhenAdminAPIAndUniverseDomainAreSet() {
     final String wantAdminRootUrl = "https://googleapis.example.com/";
     final String wantUniverseDomain = "test-universe.test";
@@ -156,6 +176,28 @@ public class ConnectorConfigTest {
         new ConnectorConfig.Builder().withAdminRootUrl("http://example.com/1").build();
     ConnectorConfig k2 =
         new ConnectorConfig.Builder().withAdminRootUrl("http://example.com/1").build();
+
+    assertThat(k1).isEqualTo(k2);
+    assertThat(k1.hashCode()).isEqualTo(k2.hashCode());
+  }
+
+  @Test
+  public void testNotEqual_withRefreshStrategyNotEqual() {
+    ConnectorConfig k1 =
+        new ConnectorConfig.Builder().withRefreshStrategy(RefreshStrategy.LAZY).build();
+    ConnectorConfig k2 =
+        new ConnectorConfig.Builder().withRefreshStrategy(RefreshStrategy.BACKGROUND).build();
+
+    assertThat(k1).isNotEqualTo(k2);
+    assertThat(k1.hashCode()).isNotEqualTo(k2.hashCode());
+  }
+
+  @Test
+  public void testEqual_withRefreshStrategyEqual() {
+    ConnectorConfig k1 =
+        new ConnectorConfig.Builder().withRefreshStrategy(RefreshStrategy.LAZY).build();
+    ConnectorConfig k2 =
+        new ConnectorConfig.Builder().withRefreshStrategy(RefreshStrategy.LAZY).build();
 
     assertThat(k1).isEqualTo(k2);
     assertThat(k1.hashCode()).isEqualTo(k2.hashCode());
@@ -360,6 +402,7 @@ public class ConnectorConfigTest {
     final String wantAdminServicePath = "sqladmin/";
     final String wantGoogleCredentialsPath = "/path/to/credentials";
     final String wantAdminQuotaProject = "myNewProject";
+    final RefreshStrategy wantRefreshStrategy = RefreshStrategy.LAZY;
     ConnectorConfig cc =
         new ConnectorConfig.Builder()
             .withTargetPrincipal(wantTargetPrincipal)
@@ -368,6 +411,7 @@ public class ConnectorConfigTest {
             .withAdminServicePath(wantAdminServicePath)
             .withGoogleCredentialsPath(wantGoogleCredentialsPath)
             .withAdminQuotaProject(wantAdminQuotaProject)
+            .withRefreshStrategy(wantRefreshStrategy)
             .build();
 
     assertThat(cc.hashCode())
@@ -381,6 +425,8 @@ public class ConnectorConfigTest {
                 null, // googleCredentials
                 wantGoogleCredentialsPath,
                 wantAdminQuotaProject,
-                null)); // universeDomain
+                null, // universeDomain
+                wantRefreshStrategy // refreshStrategy
+                ));
   }
 }

--- a/core/src/test/java/com/google/cloud/sql/core/ConnectionConfigTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/ConnectionConfigTest.java
@@ -21,6 +21,7 @@ import static com.google.common.truth.Truth.assertThat;
 import com.google.cloud.sql.AuthType;
 import com.google.cloud.sql.ConnectorConfig;
 import com.google.cloud.sql.IpType;
+import com.google.cloud.sql.RefreshStrategy;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
@@ -46,6 +47,8 @@ public class ConnectionConfigTest {
     final String wantUnixSuffix = ".psql.5432";
     final String wantPath = "my-path";
     final String wantAdminQuotaProject = "myNewProject";
+    final String propRefreshStrategy = "Lazy";
+    final RefreshStrategy wantRefreshStrategy = RefreshStrategy.LAZY;
 
     Properties props = new Properties();
     props.setProperty(ConnectionConfig.CLOUD_SQL_INSTANCE_PROPERTY, wantCsqlInstance);
@@ -61,6 +64,7 @@ public class ConnectionConfigTest {
     props.setProperty(ConnectionConfig.CLOUD_SQL_GOOGLE_CREDENTIALS_PATH, wantPath);
     props.setProperty(
         ConnectionConfig.CLOUD_SQL_ADMIN_QUOTA_PROJECT_PROPERTY, wantAdminQuotaProject);
+    props.setProperty(ConnectionConfig.CLOUD_SQL_REFRESH_STRATEGY_PROPERTY, propRefreshStrategy);
 
     ConnectionConfig c = ConnectionConfig.fromConnectionProperties(props);
 
@@ -76,6 +80,7 @@ public class ConnectionConfigTest {
     assertThat(c.getConnectorConfig().getGoogleCredentialsPath()).isEqualTo(wantPath);
     assertThat(c.getConnectorConfig().getAdminQuotaProject()).isEqualTo(wantAdminQuotaProject);
     assertThat(c.getUnixSocketPathSuffix()).isEqualTo(wantUnixSuffix);
+    assertThat(c.getConnectorConfig().getRefreshStrategy()).isEqualTo(wantRefreshStrategy);
   }
 
   @Test

--- a/r2dbc/core/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProvider.java
+++ b/r2dbc/core/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProvider.java
@@ -23,6 +23,7 @@ import static io.r2dbc.spi.ConnectionFactoryOptions.PROTOCOL;
 
 import com.google.cloud.sql.AuthType;
 import com.google.cloud.sql.ConnectorConfig;
+import com.google.cloud.sql.RefreshStrategy;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.ConnectionFactoryOptions;
@@ -51,6 +52,8 @@ public abstract class GcpConnectionFactoryProvider implements ConnectionFactoryP
   public static final Option<String> UNIVERSE_DOMAIN = Option.valueOf("UNIVERSE_DOMAIN");
   public static final Option<String> GOOGLE_CREDENTIALS_PATH =
       Option.valueOf("GOOGLE_CREDENTIALS_PATH");
+
+  public static final Option<String> REFRESH_STRATEGY = Option.valueOf("REFRESH_STRATEGY");
 
   /**
    * Creates a ConnectionFactory that creates an SSL connection over a TCP socket, using
@@ -116,6 +119,10 @@ public abstract class GcpConnectionFactoryProvider implements ConnectionFactoryP
     final String googleCredentialsPath =
         (String) connectionFactoryOptions.getValue(GOOGLE_CREDENTIALS_PATH);
     final String universeDomain = (String) connectionFactoryOptions.getValue(UNIVERSE_DOMAIN);
+    final RefreshStrategy refreshStrategy =
+        "lazy".equalsIgnoreCase((String) connectionFactoryOptions.getValue(REFRESH_STRATEGY))
+            ? RefreshStrategy.LAZY
+            : RefreshStrategy.BACKGROUND;
 
     Builder optionBuilder = createBuilder(connectionFactoryOptions);
     String cloudSqlInstance = (String) connectionFactoryOptions.getRequiredValue(HOST);
@@ -134,6 +141,7 @@ public abstract class GcpConnectionFactoryProvider implements ConnectionFactoryP
                     .withAdminQuotaProject(adminQuotaProject)
                     .withGoogleCredentialsPath(googleCredentialsPath)
                     .withUniverseDomain(universeDomain)
+                    .withRefreshStrategy(refreshStrategy)
                     .build())
             .build();
     // Precompute SSL Data to trigger the initial refresh to happen immediately,


### PR DESCRIPTION
This adds the new JDBC and R2DBC configuration property `refreshStrategy` with valid values `lazy` or `background`. 
For R2DBC, the configuration option is named 'REFRESH_STRATEGY' to match formatting of the 
other configuration options. 

Part of #992.