### PR TITLE
fix: Fix lint issues when upgrading to checkstyle 3.6.0 google-shared-config 1.12.0

### DIFF
--- a/jdbc/mariadb/src/main/java/com/google/cloud/sql/mariadb/SocketFactory.java
+++ b/jdbc/mariadb/src/main/java/com/google/cloud/sql/mariadb/SocketFactory.java
@@ -38,6 +38,7 @@ public class SocketFactory extends ConfigurableSocketFactory {
 
   private Configuration conf;
 
+  /** Instantiate a socket factory. */
   public SocketFactory() {}
 
   @Override

--- a/jdbc/postgres/src/main/java/com/google/cloud/sql/postgres/SocketFactory.java
+++ b/jdbc/postgres/src/main/java/com/google/cloud/sql/postgres/SocketFactory.java
@@ -61,6 +61,11 @@ public class SocketFactory extends javax.net.SocketFactory {
     this.props = info;
   }
 
+  /**
+   * Instantiate a socket factory.
+   *
+   * @param instanceName the instance name.
+   */
   @Deprecated
   public SocketFactory(String instanceName) {
     // Deprecated constructor for converting 'SocketFactoryArg' to 'CloudSqlInstance'

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-shared-config</artifactId>
-    <version>1.11.2</version>
+    <version>1.12.0</version>
   </parent>
 
   <name>Cloud SQL JDBC Socket Factory</name>
@@ -549,7 +549,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-checkstyle-plugin</artifactId>
-            <version>3.5.0</version>
+            <version>3.6.0</version>
             <configuration>
               <configLocation>google_checks.xml</configLocation>
               <logViolationsToConsole>true</logViolationsToConsole>


### PR DESCRIPTION
The latest versions of checkstyle and google-shared-config caused some checkstyle errors. This upgrades the libraries and fixes the errors.