### PR TITLE
feat: Automatically configure connections using DNS. Part of #2043.

### DIFF
--- a/core/src/main/java/com/google/cloud/sql/core/ConnectionConfig.java
+++ b/core/src/main/java/com/google/cloud/sql/core/ConnectionConfig.java
@@ -200,6 +200,18 @@ public class ConnectionConfig {
         config);
   }
 
+  /** Creates a new instance of the ConnectionConfig with an updated cloudSqlInstance. */
+  public ConnectionConfig withCloudSqlInstance(String newCloudSqlInstance) {
+    return new ConnectionConfig(
+        newCloudSqlInstance,
+        namedConnector,
+        unixSocketPath,
+        ipTypes,
+        authType,
+        unixSocketPathSuffix,
+        connectorConfig);
+  }
+
   public String getNamedConnector() {
     return namedConnector;
   }

--- a/core/src/main/java/com/google/cloud/sql/core/DnsInstanceConnectionNameResolver.java
+++ b/core/src/main/java/com/google/cloud/sql/core/DnsInstanceConnectionNameResolver.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.sql.core;
+
+import java.util.Collection;
+import java.util.Objects;
+import javax.naming.NameNotFoundException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * An implementation of InstanceConnectionNameResolver that uses DNS SRV records to resolve an
+ * instance name from a domain name.
+ */
+class DnsInstanceConnectionNameResolver implements InstanceConnectionNameResolver {
+  private static final Logger logger =
+      LoggerFactory.getLogger(DnsInstanceConnectionNameResolver.class);
+
+  private final DnsResolver dnsResolver;
+
+  public DnsInstanceConnectionNameResolver(DnsResolver dnsResolver) {
+    this.dnsResolver = dnsResolver;
+  }
+
+  @Override
+  public CloudSqlInstanceName resolve(final String name) {
+    // Attempt to parse the instance name
+    try {
+      return new CloudSqlInstanceName(name);
+    } catch (IllegalArgumentException e) {
+      // Not a well-formed instance name.
+    }
+
+    // Next, attempt to resolve DNS name.
+    Collection<DnsSrvRecord> instanceNames;
+    try {
+      instanceNames = this.dnsResolver.resolveSrv(name);
+    } catch (NameNotFoundException ne) {
+      // No DNS record found. This is not a valid instance name.
+      throw new IllegalArgumentException(
+          String.format("Unable to resolve SRV record for \"%s\".", name));
+    }
+
+    // Use the first valid instance name from the list
+    // or throw an IllegalArgumentException if none of the values can be parsed.
+    return instanceNames.stream()
+        .map(
+            r -> {
+              String target = r.getTarget();
+              // Trim trailing '.' from target field
+              if (target.endsWith(".")) {
+                target = target.substring(0, target.length() - 1);
+              }
+              try {
+                return new CloudSqlInstanceName(target);
+              } catch (IllegalArgumentException e) {
+                logger.info(
+                    "Unable to parse instance name in SRV record for "
+                        + "domain name \"{}\" with target \"{}\"",
+                    name,
+                    target,
+                    e);
+                return null;
+              }
+            })
+        .filter(Objects::nonNull)
+        .findFirst()
+        .orElseThrow(
+            () ->
+                new IllegalArgumentException(
+                    String.format("Unable to parse values of SRV record for \"%s\".", name)));
+  }
+}

--- a/core/src/main/java/com/google/cloud/sql/core/InstanceConnectionNameResolver.java
+++ b/core/src/main/java/com/google/cloud/sql/core/InstanceConnectionNameResolver.java
@@ -16,10 +16,15 @@
 
 package com.google.cloud.sql.core;
 
-import java.util.Collection;
-import javax.naming.NameNotFoundException;
+/** Resolves the Cloud SQL Instance from the configuration name. */
+interface InstanceConnectionNameResolver {
 
-/** Wraps the Java DNS API. */
-interface DnsResolver {
-  Collection<DnsSrvRecord> resolveSrv(String name) throws NameNotFoundException;
+  /**
+   * Resolves the CloudSqlInstanceName from a configuration string value.
+   *
+   * @param name the configuration string
+   * @return the CloudSqlInstanceName
+   * @throws IllegalArgumentException if the name cannot be resolved.
+   */
+  CloudSqlInstanceName resolve(String name);
 }

--- a/core/src/main/java/com/google/cloud/sql/core/InternalConnectorRegistry.java
+++ b/core/src/main/java/com/google/cloud/sql/core/InternalConnectorRegistry.java
@@ -332,7 +332,8 @@ public final class InternalConnectorRegistry {
         localKeyPair,
         MIN_REFRESH_DELAY_MS,
         connectTimeoutMs,
-        serverProxyPort);
+        serverProxyPort,
+        new DnsInstanceConnectionNameResolver(new JndiDnsResolver()));
   }
 
   /** Register the configuration for a named connector. */

--- a/core/src/test/java/com/google/cloud/sql/core/DnsSrvRecordTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/DnsSrvRecordTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
A connection may be configured to using a DNS name instead of an instance name. If the cloudSqlInstance property is
set to be a domain name instead of an instance name, the connector will look up a SRV record for that name and
connect to that instance.

There should be exactly 1 SRV for the database instance. The connector will always use the SRV record with the
highest priority.

Part of #2043 