### PR TITLE
chore: Superficial annotations for Deprecated and test runner.

### DIFF
--- a/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CoreSocketFactory.java
@@ -23,6 +23,7 @@ package com.google.cloud.sql.core;
  * @deprecated Use the official java API instead.
  * @see com.google.cloud.sql.ConnectorRegistry
  */
+@SuppressWarnings("InlineMeSuggester")
 @Deprecated
 public final class CoreSocketFactory {
 
@@ -80,6 +81,7 @@ public final class CoreSocketFactory {
    * @deprecated Use the official java API instead.
    * @see com.google.cloud.sql.ConnectorRegistry
    */
+  @Deprecated
   static void setApplicationName(String artifactId) {
     InternalConnectorRegistry.setApplicationName(artifactId);
   }

--- a/core/src/main/java/com/google/cloud/sql/core/InstanceCheckingTrustManger.java
+++ b/core/src/main/java/com/google/cloud/sql/core/InstanceCheckingTrustManger.java
@@ -170,7 +170,7 @@ class InstanceCheckingTrustManger extends X509ExtendedTrustManager {
       return names;
     }
 
-    for (List item : sanAsn1Field) {
+    for (List<?> item : sanAsn1Field) {
       Integer type = (Integer) item.get(0);
       // RFC 5280 section 4.2.1.6.  "Subject Alternative Name"
       // describes the structure of subjectAlternativeName record.

--- a/core/src/main/java/com/google/cloud/sql/core/InternalConnectorRegistry.java
+++ b/core/src/main/java/com/google/cloud/sql/core/InternalConnectorRegistry.java
@@ -71,7 +71,7 @@ public final class InternalConnectorRegistry {
    * @deprecated Use {@link #setApplicationName(String)} to set the application name
    *     programmatically.
    */
-  static final String USER_TOKEN_PROPERTY_NAME = "_CLOUD_SQL_USER_TOKEN";
+  @Deprecated static final String USER_TOKEN_PROPERTY_NAME = "_CLOUD_SQL_USER_TOKEN";
 
   @VisibleForTesting
   InternalConnectorRegistry(

--- a/core/src/main/java/com/google/cloud/sql/core/JndiDnsResolver.java
+++ b/core/src/main/java/com/google/cloud/sql/core/JndiDnsResolver.java
@@ -61,7 +61,7 @@ class JndiDnsResolver implements DnsResolver {
       // See https://docs.oracle.com/javase/7/docs/technotes/guides/jndi/jndi-dns.html
 
       // Explicitly reference the JNDI DNS classes. This is required for GraalVM.
-      Hashtable contextProps = new Hashtable<>();
+      Hashtable<String, String> contextProps = new Hashtable<>();
       contextProps.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.dns.DnsContextFactory");
       contextProps.put(Context.OBJECT_FACTORIES, "com.sun.jndi.url.dns.dnsURLContextFactory");
       Attribute attr =

--- a/core/src/test/java/com/google/cloud/sql/ConnectorConfigTest.java
+++ b/core/src/test/java/com/google/cloud/sql/ConnectorConfigTest.java
@@ -28,7 +28,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Supplier;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
+@RunWith(JUnit4.class)
 public class ConnectorConfigTest {
   @Test
   public void testConfigFromBuilder() {

--- a/core/src/test/java/com/google/cloud/sql/CredentialFactoryTest.java
+++ b/core/src/test/java/com/google/cloud/sql/CredentialFactoryTest.java
@@ -34,7 +34,10 @@ import com.google.auth.oauth2.OAuth2Credentials;
 import java.io.IOException;
 import java.util.Collections;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
+@RunWith(JUnit4.class)
 public class CredentialFactoryTest {
 
   @Test

--- a/core/src/test/java/com/google/cloud/sql/core/ApiClientRetryingCallableTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/ApiClientRetryingCallableTest.java
@@ -23,7 +23,10 @@ import com.google.api.client.http.HttpResponseException;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
+@RunWith(JUnit4.class)
 public class ApiClientRetryingCallableTest {
   @Test
   public void testApiClientRetriesOn500ErrorAndSucceeds() throws Exception {

--- a/core/src/test/java/com/google/cloud/sql/core/ConnectionConfigTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/ConnectionConfigTest.java
@@ -27,7 +27,10 @@ import java.util.List;
 import java.util.Properties;
 import java.util.stream.Collectors;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
+@RunWith(JUnit4.class)
 public class ConnectionConfigTest {
 
   @Test

--- a/core/src/test/java/com/google/cloud/sql/core/ConnectorTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/ConnectorTest.java
@@ -45,7 +45,10 @@ import javax.net.ssl.SSLHandshakeException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
+@RunWith(JUnit4.class)
 public class ConnectorTest extends CloudSqlCoreTestingBase {
   ListeningScheduledExecutorService defaultExecutor;
   private final long TEST_MAX_REFRESH_MS = 5000L;

--- a/core/src/test/java/com/google/cloud/sql/core/ConstantCredentialsFactoryTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/ConstantCredentialsFactoryTest.java
@@ -20,7 +20,10 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.auth.oauth2.GoogleCredentials;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
+@RunWith(JUnit4.class)
 public class ConstantCredentialsFactoryTest {
 
   @Test

--- a/core/src/test/java/com/google/cloud/sql/core/DefaultAccessTokenSupplierTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/DefaultAccessTokenSupplierTest.java
@@ -45,7 +45,10 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
+@RunWith(JUnit4.class)
 public class DefaultAccessTokenSupplierTest {
 
   private final Instant now = Instant.now();

--- a/core/src/test/java/com/google/cloud/sql/core/DefaultConnectionInfoRepositoryTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/DefaultConnectionInfoRepositoryTest.java
@@ -36,7 +36,10 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 import javax.net.ssl.SSLContext;
 import org.bouncycastle.operator.OperatorCreationException;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
+@RunWith(JUnit4.class)
 public class DefaultConnectionInfoRepositoryTest {
 
   public static final String SAMPLE_PUBLIC_IP = "34.1.2.3";

--- a/core/src/test/java/com/google/cloud/sql/core/FileCredentialFactoryTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/FileCredentialFactoryTest.java
@@ -21,7 +21,10 @@ import static org.junit.Assert.*;
 
 import com.google.auth.oauth2.GoogleCredentials;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
+@RunWith(JUnit4.class)
 public class FileCredentialFactoryTest {
 
   @Test

--- a/core/src/test/java/com/google/cloud/sql/core/LazyRefreshConnectionInfoCacheTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/LazyRefreshConnectionInfoCacheTest.java
@@ -23,7 +23,10 @@ import java.security.KeyPair;
 import java.util.concurrent.ExecutionException;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
+@RunWith(JUnit4.class)
 public class LazyRefreshConnectionInfoCacheTest {
   private ListenableFuture<KeyPair> keyPairFuture;
   private final StubCredentialFactory stubCredentialFactory =

--- a/core/src/test/java/com/google/cloud/sql/core/LazyRefreshStrategyTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/LazyRefreshStrategyTest.java
@@ -24,7 +24,10 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
+@RunWith(JUnit4.class)
 public class LazyRefreshStrategyTest {
   public static final long TEST_TIMEOUT_MS = 3000;
 

--- a/core/src/test/java/com/google/cloud/sql/core/MonitoredCacheTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/MonitoredCacheTest.java
@@ -26,7 +26,10 @@ import javax.net.ssl.SSLSocket;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
+@RunWith(JUnit4.class)
 public class MonitoredCacheTest {
   private static final Timer timer = new Timer(true);
 

--- a/core/src/test/java/com/google/cloud/sql/core/RefreshAheadConnectionInfoCacheConcurrencyTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/RefreshAheadConnectionInfoCacheConcurrencyTest.java
@@ -30,9 +30,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@RunWith(JUnit4.class)
 public class RefreshAheadConnectionInfoCacheConcurrencyTest {
 
   public static final int DEFAULT_WAIT = 200;

--- a/core/src/test/java/com/google/cloud/sql/core/RefreshAheadConnectionInfoCacheTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/RefreshAheadConnectionInfoCacheTest.java
@@ -41,7 +41,10 @@ import javax.net.ssl.KeyManagerFactory;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
+@RunWith(JUnit4.class)
 public class RefreshAheadConnectionInfoCacheTest {
 
   public static final long TEST_TIMEOUT_MS = 3000;

--- a/core/src/test/java/com/google/cloud/sql/core/RetryingCallableTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/RetryingCallableTest.java
@@ -21,7 +21,10 @@ import static com.google.common.truth.Truth.assertThat;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
+@RunWith(JUnit4.class)
 public class RetryingCallableTest {
   @Test
   public void testConstructorIllegalArguments() throws Exception {

--- a/core/src/test/java/com/google/cloud/sql/core/ServiceAccountImpersonatingCredentialFactoryIntegrationTests.java
+++ b/core/src/test/java/com/google/cloud/sql/core/ServiceAccountImpersonatingCredentialFactoryIntegrationTests.java
@@ -27,7 +27,10 @@ import com.google.cloud.sql.CredentialFactory;
 import java.util.Arrays;
 import java.util.Collections;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
+@RunWith(JUnit4.class)
 public class ServiceAccountImpersonatingCredentialFactoryIntegrationTests {
 
   @Test

--- a/core/src/test/java/com/google/cloud/sql/core/SupplierCredentialFactoryTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/SupplierCredentialFactoryTest.java
@@ -20,7 +20,10 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.auth.oauth2.GoogleCredentials;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
+@RunWith(JUnit4.class)
 public class SupplierCredentialFactoryTest {
 
   @Test


### PR DESCRIPTION
This contains superficial changes to annotations. This tags specific fields labeled as deprecated in the javadoc
with `@Deprecated` annotation. Also, this adds `@RunWith(JUnit4.class)` to several test cases to make 
the test classes explicit.