### PR TITLE
refactor: Remove unnecessary pre-fetching from R2DBC.

### DIFF
--- a/r2dbc/core/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProvider.java
+++ b/r2dbc/core/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProvider.java
@@ -144,9 +144,6 @@ public abstract class GcpConnectionFactoryProvider implements ConnectionFactoryP
                     .withRefreshStrategy(refreshStrategy)
                     .build())
             .build();
-    // Precompute SSL Data to trigger the initial refresh to happen immediately,
-    // and ensure enableIAMAuth is set correctly.
-    InternalConnectorRegistry.getInstance().getConnectionMetadata(config);
 
     String socket = (String) connectionFactoryOptions.getValue(UNIX_SOCKET);
     if (socket != null) {


### PR DESCRIPTION
When the java connector was refactored to use ConnectorConfig and ConnectionConfig value objects, it was no longer necessary to pre-fetch the connection configuration to ensure that enableIamAuth was set correctly. Also, this is inconsistent behavior compared to the JDBC socket factory.