### PR TITLE
docs: Add missing javadoc comments to public methods.

### DIFF
--- a/core/src/main/java/com/google/cloud/sql/ConnectorConfig.java
+++ b/core/src/main/java/com/google/cloud/sql/ConnectorConfig.java
@@ -153,52 +153,62 @@ public class ConnectorConfig {
     private String universeDomain;
     private RefreshStrategy refreshStrategy = RefreshStrategy.BACKGROUND;
 
+    /** Chained setter for TargetPrinciple field. */
     public Builder withTargetPrincipal(String targetPrincipal) {
       this.targetPrincipal = targetPrincipal;
       return this;
     }
 
+    /** Chained setter for GoogleCredentialsSupplier field. */
     public Builder withGoogleCredentialsSupplier(
         Supplier<GoogleCredentials> googleCredentialsSupplier) {
       this.googleCredentialsSupplier = googleCredentialsSupplier;
       return this;
     }
 
+    /** Chained setter for GoogleCredentials field. */
     public Builder withGoogleCredentials(GoogleCredentials googleCredentials) {
       this.googleCredentials = googleCredentials;
       return this;
     }
 
+    /** Chained setter for GoogleCredentialsPath field. */
     public Builder withGoogleCredentialsPath(String googleCredentialsPath) {
       this.googleCredentialsPath = googleCredentialsPath;
       return this;
     }
 
+    /** Chained setter for Delegates field. */
     public Builder withDelegates(List<String> delegates) {
       this.delegates = delegates;
       return this;
     }
 
+    /** Chained setter for AdminRootUrl field. */
     public Builder withAdminRootUrl(String adminRootUrl) {
       this.adminRootUrl = adminRootUrl;
       return this;
     }
 
+    /** Chained setter for AdminServicePath field. */
     public Builder withAdminServicePath(String adminServicePath) {
       this.adminServicePath = adminServicePath;
       return this;
     }
 
+    /** Chained setter for AdminQuotaProject field. */
     public Builder withAdminQuotaProject(String adminQuotaProject) {
       this.adminQuotaProject = adminQuotaProject;
       return this;
     }
 
+    /** Chained setter for UniverseDomain field. */
     public Builder withUniverseDomain(String universeDomain) {
       this.universeDomain = universeDomain;
       return this;
     }
 
+    /** Chained setter for RefreshStrategy field. */
     public Builder withRefreshStrategy(RefreshStrategy refreshStrategy) {
       this.refreshStrategy = refreshStrategy;
       return this;

--- a/core/src/main/java/com/google/cloud/sql/CredentialFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/CredentialFactory.java
@@ -32,6 +32,7 @@ public interface CredentialFactory {
   /** Name of system property that can specify an alternative credential factory. */
   String CREDENTIAL_FACTORY_PROPERTY = "cloudSql.socketFactory.credentialFactory";
 
+  /** Creates the HttpRequestInitializer. */
   HttpRequestInitializer create();
 
   /**

--- a/core/src/main/java/com/google/cloud/sql/RefreshStrategy.java
+++ b/core/src/main/java/com/google/cloud/sql/RefreshStrategy.java
@@ -18,6 +18,8 @@ package com.google.cloud.sql;
 
 /** Enum for supported refresh strategies. */
 public enum RefreshStrategy {
+  /** Use the Background refresh strategy. */
   BACKGROUND,
+  /** Use the Lazy refresh strategy. */
   LAZY
 }

--- a/core/src/main/java/com/google/cloud/sql/core/ConnectionConfig.java
+++ b/core/src/main/java/com/google/cloud/sql/core/ConnectionConfig.java
@@ -239,26 +239,31 @@ public class ConnectionConfig {
     private ConnectorConfig connectorConfig = new ConnectorConfig.Builder().build();
     private AuthType authType = DEFAULT_AUTH_TYPE;
 
+    /** Chained setter for CloudSqlInstance field. */
     public Builder withCloudSqlInstance(String cloudSqlInstance) {
       this.cloudSqlInstance = cloudSqlInstance;
       return this;
     }
 
+    /** Chained setter for NamedConnector field. */
     public Builder withNamedConnector(String namedConnector) {
       this.namedConnector = namedConnector;
       return this;
     }
 
+    /** Chained setter for ConnectorConfig field. */
     public Builder withConnectorConfig(ConnectorConfig connectorConfig) {
       this.connectorConfig = connectorConfig;
       return this;
     }
 
+    /** Chained setter for UnixSocketPath field. */
     public Builder withUnixSocketPath(String unixSocketPath) {
       this.unixSocketPath = unixSocketPath;
       return this;
     }
 
+    /** Chained setter for AuthType field. */
     public Builder withAuthType(AuthType authType) {
       this.authType = authType;
       return this;
@@ -276,6 +281,7 @@ public class ConnectionConfig {
       return this;
     }
 
+    /** Chained setter for UnixSocketPathSuffix field. */
     public Builder withUnixSocketPathSuffix(String unixSocketPathSuffix) {
       this.unixSocketPathSuffix = unixSocketPathSuffix;
       return this;

--- a/core/src/main/java/com/google/cloud/sql/core/RefreshStrategy.java
+++ b/core/src/main/java/com/google/cloud/sql/core/RefreshStrategy.java
@@ -18,11 +18,18 @@ package com.google.cloud.sql.core;
 
 /** Provide the refresh strategy to the DefaultConnectionInfoCache. */
 public interface RefreshStrategy {
+  /** Return the current valid ConnectionInfo, blocking if necessary for up to the timeout. */
   ConnectionInfo getConnectionInfo(long timeoutMs);
 
+  /** Force a refresh of the ConnectionInfo, possibly in the background. */
   void forceRefresh();
 
+  /** Refresh the ConnectionInfo if it has expired or is near expiration. */
   void refreshIfExpired();
 
+  /**
+   * Stop background threads and refresh operations in progress and refuse to start subsequent
+   * refresh operations.
+   */
   void close();
 }


### PR DESCRIPTION
The checkstyle rules are becoming more strict. All public methods must now have javadoc. 