### PR TITLE
chore: Add synchronous operation to DefaultConnectionInfoRepository (part of #992)

### DIFF
--- a/core/src/main/java/com/google/cloud/sql/core/ConnectionInfoRepository.java
+++ b/core/src/main/java/com/google/cloud/sql/core/ConnectionInfoRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -30,4 +30,10 @@ interface ConnectionInfoRepository {
       AuthType authType,
       ListeningScheduledExecutorService executor,
       ListenableFuture<KeyPair> keyPair);
+
+  ConnectionInfo getConnectionInfoSync(
+      CloudSqlInstanceName instanceName,
+      AccessTokenSupplier accessTokenSupplier,
+      AuthType authType,
+      KeyPair keyPair);
 }

--- a/core/src/test/java/com/google/cloud/sql/core/StubConnectionInfoRepository.java
+++ b/core/src/test/java/com/google/cloud/sql/core/StubConnectionInfoRepository.java
@@ -31,7 +31,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import javax.net.ssl.KeyManagerFactory;
 
 class StubConnectionInfoRepository implements ConnectionInfoRepository {
-  private AtomicInteger refreshCount = new AtomicInteger();
+  private final AtomicInteger refreshCount = new AtomicInteger();
 
   int getRefreshCount() {
     return refreshCount.get();
@@ -60,5 +60,15 @@ class StubConnectionInfoRepository implements ConnectionInfoRepository {
     refreshCount.incrementAndGet();
     ConnectionInfo connectionInfo = newConnectionInfo();
     return Futures.immediateFuture(connectionInfo);
+  }
+
+  @Override
+  public ConnectionInfo getConnectionInfoSync(
+      CloudSqlInstanceName instanceName,
+      AccessTokenSupplier accessTokenSupplier,
+      AuthType authType,
+      KeyPair keyPair) {
+    refreshCount.incrementAndGet();
+    return newConnectionInfo();
   }
 }

--- a/core/src/test/java/com/google/cloud/sql/core/TestDataSupplier.java
+++ b/core/src/test/java/com/google/cloud/sql/core/TestDataSupplier.java
@@ -86,4 +86,18 @@ class TestDataSupplier implements ConnectionInfoRepository {
 
     return f;
   }
+
+  @Override
+  public ConnectionInfo getConnectionInfoSync(
+      CloudSqlInstanceName instanceName,
+      AccessTokenSupplier accessTokenSupplier,
+      AuthType authType,
+      KeyPair keyPair) {
+    int c = counter.incrementAndGet();
+    if (flaky && c % 2 == 0) {
+      throw new RuntimeException("Flaky");
+    }
+    successCounter.incrementAndGet();
+    return null;
+  }
 }


### PR DESCRIPTION
Adds a new method ConnectionInfoRepository.getConnectorInfoSync() which blocks until it can return a valid 
ConnectorInfo. Adds the implementation of this new method to DefaultConnectionInfoRepository.  This is used 
by the LazyRefresher to fetch connection info on the active thread.  

Part of Lazy Refresh #992.