### PR TITLE
fix: Remove unsupported GraalVM UnsupportedExperimentalVMOptions flag.

### DIFF
--- a/core/src/main/resources/META-INF/native-image/com.google.cloud.sql/cloud-sql-jdbc-socket-factory-parent/native-image.properties
+++ b/core/src/main/resources/META-INF/native-image/com.google.cloud.sql/cloud-sql-jdbc-socket-factory-parent/native-image.properties
@@ -1,5 +1,4 @@
 Args =\
-  -H:+UnlockExperimentalVMOptions \
   -H:+AddAllCharsets \
   -H:ReflectionConfigurationResources=META-INF/native-image/com.google.cloud.sql/cloud-sql-jdbc-socket-factory-parent/jni-unix-socket-config.json \
   -H:ResourceConfigurationResources=META-INF/native-image/com.google.cloud.sql/cloud-sql-jdbc-socket-factory-parent/resource-config.json \


### PR DESCRIPTION
The GraalVM flag UnlockExperimentalVMOptions is not supported in GrallVM 17.0, 
and is not required in 21.0 or 23.0. Removing the flag restores compatibility 
with GraalVM 17.

Fixes #2140