### PR TITLE
ci: add trusted-contribution.yml to trigger cloud build

### DIFF
--- a/.github/trusted-contribution.yml
+++ b/.github/trusted-contribution.yml
@@ -1,0 +1,28 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Trigger presubmit tests for trusted contributors
+# https://github.com/googleapis/repo-automation-bots/tree/main/packages/trusted-contribution
+# Install: https://github.com/apps/trusted-contributions-gcf
+
+trustedContributors:
+  - "dependabot[bot]"
+  - "renovate-bot"
+  - "renovate[bot]"
+  - "forking-renovate[bot]"
+  - "release-please[bot]"
+annotations:
+  # Trigger Cloud Build tests
+  - type: comment
+    text: "/gcbrun"


### PR DESCRIPTION
Have the `/gcbrun` label auto-added to trusted contributor PRs, such as renovate-bot, release-please, etc.