### PR TITLE
chore: Use domain name from JDBC URL for SQL Server, Part of #2043.

### DIFF
--- a/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstanceName.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CloudSqlInstanceName.java
@@ -24,8 +24,10 @@ import java.util.regex.Pattern;
 /**
  * This class parses the different parts of a Cloud SQL Connection Name to allow users to easily
  * fetch the projectId, regionId, and instanceId.
+ *
+ * <p>INTERNAL USE ONLY! This API may change without notice.
  */
-class CloudSqlInstanceName {
+public class CloudSqlInstanceName {
 
   // Unique identifier for each Cloud SQL instance in the format "PROJECT:REGION:INSTANCE"
   // Some legacy project ids are domain-scoped (e.g. "example.com:PROJECT:REGION:INSTANCE")
@@ -65,6 +67,17 @@ class CloudSqlInstanceName {
    */
   public static boolean isValidDomain(String domain) {
     Matcher matcher = DOMAIN_NAME.matcher(domain);
+    return matcher.matches();
+  }
+
+  /**
+   * Checks if a string is a well-formed instance name.
+   *
+   * @param connectionName the value to check
+   * @return true if it is a well-formed instance name.
+   */
+  public static boolean isValidInstanceName(String connectionName) {
+    Matcher matcher = CONNECTION_NAME.matcher(connectionName);
     return matcher.matches();
   }
 

--- a/docs/jdbc.md
+++ b/docs/jdbc.md
@@ -563,6 +563,123 @@ Properties connProps = new Properties();
 connProps.setProperty("cloudSqlRefreshStrategy", "lazy");
 ```
 
+
+
+### Using DNS domain names to identify instances
+
+The connector can be configured to use DNS to look up an instance. This would
+allow you to configure your application to connect to a database instance, and
+centrally configure which instance in your DNS zone.
+
+#### Configure your DNS Records
+
+Add a DNS TXT record for the Cloud SQL instance to a **private** DNS server
+or a private Google Cloud DNS Zone used by your application.
+
+**Note:** You are strongly discouraged from adding DNS records for your
+Cloud SQL instances to a public DNS server. This would allow anyone on the
+internet to discover the Cloud SQL instance name.
+
+For example: suppose you wanted to use the domain name
+`prod-db.mycompany.example.com` to connect to your database instance
+`my-project:region:my-instance`. You would create the following DNS record:
+
+- Record type: `TXT`
+- Name: `prod-db.mycompany.example.com` – This is the domain name used by the application
+- Value: `my-project:region:my-instance` – This is the instance name
+
+
+### Creating the JDBC URL
+
+When specifying the JDBC connection URL, add the additional parameters:
+
+| Property         | Value                                                             |
+|------------------|-------------------------------------------------------------------|
+| socketFactory    | <SOCKET_FACTORY_CLASS>                                            |
+| user             | Database username                                                 |
+| password         | Database user's password                                          |
+
+Replace <SOCKET_FACTORY_CLASS> with the class name specific to your database.
+
+#### MySQL
+
+HOST: The domain name configured in your DNS TXT record. 
+
+Base JDBC URL: `jdbc:mysql://<HOST>/<DATABASE_NAME>`
+
+SOCKET_FACTORY_CLASS: `com.google.cloud.sql.mysql.SocketFactory`
+
+The full JDBC URL should look like this:
+
+```java
+String jdbcUrl = "jdbc:mysql://<HOST>/<DATABASE_NAME>?" 
+    + "&socketFactory=com.google.cloud.sql.mysql.SocketFactory" 
+    + "&user=<MYSQL_USER_NAME>" 
+    + "&password=<MYSQL_USER_PASSWORD>";
+```
+
+#### Maria DB
+
+HOST: The domain name configured in your DNS TXT record.
+
+Base JDBC URL: `jdbc:mariadb://<HOST>/<DATABASE_NAME>`
+
+SOCKET_FACTORY_CLASS: `com.google.cloud.sql.mariadb.SocketFactory`
+
+**Note:** You can use `mysql` as the scheme if you set `permitMysqlScheme` on
+the URL.
+Please refer to the
+MariaDB [documentation](https://mariadb.com/kb/en/about-mariadb-connector-j/#jdbcmysql-scheme-compatibility).
+
+The full JDBC URL should look like this:
+
+```java
+String jdbcUrl = "jdbc:mariadb://<HOST>/<DATABASE_NAME>?" 
+    + "&socketFactory=com.google.cloud.sql.mariadb.SocketFactory" 
+    + "&user=<MYSQL_USER_NAME>" 
+    + "&password=<MYSQL_USER_PASSWORD>";
+```
+
+#### Postgres
+
+Base JDBC URL: `jdbc:postgresql://<HOST>/<DATABASE_NAME>`
+
+SOCKET_FACTORY_CLASS: `com.google.cloud.sql.postgres.SocketFactory`
+
+When specifying the JDBC connection URL, add the additional parameters:
+
+The full JDBC URL should look like this:
+
+```java
+String jdbcUrl = "jdbc:postgresql://<HOST>/<DATABASE_NAME>?" 
+    + "&socketFactory=com.google.cloud.sql.postgres.SocketFactory" 
+    + "&user=<POSTGRESQL_USER_NAME>" 
+    + "&password=<POSTGRESQL_USER_PASSWORD>";
+```
+
+#### SQL Server
+
+Base JDBC URL: `jdbc:sqlserver://localhost;databaseName=<DATABASE_NAME>`
+
+SOCKET_FACTORY_CLASS: `com.google.cloud.sql.sqlserver.SocketFactory`
+
+The full JDBC URL should look like this:
+
+```java
+String jdbcUrl = "jdbc:sqlserver://localhost;" 
+    + "databaseName=<DATABASE_NAME>;" 
+    + "socketFactoryClass=com.google.cloud.sql.sqlserver.SocketFactory;" 
+    + "socketFactoryConstructorArg=<HOST>;" 
+    + "user=<USER_NAME>;" 
+    + "password=<PASSWORD>";
+```
+
+**Note:** The host portion of the JDBC URL is currently unused, and has no
+effect on the connection process. The SocketFactory will get your instances IP
+address based on the provided `socketFactoryConstructorArg` arg.
+
+
+
 ## Configuration Reference
 
 - See [Configuration Reference](configuration.md)

--- a/docs/r2dbc.md
+++ b/docs/r2dbc.md
@@ -362,6 +362,90 @@ ConnectionFactoryOptions options = ConnectionFactoryOptions.builder()
     .build;
 ```
 
+### Using DNS domain names to identify instances
+
+The connector can be configured to use DNS to look up an instance. This would
+allow you to configure your application to connect to a database instance, and
+centrally configure which instance in your DNS zone.
+
+#### Configure your DNS Records
+
+Add a DNS TXT record for the Cloud SQL instance to a **private** DNS server
+or a private Google Cloud DNS Zone used by your application.
+
+**Note:** You are strongly discouraged from adding DNS records for your
+Cloud SQL instances to a public DNS server. This would allow anyone on the
+internet to discover the Cloud SQL instance name.
+
+For example: suppose you wanted to use the domain name
+`prod-db.mycompany.example.com` to connect to your database instance
+`my-project:region:my-instance`. You would create the following DNS record:
+
+- Record type: `TXT`
+- Name: `prod-db.mycompany.example.com` – This is the domain name used by the application
+- Value: `my-project:region:my-instance` – This is the instance name
+
+#### Creating the R2DBC URL
+
+Add the following connection properties:
+
+| Property      | Value                            |
+|---------------|----------------------------------|
+| DATABASE_NAME | The name of the database         |
+| HOST          | The domain name for the instance |
+| DB_USER       | Database username                |
+| DB_PASS       | Database user's password         |
+
+R2DBC URL template:
+
+#### MySQL
+
+```
+r2dbc:gcp:mysql://<DB_USER>:<DB_PASS>@<HOST>/<DATABASE_NAME>
+```
+
+#### MariaDB
+
+```
+r2dbc:gcp:mariadb://<DB_USER>:<DB_PASS>@<HOST>/<DATABASE_NAME>
+```
+
+#### Postgres
+
+```
+r2dbc:gcp:postgres://<DB_USER>:<DB_PASS>@<HOST>/<DATABASE_NAME>
+```
+
+##### SQL Server
+
+```
+r2dbc:gcp:mssql://<DB_USER>:<DB_PASS>@<HOST>/<DATABASE_NAME>
+```
+
+#### Example
+
+```java
+// Set up URL parameters
+ConnectionFactoryOptions options = ConnectionFactoryOptions.builder()
+    .option(DRIVER,"gcp")
+    .option(PROTOCOL,"mysql") // OR "postgres" or "mssql" or "mariadb"
+    .option(PASSWORD,"<DB_PASSWORD>")
+    .option(USER,"<DB_USER>")
+    .option(DATABASE,"<DATABASE_NAME}")
+    .option(HOST,"<HOST>")
+    .build();
+
+ConnectionFactory connectionFactory = ConnectionFactories.get(options);
+ConnectionPoolConfiguration configuration = ConnectionPoolConfiguration
+    .builder(connectionFactory)
+    .build();
+
+ConnectionPool connectionPool = new ConnectionPool(configuration);
+```
+
+
+
+
 ## Configuration Reference
 
 - See [Configuration Reference](configuration.md)

--- a/jdbc/sqlserver/src/test/java/com/google/cloud/sql/sqlserver/JdbcSqlServerIntegrationTests.java
+++ b/jdbc/sqlserver/src/test/java/com/google/cloud/sql/sqlserver/JdbcSqlServerIntegrationTests.java
@@ -74,7 +74,9 @@ public class JdbcSqlServerIntegrationTests {
         "socketFactoryClass", "com.google.cloud.sql.sqlserver.SocketFactory");
     config.addDataSourceProperty("socketFactoryConstructorArg", CONNECTION_NAME);
     config.addDataSourceProperty("encrypt", "false");
-    config.setConnectionTimeout(10000); // 10s
+    config.setConnectionTimeout(30000); // 30s
+    config.setInitializationFailTimeout(10000);
+    config.setValidationTimeout(10000);
 
     this.connectionPool = new HikariDataSource(config);
   }

--- a/jdbc/sqlserver/src/test/java/com/google/cloud/sql/sqlserver/JdbcSqlServerUnitTests.java
+++ b/jdbc/sqlserver/src/test/java/com/google/cloud/sql/sqlserver/JdbcSqlServerUnitTests.java
@@ -28,6 +28,7 @@ import org.junit.runners.JUnit4;
 public class JdbcSqlServerUnitTests {
 
   private static final String CONNECTION_NAME = "my-project:my-region:my-instance";
+  private static final String DOMAIN_NAME = "mydatabase.example.com";
 
   @Test
   public void checkConnectionStringNoQueryParams() throws UnsupportedEncodingException {
@@ -43,6 +44,23 @@ public class JdbcSqlServerUnitTests {
     SocketFactory socketFactory = new SocketFactory(socketFactoryConstructorArg);
     assertThat(socketFactory.props.get(ConnectionConfig.CLOUD_SQL_INSTANCE_PROPERTY))
         .isEqualTo(CONNECTION_NAME);
+    assertThat(socketFactory.props.get("ipTypes")).isEqualTo("PRIVATE");
+  }
+
+  @Test
+  public void checkConnectionStringDomainNameNoQueryParams() throws UnsupportedEncodingException {
+    SocketFactory socketFactory = new SocketFactory(DOMAIN_NAME);
+    assertThat(socketFactory.props.get(ConnectionConfig.CLOUD_SQL_INSTANCE_PROPERTY)).isNull();
+    assertThat(socketFactory.domainName).isEqualTo(DOMAIN_NAME);
+  }
+
+  @Test
+  public void checkConnectionStringDomainNameWithQueryParam() throws UnsupportedEncodingException {
+    String socketFactoryConstructorArg =
+        String.format("%s?%s=%s", DOMAIN_NAME, "ipTypes", "PRIVATE");
+    SocketFactory socketFactory = new SocketFactory(socketFactoryConstructorArg);
+    assertThat(socketFactory.props.get(ConnectionConfig.CLOUD_SQL_INSTANCE_PROPERTY)).isNull();
+    assertThat(socketFactory.domainName).isEqualTo(DOMAIN_NAME);
     assertThat(socketFactory.props.get("ipTypes")).isEqualTo("PRIVATE");
   }
 


### PR DESCRIPTION
Enables Sql Server users to set the domain name in the JDBC URL. Users simply replace the instance connection
name with the domain name.

Due to limitations of the SQL Server driver, users cannot use the JDBC URL's host field. 