### PR TITLE
test: Add tests for R2DBC connector configuration

### DIFF
--- a/r2dbc/core/pom.xml
+++ b/r2dbc/core/pom.xml
@@ -79,18 +79,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.apis</groupId>
-      <artifactId>google-api-services-sqladmin</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.http-client</groupId>
-      <artifactId>google-http-client</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.http-client</groupId>
-      <artifactId>google-http-client-gson</artifactId>
+      <groupId>com.google.truth</groupId>
+      <artifactId>truth</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
This adds a new test to check that the GcpConnectionFactoryProvider correctly configures the ConnectionConfiguration.
This also removes up unused test setup code from the GcpConnectionFactoryProviderTest. 