### PR TITLE
fix: Add TrustManagerFactory workaround for Conscrypt bug

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -229,5 +229,23 @@
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>google-conscript</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.conscrypt</groupId>
+          <artifactId>conscrypt-openjdk-uber</artifactId>
+          <version>2.5.2</version>
+        </dependency>
+        <dependency>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcpkix-jdk15on</artifactId>
+          <version>1.70</version>
+          <scope>provided</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
 
 </project>

--- a/core/src/main/java/com/google/cloud/sql/core/ConscryptWorkaroundDelegatingTrustManger.java
+++ b/core/src/main/java/com/google/cloud/sql/core/ConscryptWorkaroundDelegatingTrustManger.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.sql.core;
+
+import java.net.Socket;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.X509ExtendedTrustManager;
+
+/**
+ * This is a workaround for a known bug in Conscrypt crypto in how it handles X509 auth type.
+ * OpenJDK interpres the X509 certificate auth type as "UNKNOWN" while Conscrypt interpret the same
+ * certificate as auth type "GENERIC". This incompatibility causes problems in the JDK.
+ *
+ * <p>This adapter works around the issue by creating wrappers around all TrustManager instances. It
+ * replaces "GENERIC" auth type with "UNKNOWN" auth type before delegating calls.
+ *
+ * <p>See https://github.com/google/conscrypt/issues/1033#issuecomment-982701272
+ */
+class ConscryptWorkaroundDelegatingTrustManger extends X509ExtendedTrustManager {
+  private final X509ExtendedTrustManager tm;
+
+  ConscryptWorkaroundDelegatingTrustManger(X509ExtendedTrustManager tm) {
+    this.tm = tm;
+  }
+
+  @Override
+  public void checkClientTrusted(X509Certificate[] chain, String authType, Socket socket)
+      throws CertificateException {
+    tm.checkClientTrusted(chain, fixAuthType(authType), socket);
+  }
+
+  @Override
+  public void checkClientTrusted(X509Certificate[] chain, String authType, SSLEngine engine)
+      throws CertificateException {
+    tm.checkClientTrusted(chain, fixAuthType(authType), engine);
+  }
+
+  @Override
+  public void checkClientTrusted(X509Certificate[] chain, String authType)
+      throws CertificateException {
+    tm.checkClientTrusted(chain, fixAuthType(authType));
+  }
+
+  @Override
+  public void checkServerTrusted(X509Certificate[] chain, String authType, Socket socket)
+      throws CertificateException {
+    tm.checkServerTrusted(chain, fixAuthType(authType), socket);
+  }
+
+  @Override
+  public void checkServerTrusted(X509Certificate[] chain, String authType, SSLEngine engine)
+      throws CertificateException {
+    tm.checkServerTrusted(chain, fixAuthType(authType), engine);
+  }
+
+  @Override
+  public void checkServerTrusted(X509Certificate[] chain, String authType)
+      throws CertificateException {
+    tm.checkServerTrusted(chain, fixAuthType(authType));
+  }
+
+  @Override
+  public X509Certificate[] getAcceptedIssuers() {
+    return tm.getAcceptedIssuers();
+  }
+
+  private String fixAuthType(String authType) {
+    if ("GENERIC".equals(authType)) {
+      return "UNKNOWN";
+    }
+    return authType;
+  }
+}

--- a/core/src/main/java/com/google/cloud/sql/core/ConscryptWorkaroundTrustManagerFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/core/ConscryptWorkaroundTrustManagerFactory.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.sql.core;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.Provider;
+import java.security.Security;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+
+/**
+ * This is a workaround for a known bug in Conscrypt crypto in how it handles X509 auth type.
+ * OpenJDK interpres the X509 certificate auth type as "UNKNOWN" while Conscrypt interpret the same
+ * certificate as auth type "GENERIC". This incompatibility causes problems in the JDK.
+ *
+ * <p>This adapter works around the issue by creating wrappers around all TrustManager instances. It
+ * replaces "GENERIC" auth type with "UNKNOWN" auth type before delegating calls.
+ *
+ * <p>In the JVM, we need to implement 3 classes to make sure that we are capturing all of the
+ * TrustManager instances created when Conscrypt is the Java Crypto provider so that we can wrap
+ * them with the ConscryptWorkaroundTrustManager:
+ *
+ * <p>class ConscryptWorkaroundTrustManagerFactory extends TrustManagerFactory - has a bunch of
+ * final methods that delegate to a TrustManagerFactorySpi. class
+ * ConscryptWorkaroundTrustManagerFactorySpi implements TrustManagerFactorySpi - can actually
+ * intercept and delegate calls related to trust managers and wrap them with
+ * ConscryptWorkaroundTrustManager ConscryptWorkaroundTrustManager - the workaround for the
+ * Conscrypt bug.
+ *
+ * <p>See https://github.com/google/conscrypt/issues/1033#issuecomment-982701272
+ */
+class ConscryptWorkaroundTrustManagerFactory extends TrustManagerFactory {
+  private static final boolean CONSCRYPT_TLS;
+
+  static {
+    // Provider name is "Conscrypt", hardcoded string in the library source:
+    // https://github.com/google/conscrypt/blob/655ad5069e1cb4d1989b8117eaf090371885af99/openjdk/src/main/java/org/conscrypt/Platform.java#L149
+    Provider p = Security.getProvider("Conscrypt");
+    if (p != null) {
+      try {
+        SSLContext ctx = SSLContext.getInstance("TLS");
+        Provider prov = ctx.getProvider();
+        CONSCRYPT_TLS = "Conscrypt".equals(prov.getName());
+      } catch (NoSuchAlgorithmException e) {
+        throw new RuntimeException("Unable to load algorithm TLS", e);
+      }
+    } else {
+      CONSCRYPT_TLS = false;
+    }
+  }
+
+  /** Returns true if the Conscrypt Java Crypto Extension is installed. */
+  static boolean isWorkaroundNeeded() {
+    return CONSCRYPT_TLS;
+  }
+
+  static ConscryptWorkaroundTrustManagerFactory newInstance() throws NoSuchAlgorithmException {
+    TrustManagerFactory delegate = TrustManagerFactory.getInstance("X.509");
+    return new ConscryptWorkaroundTrustManagerFactory(delegate);
+  }
+
+  private ConscryptWorkaroundTrustManagerFactory(TrustManagerFactory delegate) {
+    super(
+        new ConscryptWorkaroundTrustManagerFactorySpi(delegate),
+        delegate.getProvider(),
+        delegate.getAlgorithm());
+  }
+}

--- a/core/src/main/java/com/google/cloud/sql/core/ConscryptWorkaroundTrustManagerFactorySpi.java
+++ b/core/src/main/java/com/google/cloud/sql/core/ConscryptWorkaroundTrustManagerFactorySpi.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.sql.core;
+
+import java.security.InvalidAlgorithmParameterException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import javax.net.ssl.ManagerFactoryParameters;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.TrustManagerFactorySpi;
+import javax.net.ssl.X509ExtendedTrustManager;
+
+/**
+ * This is a workaround for a known bug in Conscrypt crypto in how it handles X509 auth type.
+ * OpenJDK interpres the X509 certificate auth type as "UNKNOWN" while Conscrypt interpret the same
+ * certificate as auth type "GENERIC". This incompatibility causes problems in the JDK.
+ *
+ * <p>This adapter works around the issue by creating wrappers around all TrustManager instances. It
+ * replaces "GENERIC" auth type with "UNKNOWN" auth type before delegating calls.
+ *
+ * <p>See https://github.com/google/conscrypt/issues/1033#issuecomment-982701272
+ */
+class ConscryptWorkaroundTrustManagerFactorySpi extends TrustManagerFactorySpi {
+  private final TrustManagerFactory delegate;
+
+  ConscryptWorkaroundTrustManagerFactorySpi(TrustManagerFactory delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  protected void engineInit(KeyStore ks) throws KeyStoreException {
+    delegate.init(ks);
+  }
+
+  @Override
+  protected void engineInit(ManagerFactoryParameters spec)
+      throws InvalidAlgorithmParameterException {
+    delegate.init(spec);
+  }
+
+  @Override
+  protected TrustManager[] engineGetTrustManagers() {
+    TrustManager[] tms = delegate.getTrustManagers();
+    TrustManager[] delegates = new TrustManager[tms.length];
+    for (int i = 0; i < tms.length; i++) {
+      if (tms[i] instanceof X509ExtendedTrustManager) {
+        delegates[i] =
+            new ConscryptWorkaroundDelegatingTrustManger((X509ExtendedTrustManager) tms[i]);
+      } else {
+
+        delegates[i] = tms[i];
+      }
+    }
+    return delegates;
+  }
+}

--- a/jdbc/postgres/pom.xml
+++ b/jdbc/postgres/pom.xml
@@ -104,7 +104,44 @@
         </dependency>
       </dependencies>
     </profile>
+
+    <profile>
+      <id>google-conscript</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.conscrypt</groupId>
+          <artifactId>conscrypt-openjdk-uber</artifactId>
+          <version>2.5.2</version>
+        </dependency>
+      </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>3.2.5</version>
+            <executions>
+              <execution>
+                <phase>integration-test</phase>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <configuration>
+                  <!-- double-equals means override the JRE default properties, don't append -->
+                  <argLine>-Djava.security.properties==src/test/resources/conscrypt-security.properties</argLine>
+                  <classpathDependencyExcludes>
+                    <classpathDependencyExclude>org.bouncycastle:bcpkix-jdk15on</classpathDependencyExclude>
+                    <classpathDependencyExclude>org.bouncycastle:bcprov-jdk15on</classpathDependencyExclude>
+                    <classpathDependencyExclude>org.bouncycastle:bcutil-jdk15on</classpathDependencyExclude>
+                  </classpathDependencyExcludes>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
+
 
   <build>
     <plugins>

--- a/jdbc/postgres/src/test/java/com/google/cloud/sql/postgres/JdbcPostgresIamAuthIntegrationTests.java
+++ b/jdbc/postgres/src/test/java/com/google/cloud/sql/postgres/JdbcPostgresIamAuthIntegrationTests.java
@@ -22,11 +22,15 @@ import static com.google.common.truth.Truth.assertWithMessage;
 import com.google.common.collect.ImmutableList;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import java.security.NoSuchAlgorithmException;
+import java.security.Provider;
+import java.security.Security;
 import java.sql.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
+import javax.net.ssl.SSLContext;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -34,9 +38,13 @@ import org.junit.Test;
 import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @RunWith(JUnit4.class)
 public class JdbcPostgresIamAuthIntegrationTests {
+  private static final Logger log =
+      LoggerFactory.getLogger(JdbcPostgresIamAuthIntegrationTests.class);
 
   // [START cloud_sql_connector_postgres_jdbc_iam_auth]
   private static final String CONNECTION_NAME = System.getenv("POSTGRES_IAM_CONNECTION_NAME");
@@ -59,6 +67,19 @@ public class JdbcPostgresIamAuthIntegrationTests {
                         "Environment variable '%s' must be set to perform these tests.", varName))
                 .that(System.getenv(varName))
                 .isNotEmpty());
+
+    log.info("Crypto Providers: ");
+    Provider[] providers = Security.getProviders();
+    for (Provider p : providers) {
+      log.info("  {}", p.getName());
+    }
+    try {
+      SSLContext ctx = SSLContext.getInstance("TLS");
+      Provider prov = ctx.getProvider();
+      log.info("TLS Provider: {}", prov.getName());
+    } catch (NoSuchAlgorithmException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   @Before

--- a/jdbc/postgres/src/test/resources/conscrypt-security.properties
+++ b/jdbc/postgres/src/test/resources/conscrypt-security.properties
@@ -1,0 +1,146 @@
+####
+# This file fully replaces the built-in JVM security properties for testing
+# the Conscrypt crypto library.
+
+
+###
+# Updated properties to prioritize the Conscrypt provider over
+# OpenJDK providers.
+
+# Make Conscrypt the #1 security provider
+security.provider.1=org.conscrypt.OpenSSLProvider
+
+# Allow the JVM to fall back to default OpenJDK security providers
+# in case Conscrypt does not include an algorithm.
+security.provider.2=SUN
+security.provider.3=SunRsaSign
+security.provider.4=SunEC
+security.provider.5=SunJSSE
+security.provider.6=SunJCE
+security.provider.7=SunJGSS
+security.provider.8=SunSASL
+security.provider.9=XMLDSig
+security.provider.10=SunPCSC
+security.provider.11=JdkLDAP
+security.provider.12=JdkSASL
+security.provider.13=SunPKCS11
+
+###
+# JVM default property values. These properties were copied from
+# OpenJDK 1.22.3 Linux.
+
+securerandom.source=file:/dev/random
+
+securerandom.strongAlgorithms=NativePRNGBlocking:SUN,DRBG:SUN
+
+securerandom.drbg.config=
+
+login.configuration.provider=sun.security.provider.ConfigFile
+
+
+policy.provider=sun.security.provider.PolicyFile
+
+policy.url.1=file:${java.home}/conf/security/java.policy
+policy.url.2=file:${user.home}/.java.policy
+
+policy.expandProperties=true
+
+policy.allowSystemProperty=true
+
+policy.ignoreIdentityScope=false
+
+keystore.type=pkcs12
+
+keystore.type.compat=true
+
+package.access=sun.misc.,\
+               sun.reflect.
+
+package.definition=sun.misc.,\
+                   sun.reflect.
+
+security.overridePropertiesFile=true
+
+ssl.KeyManagerFactory.algorithm=SunX509
+ssl.TrustManagerFactory.algorithm=PKIX
+
+
+
+networkaddress.cache.negative.ttl=10
+
+
+
+
+
+
+
+krb5.kdc.bad.policy = tryLast
+
+sun.security.krb5.disableReferrals=false
+
+sun.security.krb5.maxReferrals=5
+
+
+jdk.certpath.disabledAlgorithms=MD2, MD5, SHA1 jdkCA & usage TLSServer, \
+    RSA keySize < 1024, DSA keySize < 1024, EC keySize < 224, \
+    SHA1 usage SignedJAR & denyAfter 2019-01-01
+
+
+jdk.security.legacyAlgorithms=SHA1, \
+    RSA keySize < 2048, DSA keySize < 2048, \
+    DES, DESede, MD5, RC2, ARCFOUR
+
+jdk.jar.disabledAlgorithms=MD2, MD5, RSA keySize < 1024, \
+      DSA keySize < 1024, SHA1 denyAfter 2019-01-01
+
+http.auth.digest.disabledAlgorithms = MD5, SHA-1
+
+jdk.tls.disabledAlgorithms=SSLv3, TLSv1, TLSv1.1, DTLSv1.0, RC4, DES, \
+    MD5withRSA, DH keySize < 1024, EC keySize < 224, 3DES_EDE_CBC, anon, NULL, \
+    ECDH
+
+jdk.tls.legacyAlgorithms=NULL, anon, RC4, DES, 3DES_EDE_CBC
+
+
+jdk.tls.keyLimits=AES/GCM/NoPadding KeyUpdate 2^37, \
+                  ChaCha20-Poly1305 KeyUpdate 2^37
+
+crypto.policy=unlimited
+
+jdk.xml.dsig.secureValidationPolicy=\
+    disallowAlg http://www.w3.org/TR/1999/REC-xslt-19991116,\
+    maxTransforms 5,\
+    maxReferences 30,\
+    disallowReferenceUriSchemes file http https,\
+    minKeySize RSA 1024,\
+    minKeySize DSA 1024,\
+    minKeySize EC 224,\
+    noDuplicateIds,\
+    noRetrievalMethodLoops
+
+
+
+
+
+jceks.key.serialFilter = java.base/java.lang.Enum;java.base/java.security.KeyRep;\
+  java.base/java.security.KeyRep$Type;java.base/javax.crypto.spec.SecretKeySpec;!*
+
+
+
+
+
+
+
+
+
+
+jdk.sasl.disabledMechanisms=
+
+jdk.security.caDistrustPolicies=SYMANTEC_TLS
+
+jdk.io.permissionsUseCanonicalPath=false
+
+
+
+
+jdk.tls.alpnCharset=ISO_8859_1

--- a/pom.xml
+++ b/pom.xml
@@ -304,7 +304,7 @@
         <scope>test</scope>
       </dependency>
       <dependency>
-      <groupId>org.bouncycastle</groupId>
+        <groupId>org.bouncycastle</groupId>
         <artifactId>bcpkix-jdk15on</artifactId>
         <version>1.70</version>
         <scope>test</scope>
@@ -345,6 +345,14 @@
         <filtering>true</filtering>
       </resource>
     </resources>
+
+    <extensions>
+      <extension>
+        <groupId>kr.motd.maven</groupId>
+        <artifactId>os-maven-plugin</artifactId>
+        <version>1.4.1.Final</version>
+      </extension>
+    </extensions>
 
     <plugins>
 
@@ -900,6 +908,40 @@
                 <goals>
                   <goal>single</goal>
                 </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>google-conscript</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.conscrypt</groupId>
+          <artifactId>conscrypt-openjdk-uber</artifactId>
+          <version>2.5.2</version>
+        </dependency>
+      </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>3.2.5</version>
+            <executions>
+              <execution>
+                <phase>integration-test</phase>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <configuration>
+                  <classpathDependencyExcludes>
+                    <classpathDependencyExclude>org.bouncycastle:bcpkix-jdk15on</classpathDependencyExclude>
+                    <classpathDependencyExclude>org.bouncycastle:bcprov-jdk15on</classpathDependencyExclude>
+                    <classpathDependencyExclude>org.bouncycastle:bcutil-jdk15on</classpathDependencyExclude>
+                  </classpathDependencyExcludes>
+                </configuration>
               </execution>
             </executions>
           </plugin>


### PR DESCRIPTION
This is a workaround for an underlying bug in the Google Conscrypt crypto library 
[google/conscrypt #1033](https://github.com/google/conscrypt/issues/1033). 
The root cause is that the Conscrypt and OpenJDK X509 certificate libraries sometimes interpret the AuthType 
field differently: Conscrypt finds 'GENERIC' auth type when OpenJDK finds 'UNKNOWN' auth type. This causes certificate validation to fail. 

The workaround implemented here is to add a delegate `TrustManager` that replaces 'GENERIC' auth type with 'UNKNOWN' auth type so that the Conscrypt crypto plays nice with the JDK crypto. [See comment on #1033](https://github.com/google/conscrypt/issues/1033#issuecomment-982701272). 

I manually tested this on a modified JVM that used Conscrypt as it's primary crypto library. The integration tests  passed. I have not found a good way to make this test part of the test suite.

Fixes #1983