### PR TITLE
feat: Retry API calls that return a 500 error

### DIFF
--- a/core/src/main/java/com/google/cloud/sql/core/ApiClientRetryingCallable.java
+++ b/core/src/main/java/com/google/cloud/sql/core/ApiClientRetryingCallable.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.sql.core;
+
+import com.google.api.client.http.HttpResponseException;
+import java.util.concurrent.Callable;
+
+/**
+ * Extends RetryingCallable with logic to only retry on HTTP errors with error codes in the 5xx
+ * range.
+ *
+ * @param <T> the return value for Callable
+ */
+class ApiClientRetryingCallable<T> extends RetryingCallable<T> {
+
+  /**
+   * Construct a new RetryLogic.
+   *
+   * @param callable the callable that should be retried
+   */
+  public ApiClientRetryingCallable(Callable<T> callable) {
+    super(callable);
+  }
+
+  /**
+   * Returns false indicating that there should be another attempt if the exception is an HTTP
+   * response with an error code in the 5xx range.
+   *
+   * @param e the exception
+   * @return false if this is a http response with a 5xx status code, otherwise true.
+   */
+  @Override
+  protected boolean isFatalException(Exception e) {
+    // Only retry if the error is an HTTP response with a 5xx error code.
+    if (e instanceof HttpResponseException) {
+      HttpResponseException re = (HttpResponseException) e;
+      return re.getStatusCode() < 500;
+    }
+    // Otherwise this is a fatal exception, no more tries.
+    return true;
+  }
+}

--- a/core/src/test/java/com/google/cloud/sql/core/DefaultAccessTokenSupplierTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/DefaultAccessTokenSupplierTest.java
@@ -37,7 +37,6 @@ import com.google.auth.oauth2.GoogleCredentials;
 import com.google.auth.oauth2.OAuth2Credentials;
 import com.google.cloud.sql.CredentialFactory;
 import java.io.IOException;
-import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Collections;
@@ -75,8 +74,7 @@ public class DefaultAccessTokenSupplierTest {
 
   @Test
   public void testEmptyTokenOnEmptyCredentials() throws IOException {
-    DefaultAccessTokenSupplier supplier =
-        new DefaultAccessTokenSupplier(null, 1, Duration.ofMillis(10));
+    DefaultAccessTokenSupplier supplier = new DefaultAccessTokenSupplier(null);
     assertThat(supplier.get()).isEqualTo(Optional.empty());
   }
 
@@ -100,8 +98,7 @@ public class DefaultAccessTokenSupplierTest {
         };
 
     DefaultAccessTokenSupplier supplier =
-        new DefaultAccessTokenSupplier(
-            new GoogleCredentialsFactory(googleCredentials), 1, Duration.ofMillis(10));
+        new DefaultAccessTokenSupplier(new GoogleCredentialsFactory(googleCredentials));
     Optional<AccessToken> token = supplier.get();
 
     assertThat(token.isPresent()).isTrue();
@@ -127,8 +124,7 @@ public class DefaultAccessTokenSupplierTest {
           }
         };
 
-    DefaultAccessTokenSupplier supplier =
-        new DefaultAccessTokenSupplier(badFactory, 1, Duration.ofMillis(10));
+    DefaultAccessTokenSupplier supplier = new DefaultAccessTokenSupplier(badFactory);
     RuntimeException ex = assertThrows(RuntimeException.class, supplier::get);
     assertThat(ex).hasMessageThat().contains("Unsupported credentials of type");
   }
@@ -153,11 +149,10 @@ public class DefaultAccessTokenSupplierTest {
         };
 
     DefaultAccessTokenSupplier supplier =
-        new DefaultAccessTokenSupplier(
-            new GoogleCredentialsFactory(expiredGoogleCredentials), 1, Duration.ofMillis(10));
+        new DefaultAccessTokenSupplier(new GoogleCredentialsFactory(expiredGoogleCredentials));
     IllegalStateException ex = assertThrows(IllegalStateException.class, supplier::get);
     assertThat(ex).hasMessageThat().contains("Error refreshing credentials");
-    assertThat(refreshCounter.get()).isEqualTo(1);
+    assertThat(refreshCounter.get()).isEqualTo(5);
   }
 
   @Test
@@ -180,11 +175,10 @@ public class DefaultAccessTokenSupplierTest {
         };
 
     DefaultAccessTokenSupplier supplier =
-        new DefaultAccessTokenSupplier(
-            new GoogleCredentialsFactory(refreshGetsExpiredToken), 1, Duration.ofMillis(10));
+        new DefaultAccessTokenSupplier(new GoogleCredentialsFactory(refreshGetsExpiredToken));
     IllegalStateException ex = assertThrows(IllegalStateException.class, supplier::get);
     assertThat(ex).hasMessageThat().contains("expiration time is in the past");
-    assertThat(refreshCounter.get()).isEqualTo(1);
+    assertThat(refreshCounter.get()).isEqualTo(5);
   }
 
   @Test
@@ -206,8 +200,7 @@ public class DefaultAccessTokenSupplierTest {
         };
 
     DefaultAccessTokenSupplier supplier =
-        new DefaultAccessTokenSupplier(
-            new GoogleCredentialsFactory(refreshableCredentials), 1, Duration.ofMillis(10));
+        new DefaultAccessTokenSupplier(new GoogleCredentialsFactory(refreshableCredentials));
     Optional<AccessToken> token = supplier.get();
 
     assertThat(token.isPresent()).isTrue();
@@ -239,8 +232,7 @@ public class DefaultAccessTokenSupplierTest {
         };
 
     DefaultAccessTokenSupplier supplier =
-        new DefaultAccessTokenSupplier(
-            new GoogleCredentialsFactory(refreshableCredentials), 3, Duration.ofMillis(10));
+        new DefaultAccessTokenSupplier(new GoogleCredentialsFactory(refreshableCredentials));
     Optional<AccessToken> token = supplier.get();
 
     assertThat(token.isPresent()).isTrue();
@@ -271,8 +263,7 @@ public class DefaultAccessTokenSupplierTest {
   public void throwsErrorForWrongCredentialType() {
     OAuth2Credentials creds = OAuth2Credentials.create(new AccessToken("abc", null));
     DefaultAccessTokenSupplier supplier =
-        new DefaultAccessTokenSupplier(
-            new Oauth2BadCredentialFactory(creds), 1, Duration.ofMillis(10));
+        new DefaultAccessTokenSupplier(new Oauth2BadCredentialFactory(creds));
     RuntimeException ex = assertThrows(RuntimeException.class, supplier::get);
 
     assertThat(ex)
@@ -291,8 +282,7 @@ public class DefaultAccessTokenSupplierTest {
           }
         };
     DefaultAccessTokenSupplier supplier =
-        new DefaultAccessTokenSupplier(
-            new GoogleCredentialsFactory(creds), 1, Duration.ofMillis(10));
+        new DefaultAccessTokenSupplier(new GoogleCredentialsFactory(creds));
     RuntimeException ex = assertThrows(RuntimeException.class, supplier::get);
 
     assertThat(ex).hasMessageThat().contains("Access Token has length of zero");
@@ -317,8 +307,7 @@ public class DefaultAccessTokenSupplierTest {
         };
 
     DefaultAccessTokenSupplier supplier =
-        new DefaultAccessTokenSupplier(
-            new GoogleCredentialsFactory(refreshableCredentials), 1, Duration.ofMillis(10));
+        new DefaultAccessTokenSupplier(new GoogleCredentialsFactory(refreshableCredentials));
     RuntimeException ex = assertThrows(RuntimeException.class, supplier::get);
 
     assertThat(ex).hasMessageThat().contains("Access Token expiration time is in the past");
@@ -368,8 +357,7 @@ public class DefaultAccessTokenSupplierTest {
     credential.setExpirationTimeMilliseconds(future.toEpochMilli());
 
     DefaultAccessTokenSupplier supplier =
-        new DefaultAccessTokenSupplier(
-            new Oauth2CredentialFactory(credential), 1, Duration.ofMillis(10));
+        new DefaultAccessTokenSupplier(new Oauth2CredentialFactory(credential));
     Optional<AccessToken> token = supplier.get();
 
     assertThat(token.isPresent()).isTrue();
@@ -438,8 +426,7 @@ public class DefaultAccessTokenSupplierTest {
     credential.setExpirationTimeMilliseconds(past.toEpochMilli());
 
     DefaultAccessTokenSupplier supplier =
-        new DefaultAccessTokenSupplier(
-            new Oauth2CredentialFactory(credential), 1, Duration.ofMillis(10));
+        new DefaultAccessTokenSupplier(new Oauth2CredentialFactory(credential));
     Optional<AccessToken> token = supplier.get();
 
     assertThat(token.isPresent()).isTrue();


### PR DESCRIPTION
This updates the retry logic for API calls made by the connector: 

- Attempts to get an authentication token from the Google auth API are always retried 5 times.
- SQL Admin API requests are retried up to 5 times if the http response status code is a 5xx. Otherwise they are fatal on the first error.

This also implements the exponential backoff logic defined used in the go connector.
See: https://github.com/GoogleCloudPlatform/cloud-sql-go-connector/pull/781