### PR TITLE
fix: Roll back dependency update that broke R2DBC + MariaDB IAM E2E Test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <javac.version>9+181-r4173-1</javac.version>
     <graal-sdk.version>24.2.1</graal-sdk.version>
-    <netty.version>4.2.0.Final</netty.version>
+    <netty.version>4.1.119.Final</netty.version>
     <ow2-asm.version>9.8</ow2-asm.version>
     <assembly.skipAssembly>true</assembly.skipAssembly>
   </properties>


### PR DESCRIPTION
Roll back from Netty 4.2.0.Final to 4.1.119.Final. 

The upgrade to Netty 4.2.0.Final broke R2DBC tests. We will need to investigate further before we upgrade Netty.

```
Error:  com.google.cloud.sql.core.R2dbcMariadbIntegrationTests.pooledConnectionTest -- Time elapsed: 0.280 s <<< ERROR!
io.r2dbc.spi.R2dbcNonTransientResourceException: [9000] [H1000] Fail to establish connection to [34.72.43.231:3307] : Connection error
	at org.mariadb.r2dbc.ExceptionFactory.createParsingException(ExceptionFactory.java:66)
	at org.mariadb.r2dbc.HaMode.resumeConnect(HaMode.java:157)
	at org.mariadb.r2dbc.HaMode.lambda$connectHost$7(HaMode.java:206)
	at reactor.core.publisher.FluxOnErrorResume$ResumeSubscriber.onError(FluxOnErrorResume.java:94)
	at reactor.core.publisher.MonoFlatMap$FlatMapMain.onError(MonoFlatMap.java:180)
	at reactor.core.publisher.FluxMapFuseable$MapFuseableSubscriber.onError(FluxMapFuseable.java:142)
	at reactor.core.publisher.MonoPeekTerminal$MonoTerminalPeekSubscriber.onError(MonoPeekTerminal.java:258)
	at reactor.core.publisher.MonoDelayUntil$DelayUntilTrigger.onError(MonoDelayUntil.java:516)
	at reactor.core.publisher.MonoIgnoreThen$ThenIgnoreMain.onError(MonoIgnoreThen.java:280)
	at reactor.core.publisher.FluxDoFinally$DoFinallySubscriber.onError(FluxDoFinally.java:119)
	at reactor.core.publisher.FluxPeek$PeekSubscriber.onError(FluxPeek.java:222)
	at reactor.core.publisher.FluxPeek$PeekSubscriber.onError(FluxPeek.java:222)
	at reactor.core.publisher.FluxPeek$PeekSubscriber.onError(FluxPeek.java:222)
	at reactor.core.publisher.FluxCreate$BaseSink.error(FluxCreate.java:479)
	at reactor.core.publisher.FluxCreate$BufferAsyncSink.drain(FluxCreate.java:868)
	at reactor.core.publisher.FluxCreate$BufferAsyncSink.error(FluxCreate.java:813)
	at reactor.core.publisher.FluxCreate$SerializedFluxSink.drainLoop(FluxCreate.java:239)
	at reactor.core.publisher.FluxCreate$SerializedFluxSink.drain(FluxCreate.java:215)
	at reactor.core.publisher.FluxCreate$SerializedFluxSink.error(FluxCreate.java:191)
	at reactor.core.publisher.LambdaMonoSubscriber.doError(LambdaMonoSubscriber.java:155)
	at reactor.core.publisher.LambdaMonoSubscriber.onError(LambdaMonoSubscriber.java:150)
	at reactor.core.publisher.MonoNext$NextSubscriber.onError(MonoNext.java:93)
	at reactor.core.publisher.FluxHandle$HandleSubscriber.onError(FluxHandle.java:213)
	at reactor.core.publisher.FluxCreate$BaseSink.error(FluxCreate.java:479)
	at reactor.core.publisher.FluxCreate$BufferAsyncSink.drain(FluxCreate.java:868)
	at reactor.core.publisher.FluxCreate$BufferAsyncSink.error(FluxCreate.java:813)
	at reactor.core.publisher.FluxCreate$SerializedFluxSink.drainLoop(FluxCreate.java:239)
	at reactor.core.publisher.FluxCreate$SerializedFluxSink.drain(FluxCreate.java:215)
	at reactor.core.publisher.FluxCreate$SerializedFluxSink.error(FluxCreate.java:191)
	at org.mariadb.r2dbc.client.Exchange.onError(Exchange.java:49)
	at org.mariadb.r2dbc.client.SimpleClient$ServerMessageSubscriber.close(SimpleClient.java:827)
	at org.mariadb.r2dbc.client.SimpleClient.handleConnectionError(SimpleClient.java:284)
	at org.mariadb.r2dbc.client.SimpleClient.sendResumeError(SimpleClient.java:291)
	at org.mariadb.r2dbc.client.SimpleClient.receiveResumeError(SimpleClient.java:298)
	at reactor.core.publisher.FluxOnErrorResume$ResumeSubscriber.onError(FluxOnErrorResume.java:94)
	at reactor.core.publisher.FluxMap$MapSubscriber.onError(FluxMap.java:134)
	at reactor.netty.channel.FluxReceive.terminateReceiver(FluxReceive.java:480)
	at reactor.netty.channel.FluxReceive.drainReceiver(FluxReceive.java:275)
	at reactor.netty.channel.FluxReceive.onInboundError(FluxReceive.java:468)
	at reactor.netty.channel.ChannelOperations.onInboundError(ChannelOperations.java:514)
	at reactor.netty.channel.ChannelOperationsHandler.exceptionCaught(ChannelOperationsHandler.java:153)
	at io.netty.channel.AbstractChannelHandlerContext.invokeExceptionCaught(AbstractChannelHandlerContext.java:291)
	at io.netty.channel.AbstractChannelHandlerContext.fireExceptionCaught(AbstractChannelHandlerContext.java:273)
	at io.netty.handler.ssl.SslHandler.exceptionCaught(SslHandler.java:1222)
	at io.netty.channel.AbstractChannelHandlerContext.invokeExceptionCaught(AbstractChannelHandlerContext.java:291)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:362)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1429)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:918)
	at io.netty.channel.epoll.AbstractEpollStreamChannel$EpollStreamUnsafe.epollInReady(AbstractEpollStreamChannel.java:799)
	at io.netty.channel.epoll.EpollEventLoop.processReady(EpollEventLoop.java:501)
	at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:399)
	at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:1073)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:840)
	Suppressed: java.lang.Exception: #block terminated with an error
		at reactor.core.publisher.BlockingSingleSubscriber.blockingGet(BlockingSingleSubscriber.java:104)
		at reactor.core.publisher.Mono.block(Mono.java:1779)
		at com.google.cloud.sql.core.R2dbcMariadbIntegrationTests.pooledConnectionTest(R2dbcMariadbIntegrationTests.java:87)
		at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
		at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
		at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
		at java.base/java.lang.reflect.Method.invoke(Method.java:569)
		at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
		at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
		at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
		at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
		at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
		at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
		at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
		at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
		... 1 more
Caused by: io.r2dbc.spi.R2dbcNonTransientResourceException: [08000] Connection error
	at org.mariadb.r2dbc.client.SimpleClient.handleConnectionError(SimpleClient.java:282)
	... 23 more
Caused by: io.netty.handler.codec.DecoderException: javax.net.ssl.SSLHandshakeException: No subject alternative names present
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:500)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:290)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:359)
	... 9 more
Caused by: javax.net.ssl.SSLHandshakeException: No subject alternative names present
	at java.base/sun.security.ssl.Alert.createSSLException(Alert.java:131)
	at java.base/sun.security.ssl.TransportContext.fatal(TransportContext.java:383)
	at java.base/sun.security.ssl.TransportContext.fatal(TransportContext.java:326)
	at java.base/sun.security.ssl.TransportContext.fatal(TransportContext.java:321)
	at java.base/sun.security.ssl.CertificateMessage$T12CertificateConsumer.checkServerCerts(CertificateMessage.java:654)
	at java.base/sun.security.ssl.CertificateMessage$T12CertificateConsumer.onCertificate(CertificateMessage.java:473)
	at java.base/sun.security.ssl.CertificateMessage$T12CertificateConsumer.consume(CertificateMessage.java:369)
	at java.base/sun.security.ssl.SSLHandshake.consume(SSLHandshake.java:396)
	at java.base/sun.security.ssl.HandshakeContext.dispatch(HandshakeContext.java:480)
	at java.base/sun.security.ssl.SSLEngineImpl$DelegatedTask$DelegatedAction.run(SSLEngineImpl.java:1277)
	at java.base/sun.security.ssl.SSLEngineImpl$DelegatedTask$DelegatedAction.run(SSLEngineImpl.java:1264)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:712)
	at java.base/sun.security.ssl.SSLEngineImpl$DelegatedTask.run(SSLEngineImpl.java:1209)
	at io.netty.handler.ssl.SslHandler.runDelegatedTasks(SslHandler.java:1695)
	at io.netty.handler.ssl.SslHandler.unwrap(SslHandler.java:1541)
	at io.netty.handler.ssl.SslHandler.decodeJdkCompatible(SslHandler.java:1377)
	at io.netty.handler.ssl.SslHandler.decode(SslHandler.java:1428)
	at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:530)
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:469)
	... 11 more
Caused by: java.security.cert.CertificateException: No subject alternative names present
	at java.base/sun.security.util.HostnameChecker.matchIP(HostnameChecker.java:142)
	at java.base/sun.security.util.HostnameChecker.match(HostnameChecker.java:101)
	at java.base/sun.security.ssl.X509TrustManagerImpl.checkIdentity(X509TrustManagerImpl.java:467)
	at java.base/sun.security.ssl.X509TrustManagerImpl.checkIdentity(X509TrustManagerImpl.java:433)
	at java.base/sun.security.ssl.X509TrustManagerImpl.checkTrusted(X509TrustManagerImpl.java:292)
	at java.base/sun.security.ssl.X509TrustManagerImpl.checkServerTrusted(X509TrustManagerImpl.java:144)
	at com.google.cloud.sql.core.InstanceCheckingTrustManger.checkServerTrusted(InstanceCheckingTrustManger.java:80)
	at java.base/sun.security.ssl.CertificateMessage$T12CertificateConsumer.checkServerCerts(CertificateMessage.java:632)
	... 25 more
```