### PR TITLE
feat: Use standard TLS hostname validation for instances with DNS names.

### DIFF
--- a/core/src/main/java/com/google/cloud/sql/core/InstanceCheckingTrustManger.java
+++ b/core/src/main/java/com/google/cloud/sql/core/InstanceCheckingTrustManger.java
@@ -96,10 +96,12 @@ class InstanceCheckingTrustManger extends X509ExtendedTrustManager {
       throw new CertificateException("Subject is missing");
     }
 
-    if (instanceMetadata.isCasManagedCertificate() || instanceMetadata.isPscEnabled()) {
-      checkSan(chain);
-    } else {
+    // If the instance metadata does not contain a domain name, use legacy CN validation
+    if (Strings.isNullOrEmpty(instanceMetadata.getDnsName())) {
       checkCn(chain);
+    } else {
+      // If there is a DNS name, check the Subject Alternative Names.
+      checkSan(chain);
     }
   }
 

--- a/core/src/test/java/com/google/cloud/sql/core/CloudSqlCoreTestingBase.java
+++ b/core/src/test/java/com/google/cloud/sql/core/CloudSqlCoreTestingBase.java
@@ -30,6 +30,7 @@ import com.google.api.client.testing.http.MockHttpTransport;
 import com.google.api.client.testing.http.MockLowLevelHttpRequest;
 import com.google.api.client.testing.http.MockLowLevelHttpResponse;
 import com.google.api.services.sqladmin.model.ConnectSettings;
+import com.google.api.services.sqladmin.model.DnsNameMapping;
 import com.google.api.services.sqladmin.model.GenerateEphemeralCertResponse;
 import com.google.api.services.sqladmin.model.IpMapping;
 import com.google.api.services.sqladmin.model.SslCert;
@@ -42,6 +43,7 @@ import java.security.KeyPair;
 import java.time.Duration;
 import java.util.Base64;
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -169,6 +171,18 @@ public class CloudSqlCoreTestingBase {
 
   MockHttpTransport fakeSuccessHttpTransport(
       String serverCert, Duration certDuration, String baseUrl, boolean cas, boolean psc) {
+    return this.fakeSuccessHttpTransport(
+        serverCert, certDuration, baseUrl, cas, psc, cas ? "db.example.com" : null, null);
+  }
+
+  MockHttpTransport fakeSuccessHttpTransport(
+      String serverCert,
+      Duration certDuration,
+      String baseUrl,
+      boolean cas,
+      boolean psc,
+      String legacyDnsName,
+      List<DnsNameMapping> dnsNames) {
     final JsonFactory jsonFactory = new GsonFactory();
     return new MockHttpTransport() {
       @Override
@@ -205,7 +219,8 @@ public class CloudSqlCoreTestingBase {
                       .setDatabaseVersion("POSTGRES14")
                       .setRegion("myRegion")
                       .setPscEnabled(psc ? Boolean.TRUE : null)
-                      .setDnsName(cas || psc ? "db.example.com" : null)
+                      .setDnsName(legacyDnsName)
+                      .setDnsNames(dnsNames)
                       .setServerCaMode(
                           cas ? "GOOGLE_MANAGED_CAS_CA" : "GOOGLE_MANAGED_INTERNAL_CA");
               settings.setFactory(jsonFactory);

--- a/core/src/test/java/com/google/cloud/sql/core/TestCertificateGenerator.java
+++ b/core/src/test/java/com/google/cloud/sql/core/TestCertificateGenerator.java
@@ -130,7 +130,7 @@ public class TestCertificateGenerator {
               SERVER_CA_SUBJECT,
               serverCaKeyPair.getPrivate(),
               ONE_YEAR_FROM_NOW,
-              null);
+              Collections.singletonList(new GeneralName(GeneralName.dNSName, "db.example.com")));
 
       this.serverCertificate2 =
           buildSignedCertificate(
@@ -139,7 +139,7 @@ public class TestCertificateGenerator {
               SERVER_CA_SUBJECT,
               serverCaKeyPair.getPrivate(),
               ONE_YEAR_FROM_NOW,
-              null);
+              Collections.singletonList(new GeneralName(GeneralName.dNSName, "db.example.com")));
 
       this.serverIntemediateCaCert =
           buildSignedCertificate(

--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
       <dependency>
         <groupId>com.google.apis</groupId>
         <artifactId>google-api-services-sqladmin</artifactId>
-        <version>v1beta4-rev20250205-2.0.0</version>
+        <version>v1beta4-rev20250226-2.0.0</version>
       </dependency>
       <dependency>
         <groupId>com.google.http-client</groupId>


### PR DESCRIPTION
When the connector is configured with a DNS name, or if the Cloud SQL Instance reports that it has a DNS Name,
the connector will use standard TLS hostname validation when checking the server certificate. Now, the server's
TLS certificate must contain a SAN record with the instance's DNS name.

The ConnectSettings API added a field dns_names which contains all of the valid DNS names for
an instance..

See also https://github.com/GoogleCloudPlatform/cloud-sql-go-connector/pull/954
