### PR TITLE
feat: Support CAS server certificate authority to validate instance connections.

### DIFF
--- a/core/src/main/java/com/google/cloud/sql/core/Connector.java
+++ b/core/src/main/java/com/google/cloud/sql/core/Connector.java
@@ -118,6 +118,7 @@ class Connector {
       SSLSocket socket = (SSLSocket) metadata.getSslContext().getSocketFactory().createSocket();
       socket.setKeepAlive(true);
       socket.setTcpNoDelay(true);
+
       socket.connect(new InetSocketAddress(instanceIp, serverProxyPort));
 
       try {

--- a/core/src/main/java/com/google/cloud/sql/core/InstanceCheckingTrustManagerFactorySpi.java
+++ b/core/src/main/java/com/google/cloud/sql/core/InstanceCheckingTrustManagerFactorySpi.java
@@ -31,11 +31,11 @@ import javax.net.ssl.X509ExtendedTrustManager;
  */
 class InstanceCheckingTrustManagerFactorySpi extends TrustManagerFactorySpi {
   private final TrustManagerFactory delegate;
-  private final CloudSqlInstanceName instanceName;
+  private final InstanceMetadata instanceMetadata;
 
   InstanceCheckingTrustManagerFactorySpi(
-      CloudSqlInstanceName instanceName, TrustManagerFactory delegate) {
-    this.instanceName = instanceName;
+      InstanceMetadata instanceMetadata, TrustManagerFactory delegate) {
+    this.instanceMetadata = instanceMetadata;
     this.delegate = delegate;
   }
 
@@ -65,7 +65,7 @@ class InstanceCheckingTrustManagerFactorySpi extends TrustManagerFactorySpi {
           tm = new ConscryptWorkaroundDelegatingTrustManger(tm);
         }
 
-        delegates[i] = new InstanceCheckingTrustManger(instanceName, tm);
+        delegates[i] = new InstanceCheckingTrustManger(instanceMetadata, tm);
       } else {
         delegates[i] = tms[i];
       }

--- a/core/src/test/java/com/google/cloud/sql/core/CloudSqlCoreTestingBase.java
+++ b/core/src/test/java/com/google/cloud/sql/core/CloudSqlCoreTestingBase.java
@@ -133,19 +133,30 @@ public class CloudSqlCoreTestingBase {
   }
 
   MockHttpTransport fakeSuccessHttpTransport(Duration certDuration) {
-    return fakeSuccessHttpTransport(TestKeys.getServerCertPem(), certDuration, null);
+    return fakeSuccessHttpTransport(TestKeys.getServerCertPem(), certDuration, null, false, false);
   }
 
   MockHttpTransport fakeSuccessHttpTransport(Duration certDuration, String baseUrl) {
-    return fakeSuccessHttpTransport(TestKeys.getServerCertPem(), certDuration, baseUrl);
+    return fakeSuccessHttpTransport(
+        TestKeys.getServerCertPem(), certDuration, baseUrl, false, false);
   }
 
   MockHttpTransport fakeSuccessHttpTransport(String serverCert, Duration certDuration) {
-    return fakeSuccessHttpTransport(serverCert, certDuration, null);
+    return fakeSuccessHttpTransport(serverCert, certDuration, null, false, false);
+  }
+
+  MockHttpTransport fakeSuccessHttpCasTransport(Duration certDuration) {
+    return fakeSuccessHttpTransport(
+        TestKeys.getCasServerCertChainPem(), certDuration, null, true, false);
+  }
+
+  MockHttpTransport fakeSuccessHttpPscCasTransport(Duration certDuration) {
+    return fakeSuccessHttpTransport(
+        TestKeys.getCasServerCertChainPem(), certDuration, null, true, true);
   }
 
   MockHttpTransport fakeSuccessHttpTransport(
-      String serverCert, Duration certDuration, String baseUrl) {
+      String serverCert, Duration certDuration, String baseUrl, boolean cas, boolean psc) {
     final JsonFactory jsonFactory = new GsonFactory();
     return new MockHttpTransport() {
       @Override
@@ -167,7 +178,10 @@ public class CloudSqlCoreTestingBase {
                               new IpMapping().setIpAddress(PRIVATE_IP).setType("PRIVATE")))
                       .setServerCaCert(new SslCert().setCert(serverCert))
                       .setDatabaseVersion("POSTGRES14")
-                      .setRegion("myRegion");
+                      .setRegion("myRegion")
+                      .setPscEnabled(psc ? Boolean.TRUE : null)
+                      .setDnsName(cas || psc ? "db.example.com" : null)
+                      .setServerCaMode(cas ? "GOOGLE_MANAGED_CAS_CA" : null);
               settings.setFactory(jsonFactory);
               response
                   .setContent(settings.toPrettyString())

--- a/core/src/test/java/com/google/cloud/sql/core/FakeSslServer.java
+++ b/core/src/test/java/com/google/cloud/sql/core/FakeSslServer.java
@@ -24,7 +24,6 @@ import java.security.KeyStore.PasswordProtection;
 import java.security.KeyStore.PrivateKeyEntry;
 import java.security.PrivateKey;
 import java.security.SecureRandom;
-import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -38,16 +37,21 @@ import javax.net.ssl.TrustManagerFactory;
 public class FakeSslServer {
 
   private final PrivateKey privateKey;
-  private final X509Certificate cert;
+  private final X509Certificate[] cert;
 
   FakeSslServer() {
     privateKey = TestKeys.getServerKeyPair().getPrivate();
-    cert = TestKeys.getServerCert();
+    cert = new X509Certificate[] {TestKeys.getServerCert()};
+  }
+
+  public FakeSslServer(PrivateKey privateKey, X509Certificate[] cert) {
+    this.privateKey = privateKey;
+    this.cert = cert;
   }
 
   public FakeSslServer(PrivateKey privateKey, X509Certificate cert) {
     this.privateKey = privateKey;
-    this.cert = cert;
+    this.cert = new X509Certificate[] {cert};
   }
 
   int start(final String ip) throws InterruptedException {
@@ -59,8 +63,7 @@ public class FakeSslServer {
               try {
                 KeyStore authKeyStore = KeyStore.getInstance(KeyStore.getDefaultType());
                 authKeyStore.load(null, null);
-                PrivateKeyEntry serverCert =
-                    new PrivateKeyEntry(privateKey, new Certificate[] {cert});
+                PrivateKeyEntry serverCert = new PrivateKeyEntry(privateKey, cert);
                 authKeyStore.setEntry(
                     "serverCert", serverCert, new PasswordProtection(new char[0]));
                 KeyManagerFactory keyManagerFactory =

--- a/core/src/test/java/com/google/cloud/sql/core/MockAdminApi.java
+++ b/core/src/test/java/com/google/cloud/sql/core/MockAdminApi.java
@@ -104,6 +104,7 @@ public class MockAdminApi {
             .setDatabaseVersion(databaseVersion)
             .setPscEnabled(pscHostname != null)
             .setDnsName(pscHostname)
+            .setPscEnabled(pscHostname != null)
             .setRegion(cloudSqlInstanceName.getRegionId());
     settings.setFactory(GsonFactory.getDefaultInstance());
 

--- a/core/src/test/java/com/google/cloud/sql/core/TestKeys.java
+++ b/core/src/test/java/com/google/cloud/sql/core/TestKeys.java
@@ -78,4 +78,19 @@ public class TestKeys {
   public static String getDomainServerCertPem() {
     return certs.getPemForCert(certs.getDomainServerCertificate());
   }
+
+  public static X509Certificate[] getCasServerCertChain() {
+    return certs.getCasServerCertificateChain();
+  }
+
+  public static String getCasServerCertChainPem() {
+    StringBuilder s = new StringBuilder();
+    for (X509Certificate c : certs.getCasServerCertificateChain()) {
+      if (s.length() > 0) {
+        s.append("\n");
+      }
+      s.append(certs.getPemForCert(c));
+    }
+    return s.toString();
+  }
 }


### PR DESCRIPTION
For Cloud SQL instances with CAS enabled, the connector will use the certificate chain of trust reported by the 
SQL Admin API to validate the instance connection.