### PR TITLE
ci: skip integration tests on fork PRs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -127,6 +127,10 @@ jobs:
           ./flakybot --repo ${{github.repository}} --commit_hash ${{github.sha}} --build_url https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
   unit-e2e:
     name: units + e2e
+    # run integration tests on all builds except pull requests from forks or dependabot
+    if: |
+      github.event_name != 'pull_request' || 
+      (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
Pull request from forks once merged will still be skipped because `github.event.pull_request.head.repo.full_name` will still be that of the fork.

To combat this we run the job on all events that are not a pull_request (aka `schedule` and `push`)