### PR TITLE
chore: Use domain name from JDBC URL for Postgres and Mysql, Part of #2043

### DIFF
--- a/jdbc/mariadb/src/main/java/com/google/cloud/sql/mariadb/SocketFactory.java
+++ b/jdbc/mariadb/src/main/java/com/google/cloud/sql/mariadb/SocketFactory.java
@@ -37,6 +37,7 @@ public class SocketFactory extends ConfigurableSocketFactory {
   }
 
   private Configuration conf;
+  private String host;
 
   /** Instantiate a socket factory. */
   public SocketFactory() {}
@@ -45,13 +46,14 @@ public class SocketFactory extends ConfigurableSocketFactory {
   public void setConfiguration(Configuration conf, String host) {
     // Ignore the hostname
     this.conf = conf;
+    this.host = host;
   }
 
   @Override
   public Socket createSocket() throws IOException {
     try {
       return InternalConnectorRegistry.getInstance()
-          .connect(ConnectionConfig.fromConnectionProperties(conf.nonMappedOptions()));
+          .connect(ConnectionConfig.fromConnectionProperties(conf.nonMappedOptions(), host));
     } catch (InterruptedException e) {
       throw new RuntimeException(e);
     }

--- a/jdbc/mysql-j-8/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
+++ b/jdbc/mysql-j-8/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
@@ -60,7 +60,7 @@ public class SocketFactory implements com.mysql.cj.protocol.SocketFactory {
     T socket =
         (T)
             InternalConnectorRegistry.getInstance()
-                .connect(ConnectionConfig.fromConnectionProperties(props));
+                .connect(ConnectionConfig.fromConnectionProperties(props, host));
     return socket;
   }
 

--- a/jdbc/mysql-j-8/src/test/java/com/google/cloud/sql/mysql/JdbcMysqlJ8DomainNameIntegrationTests.java
+++ b/jdbc/mysql-j-8/src/test/java/com/google/cloud/sql/mysql/JdbcMysqlJ8DomainNameIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
-package com.google.cloud.sql.postgres;
+package com.google.cloud.sql.mysql;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
 
+import com.google.cloud.sql.ConnectorConfig;
+import com.google.cloud.sql.ConnectorRegistry;
 import com.google.common.collect.ImmutableList;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
@@ -36,16 +38,15 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
-public class JdbcPostgresIntegrationTests {
+public class JdbcMysqlJ8DomainNameIntegrationTests {
 
-  private static final String CONNECTION_NAME = System.getenv("POSTGRES_CONNECTION_NAME");
-  private static final String DB_NAME = System.getenv("POSTGRES_DB");
-  private static final String DB_USER = System.getenv("POSTGRES_USER");
-  private static final String DB_PASSWORD = System.getenv("POSTGRES_PASS");
+  private static final String CONNECTION_NAME = System.getenv("MYSQL_CONNECTION_NAME");
+  private static final String DB_NAME = System.getenv("MYSQL_DB");
+  private static final String DB_USER = System.getenv("MYSQL_USER");
+  private static final String DB_PASSWORD = System.getenv("MYSQL_PASS");
   private static final ImmutableList<String> requiredEnvVars =
-      ImmutableList.of("POSTGRES_USER", "POSTGRES_PASS", "POSTGRES_DB", "POSTGRES_CONNECTION_NAME");
+      ImmutableList.of("MYSQL_USER", "MYSQL_PASS", "MYSQL_DB", "MYSQL_CONNECTION_NAME");
   @Rule public Timeout globalTimeout = new Timeout(80, TimeUnit.SECONDS);
-
   private HikariDataSource connectionPool;
 
   @BeforeClass
@@ -63,12 +64,19 @@ public class JdbcPostgresIntegrationTests {
   @Before
   public void setUpPool() throws SQLException {
     // Set up URL parameters
-    String jdbcURL = String.format("jdbc:postgresql://db.example.com/%s", DB_NAME);
+    String jdbcURL = String.format("jdbc:mysql://db.example.com/%s", DB_NAME);
     Properties connProps = new Properties();
     connProps.setProperty("user", DB_USER);
     connProps.setProperty("password", DB_PASSWORD);
-    connProps.setProperty("socketFactory", "com.google.cloud.sql.postgres.SocketFactory");
-    connProps.setProperty("cloudSqlInstance", CONNECTION_NAME);
+    connProps.setProperty("socketFactory", "com.google.cloud.sql.mysql.SocketFactory");
+
+    // Register a resolver that resolves `db.example.com` to the connection name
+    connProps.setProperty("cloudSqlNamedConnector", "resolver-test");
+    ConnectorRegistry.register(
+        "resolver-test",
+        new ConnectorConfig.Builder()
+            .withInstanceNameResolver((n) -> "db.example.com".equals(n) ? CONNECTION_NAME : null)
+            .build());
 
     // Initialize connection pool
     HikariConfig config = new HikariConfig();

--- a/jdbc/mysql-j-8/src/test/java/com/google/cloud/sql/mysql/JdbcMysqlJ8IntegrationTests.java
+++ b/jdbc/mysql-j-8/src/test/java/com/google/cloud/sql/mysql/JdbcMysqlJ8IntegrationTests.java
@@ -62,7 +62,7 @@ public class JdbcMysqlJ8IntegrationTests {
   @Before
   public void setUpPool() throws SQLException {
     // Set up URL parameters
-    String jdbcURL = String.format("jdbc:mysql:///%s", DB_NAME);
+    String jdbcURL = String.format("jdbc:mysql://db.example.com/%s", DB_NAME);
     Properties connProps = new Properties();
     connProps.setProperty("user", DB_USER);
     connProps.setProperty("password", DB_PASSWORD);

--- a/jdbc/postgres/src/main/java/com/google/cloud/sql/postgres/SocketFactory.java
+++ b/jdbc/postgres/src/main/java/com/google/cloud/sql/postgres/SocketFactory.java
@@ -38,6 +38,9 @@ public class SocketFactory extends javax.net.SocketFactory {
   private static final String DEPRECATED_SOCKET_ARG = "SocketFactoryArg";
   private static final String POSTGRES_SUFFIX = "/.s.PGSQL.5432";
 
+  /** The connection property containing the hostname from the JDBC url. */
+  private static final String POSTGRES_HOST_PROP = "PGHOST";
+
   private final Properties props;
 
   static {
@@ -83,7 +86,9 @@ public class SocketFactory extends javax.net.SocketFactory {
   public Socket createSocket() throws IOException {
     try {
       return InternalConnectorRegistry.getInstance()
-          .connect(ConnectionConfig.fromConnectionProperties(props));
+          .connect(
+              ConnectionConfig.fromConnectionProperties(
+                  props, props.getProperty(POSTGRES_HOST_PROP)));
     } catch (InterruptedException e) {
       throw new RuntimeException(e);
     }

--- a/jdbc/postgres/src/test/java/com/google/cloud/sql/postgres/JdbcPostgresDomainNameIntegrationTests.java
+++ b/jdbc/postgres/src/test/java/com/google/cloud/sql/postgres/JdbcPostgresDomainNameIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@ package com.google.cloud.sql.postgres;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
 
+import com.google.cloud.sql.ConnectorConfig;
+import com.google.cloud.sql.ConnectorRegistry;
 import com.google.common.collect.ImmutableList;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
@@ -36,7 +38,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
-public class JdbcPostgresIntegrationTests {
+public class JdbcPostgresDomainNameIntegrationTests {
 
   private static final String CONNECTION_NAME = System.getenv("POSTGRES_CONNECTION_NAME");
   private static final String DB_NAME = System.getenv("POSTGRES_DB");
@@ -68,7 +70,13 @@ public class JdbcPostgresIntegrationTests {
     connProps.setProperty("user", DB_USER);
     connProps.setProperty("password", DB_PASSWORD);
     connProps.setProperty("socketFactory", "com.google.cloud.sql.postgres.SocketFactory");
-    connProps.setProperty("cloudSqlInstance", CONNECTION_NAME);
+    connProps.setProperty("cloudSqlNamedConnector", "resolver-test");
+
+    ConnectorRegistry.register(
+        "resolver-test",
+        new ConnectorConfig.Builder()
+            .withInstanceNameResolver((n) -> "db.example.com".equals(n) ? CONNECTION_NAME : null)
+            .build());
 
     // Initialize connection pool
     HikariConfig config = new HikariConfig();


### PR DESCRIPTION
When connecting to a Cloud SQL database using a domain name like `db.example.com`, 
you may now set the domain name in the JDBC URL. For example, you can use a URL like
"jdbc:mysql://db.example.com/my-schema?socketFactory=com.google.cloud.sql.mysql.SocketFactory"

The socket factory will detect "db.example.com" and look up the TXT record to resolve
the instance name. 

Adding this capability to the SQLServer driver will be a separate PR.

See https://github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory/issues/2043 for the whole feature definition.