### PR TITLE
fix: Lazy refresh should refresh tokens 4 minutes before expiration.

### DIFF
--- a/core/src/main/java/com/google/cloud/sql/core/DefaultConnectionInfoRepository.java
+++ b/core/src/main/java/com/google/cloud/sql/core/DefaultConnectionInfoRepository.java
@@ -46,6 +46,7 @@ import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -196,7 +197,15 @@ class DefaultConnectionInfoRepository implements ConnectionInfoRepository {
               .orElse(x509Certificate.getNotAfter().toInstant());
     }
 
-    logger.debug(String.format("[%s] INSTANCE DATA DONE", instanceName));
+    logger.debug(
+        "[{}] INSTANCE DATA DONE - Ephemeral cert id: {} cert expiration: {} token expiration: {}",
+        instanceName,
+        Base64.getEncoder().encodeToString(((X509Certificate) ephemeralCertificate).getSignature()),
+        token
+            .map(tok -> tok.getExpirationTime())
+            .filter(time -> time != null)
+            .map(time -> time.toInstant().toString())
+            .orElse("(none)"));
 
     return new ConnectionInfo(metadata, sslContext, expiration);
   }

--- a/core/src/main/java/com/google/cloud/sql/core/LazyRefreshConnectionInfoCache.java
+++ b/core/src/main/java/com/google/cloud/sql/core/LazyRefreshConnectionInfoCache.java
@@ -16,6 +16,8 @@
 
 package com.google.cloud.sql.core;
 
+import static com.google.cloud.sql.core.RefreshCalculator.DEFAULT_REFRESH_BUFFER;
+
 import com.google.cloud.sql.CredentialFactory;
 import java.security.KeyPair;
 
@@ -54,7 +56,8 @@ class LazyRefreshConnectionInfoCache implements ConnectionInfoCache {
             config.getCloudSqlInstance(),
             () ->
                 connectionInfoRepository.getConnectionInfoSync(
-                    instanceName, accessTokenSupplier, config.getAuthType(), keyPair));
+                    instanceName, accessTokenSupplier, config.getAuthType(), keyPair),
+            DEFAULT_REFRESH_BUFFER);
   }
 
   @Override

--- a/core/src/main/java/com/google/cloud/sql/core/RefreshCalculator.java
+++ b/core/src/main/java/com/google/cloud/sql/core/RefreshCalculator.java
@@ -28,7 +28,7 @@ class RefreshCalculator {
   // defaultRefreshBuffer is the minimum amount of time for which a
   // certificate must be valid to ensure the next refresh attempt has adequate
   // time to complete.
-  private static final Duration DEFAULT_REFRESH_BUFFER = Duration.ofMinutes(4);
+  static final Duration DEFAULT_REFRESH_BUFFER = Duration.ofMinutes(4);
 
   long calculateSecondsUntilNextRefresh(Instant now, Instant expiration) {
     Duration timeUntilExp = Duration.between(now, expiration);


### PR DESCRIPTION
Added a 4 minute buffer to refreshing tokens and certificates to avoid creating race condition that would allow the connector to create an ephemeral certificate with an expired auth token. 

Now, IAM auth tokens are now refreshed 4 minutes before they token expire. Also, the Lazy Refresh Strategy will refresh the client certificate 4 minutes before the expiration of the certificate and the IAM auth token. 

This should mitigate some of the strange certificate expiration errors commonly found in Cloud Run, see: #2059 