### PR TITLE
ci: test with graalvm-community and use managed native image maven plugin

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -303,10 +303,10 @@ jobs:
         repository: ${{ github.event.pull_request.head.repo.full_name }}
 
     - name: Set up GraalVM
-      uses: graalvm/setup-graalvm@809512d83d953d3652df1c3d2f3de546111002b2
+      uses: graalvm/setup-graalvm@2911b2304bee2c2f59b9a67bf45f025a6b6de4b1 # v1.2.2
       with:
-        version: 'latest'
-        java-version: '17'
+        java-version: '21'
+        distribution: 'graalvm-community'
         components: 'native-image'
         github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,6 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <javac.version>9+181-r4173-1</javac.version>
-    <native-image.version>0.10.2</native-image.version>
     <graal-sdk.version>24.0.1</graal-sdk.version>
     <netty.version>4.1.110.Final</netty.version>
     <ow2-asm.version>9.7</ow2-asm.version>
@@ -741,7 +740,7 @@
         <dependency>
           <groupId>org.graalvm.buildtools</groupId>
           <artifactId>junit-platform-native</artifactId>
-          <version>${native-image.version}</version>
+          <version>${native-maven-plugin.version}</version>
           <scope>test</scope>
         </dependency>
       </dependencies>
@@ -764,7 +763,7 @@
           <plugin>
             <groupId>org.graalvm.buildtools</groupId>
             <artifactId>native-maven-plugin</artifactId>
-            <version>${native-image.version}</version>
+            <version>${native-maven-plugin.version}</version>
             <extensions>true</extensions>
             <executions>
               <execution>


### PR DESCRIPTION
Future update needed to use a managed version for `graal-sdk.version`, but we need to release java-shared-config with https://github.com/googleapis/java-shared-config/pull/852 before it will be available.

Future update needed to use a managed GraalVM test image.