### PR TITLE
chore: Use domain name from R2DBC connections, Part of #2043.

### DIFF
--- a/r2dbc/core/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProvider.java
+++ b/r2dbc/core/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProvider.java
@@ -124,11 +124,22 @@ public abstract class GcpConnectionFactoryProvider implements ConnectionFactoryP
             ? RefreshStrategy.LAZY
             : RefreshStrategy.BACKGROUND;
 
+    final String r2dbcHostname = (String) connectionFactoryOptions.getRequiredValue(HOST);
+    final String cloudSqlInstance;
+    final String domainName;
+    if (CloudSqlInstanceName.isValidInstanceName(r2dbcHostname)) {
+      cloudSqlInstance = r2dbcHostname;
+      domainName = null;
+    } else {
+      cloudSqlInstance = null;
+      domainName = r2dbcHostname;
+    }
+
     Builder optionBuilder = createBuilder(connectionFactoryOptions);
-    String cloudSqlInstance = (String) connectionFactoryOptions.getRequiredValue(HOST);
     ConnectionConfig config =
         new ConnectionConfig.Builder()
             .withCloudSqlInstance(cloudSqlInstance)
+            .withDomainName(domainName)
             .withAuthType(enableIamAuth ? AuthType.IAM : AuthType.PASSWORD)
             .withIpTypes(ipTypes)
             .withNamedConnector(namedConnector)

--- a/r2dbc/core/src/test/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderTest.java
+++ b/r2dbc/core/src/test/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderTest.java
@@ -107,6 +107,20 @@ public class GcpConnectionFactoryProviderTest {
     assertThat(config.getConnectorConfig().getAdminServicePath()).isEqualTo("/service");
   }
 
+  @Test
+  public void testCreateWithDomainName() {
+
+    ConnectionFactoryOptions.Builder options = ConnectionFactoryOptions.builder();
+    options.option(ConnectionFactoryOptions.PROTOCOL, "cloudsql");
+    options.option(ConnectionFactoryOptions.HOST, "db.example.com");
+
+    StubConnectionFactory factory = configureConnection(options.build());
+    ConnectionConfig config = factory.config;
+
+    assertThat(config.getDomainName()).isEqualTo("db.example.com");
+    assertThat(config.getCloudSqlInstance()).isNull();
+  }
+
   private static class StubConnectionFactory implements ConnectionFactory {
 
     final ConnectionConfig config;


### PR DESCRIPTION
Now, the connector will detect if the R2DBC `HOST` connection property contains a domain name or a 
Cloud SQL instance name. If `HOST` has a domain name, the connector will look up the domain name to
determine the instance name. 

For example, if the R2DBC url is set to `r2dbc:gcp:mssql://<DB_USER>:<DB_PASS>@db.example.com/db`,
the connector will lookup the TXT record for `db.example.com`. The record should contain a valid
Cloud SQL instance name. 

Part of #2043 

