### PR TITLE
chore(refactor): Add CAS related fields to the InstanceMetadata.

### DIFF
--- a/core/src/main/java/com/google/cloud/sql/core/InstanceCheckingTrustManagerFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/core/InstanceCheckingTrustManagerFactory.java
@@ -50,7 +50,8 @@ class InstanceCheckingTrustManagerFactory extends TrustManagerFactory {
     TrustManagerFactory delegate = TrustManagerFactory.getInstance("X.509");
     KeyStore trustedKeyStore = KeyStore.getInstance(KeyStore.getDefaultType());
     trustedKeyStore.load(null, null);
-    trustedKeyStore.setCertificateEntry("instance", instanceMetadata.getInstanceCaCertificate());
+    trustedKeyStore.setCertificateEntry(
+        "instance", instanceMetadata.getInstanceCaCertificates().get(0));
 
     InstanceCheckingTrustManagerFactory tmf =
         new InstanceCheckingTrustManagerFactory(instanceName, delegate);

--- a/core/src/main/java/com/google/cloud/sql/core/InstanceMetadata.java
+++ b/core/src/main/java/com/google/cloud/sql/core/InstanceMetadata.java
@@ -18,24 +18,55 @@ package com.google.cloud.sql.core;
 
 import com.google.cloud.sql.IpType;
 import java.security.cert.Certificate;
+import java.util.List;
 import java.util.Map;
 
 /** Represents the results of @link #fetchMetadata(). */
 class InstanceMetadata {
 
+  private final CloudSqlInstanceName instanceName;
   private final Map<IpType, String> ipAddrs;
-  private final Certificate instanceCaCertificate;
+  private final List<Certificate> instanceCaCertificates;
+  private final boolean casManagedCertificate;
+  private final String dnsName;
+  private final boolean pscEnabled;
 
-  InstanceMetadata(Map<IpType, String> ipAddrs, Certificate instanceCaCertificate) {
+  InstanceMetadata(
+      CloudSqlInstanceName instanceName,
+      Map<IpType, String> ipAddrs,
+      List<Certificate> instanceCaCertificates,
+      boolean casManagedCertificate,
+      String dnsName,
+      boolean pscEnabled) {
+    this.instanceName = instanceName;
     this.ipAddrs = ipAddrs;
-    this.instanceCaCertificate = instanceCaCertificate;
+    this.instanceCaCertificates = instanceCaCertificates;
+    this.casManagedCertificate = casManagedCertificate;
+    this.dnsName = dnsName;
+    this.pscEnabled = pscEnabled;
   }
 
   Map<IpType, String> getIpAddrs() {
     return ipAddrs;
   }
 
-  Certificate getInstanceCaCertificate() {
-    return instanceCaCertificate;
+  List<Certificate> getInstanceCaCertificates() {
+    return instanceCaCertificates;
+  }
+
+  public boolean isCasManagedCertificate() {
+    return casManagedCertificate;
+  }
+
+  public String getDnsName() {
+    return dnsName;
+  }
+
+  public boolean isPscEnabled() {
+    return pscEnabled;
+  }
+
+  public CloudSqlInstanceName getInstanceName() {
+    return instanceName;
   }
 }

--- a/core/src/test/java/com/google/cloud/sql/core/LazyRefreshStrategyTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/LazyRefreshStrategyTest.java
@@ -218,7 +218,11 @@ public class LazyRefreshStrategyTest {
 
   private static class ExampleData extends ConnectionInfo {
     ExampleData(Instant expiration) {
-      super(new InstanceMetadata(null, null), new SslData(null, null, null), expiration);
+      super(
+          new InstanceMetadata(
+              new CloudSqlInstanceName("project:region:instance"), null, null, false, "", false),
+          new SslData(null, null, null),
+          expiration);
     }
   }
 }

--- a/core/src/test/java/com/google/cloud/sql/core/MockAdminApi.java
+++ b/core/src/test/java/com/google/cloud/sql/core/MockAdminApi.java
@@ -102,6 +102,7 @@ public class MockAdminApi {
             .setIpAddresses(ipMappings)
             .setServerCaCert(new SslCert().setCert(TestKeys.getServerCertPem()))
             .setDatabaseVersion(databaseVersion)
+            .setPscEnabled(pscHostname != null)
             .setDnsName(pscHostname)
             .setRegion(cloudSqlInstanceName.getRegionId());
     settings.setFactory(GsonFactory.getDefaultInstance());

--- a/core/src/test/java/com/google/cloud/sql/core/RefreshAheadConnectionInfoCacheTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/RefreshAheadConnectionInfoCacheTest.java
@@ -259,7 +259,8 @@ public class RefreshAheadConnectionInfoCacheTest {
     Map<IpType, String> ips = Collections.singletonMap(IpType.PUBLIC, "10.1.1.1");
     try {
       return new ConnectionInfo(
-          new InstanceMetadata(ips, null),
+          new InstanceMetadata(
+              new CloudSqlInstanceName("project:region:instance"), ips, null, false, "", false),
           new SslData(
               null, KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm()), null),
           Instant.now().plus(amount, unit));
@@ -573,11 +574,15 @@ public class RefreshAheadConnectionInfoCacheTest {
     ConnectionInfo info =
         new ConnectionInfo(
             new InstanceMetadata(
+                new CloudSqlInstanceName("project:region:instance"),
                 ImmutableMap.of(
                     IpType.PUBLIC, "10.1.2.3",
                     IpType.PRIVATE, "10.10.10.10",
                     IpType.PSC, "abcde.12345.us-central1.sql.goog"),
-                null),
+                null,
+                false,
+                "",
+                false),
             sslData,
             Instant.now().plus(1, ChronoUnit.HOURS));
     AtomicInteger refreshCount = new AtomicInteger();
@@ -631,7 +636,13 @@ public class RefreshAheadConnectionInfoCacheTest {
     SslData sslData = new SslData(null, null, null);
     ConnectionInfo info =
         new ConnectionInfo(
-            new InstanceMetadata(ImmutableMap.of(IpType.PUBLIC, "10.1.2.3"), null),
+            new InstanceMetadata(
+                new CloudSqlInstanceName("project:region:instance"),
+                ImmutableMap.of(IpType.PUBLIC, "10.1.2.3"),
+                null,
+                false,
+                "",
+                false),
             sslData,
             Instant.now().plus(1, ChronoUnit.HOURS));
     AtomicInteger refreshCount = new AtomicInteger();

--- a/core/src/test/java/com/google/cloud/sql/core/RefreshAheadStrategyTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/RefreshAheadStrategyTest.java
@@ -543,7 +543,11 @@ public class RefreshAheadStrategyTest {
   private static class ExampleData extends ConnectionInfo {
 
     ExampleData(Instant expiration) {
-      super(new InstanceMetadata(null, null), new SslData(null, null, null), expiration);
+      super(
+          new InstanceMetadata(
+              new CloudSqlInstanceName("project:region:instance"), null, null, false, "", false),
+          new SslData(null, null, null),
+          expiration);
     }
   }
 

--- a/core/src/test/java/com/google/cloud/sql/core/StubConnectionInfoRepository.java
+++ b/core/src/test/java/com/google/cloud/sql/core/StubConnectionInfoRepository.java
@@ -41,7 +41,8 @@ class StubConnectionInfoRepository implements ConnectionInfoRepository {
     Map<IpType, String> ips = Collections.singletonMap(IpType.PUBLIC, "10.1.1.1");
     try {
       return new ConnectionInfo(
-          new InstanceMetadata(ips, null),
+          new InstanceMetadata(
+              new CloudSqlInstanceName("project:region:instance"), ips, null, false, "", false),
           new SslData(
               null, KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm()), null),
           Instant.now().plus(1, ChronoUnit.HOURS));

--- a/core/src/test/java/com/google/cloud/sql/core/TestDataSupplier.java
+++ b/core/src/test/java/com/google/cloud/sql/core/TestDataSupplier.java
@@ -38,11 +38,15 @@ class TestDataSupplier implements ConnectionInfoRepository {
   final ConnectionInfo response =
       new ConnectionInfo(
           new InstanceMetadata(
+              new CloudSqlInstanceName("project:region:instance"),
               ImmutableMap.of(
                   IpType.PUBLIC, "10.1.2.3",
                   IpType.PRIVATE, "10.10.10.10",
                   IpType.PSC, "abcde.12345.us-central1.sql.goog"),
-              null),
+              null,
+              false,
+              "",
+              false),
           new SslData(null, createKeyManagerFactory(), null),
           Instant.now().plus(1, ChronoUnit.HOURS));
 


### PR DESCRIPTION
Refactor InstanceMetadata to include fields needed to validate the TLS server certificates from CAS-
enabled instances. This contains only changes to the data structure of InstanceMetadata. It does not change
to the certificate validation logic.