### PR TITLE
fix: Remove native image flag that breaks GraalVM CE builds.

### DIFF
--- a/core/src/main/resources/META-INF/native-image/com.google.cloud.sql/cloud-sql-jdbc-socket-factory-parent/native-image.properties
+++ b/core/src/main/resources/META-INF/native-image/com.google.cloud.sql/cloud-sql-jdbc-socket-factory-parent/native-image.properties
@@ -1,7 +1,6 @@
 Args =\
   -H:+UnlockExperimentalVMOptions \
   -H:+AddAllCharsets \
-  -H:+BuildReport \
   -H:ReflectionConfigurationResources=META-INF/native-image/com.google.cloud.sql/cloud-sql-jdbc-socket-factory-parent/jni-unix-socket-config.json \
   -H:ResourceConfigurationResources=META-INF/native-image/com.google.cloud.sql/cloud-sql-jdbc-socket-factory-parent/resource-config.json \
   -H:DynamicProxyConfigurationResources=META-INF/native-image/com.google.cloud.sql/cloud-sql-jdbc-socket-factory-parent/proxy-config.json \


### PR DESCRIPTION
Removes the -H:+BuildReport flag from the native image module configuration. This will allow builds
on GraalVM CE to run successfully.

Fixes #1979 