### PR TITLE
ci: Update to use zulu-openjdk-17 image for integration tests.

### DIFF
--- a/.ci/cloudbuild.yaml
+++ b/.ci/cloudbuild.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 steps:
   - id: run integration tests
-    name: maven:${_MAVEN_VERSION}
+    name: ${_CONTAINER_IMAGE}
     entrypoint: bash
     env:
       - "IP_TYPE=${_IP_TYPE}"
@@ -106,7 +106,6 @@ availableSecrets:
     - versionName: "projects/$PROJECT_ID/secrets/CLOUD_BUILD_SA/versions/latest"
       env: "IMPERSONATED_USER"
 substitutions:
-  _MAVEN_VERSION: ${_VERSION}
   _IP_TYPE: ${_IP_TYPE}
 options:
   dynamicSubstitutions: true

--- a/.github/scripts/run_tests.sh
+++ b/.github/scripts/run_tests.sh
@@ -14,7 +14,10 @@
 # limitations under the License.
 
 # `-e` enables the script to automatically fail when a command fails
-set -e
+set -ex
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+PROJECT_DIR=$( dirname "$SCRIPT_DIR" )
 
 if [[ $OSTYPE == 'darwin'* ]]; then
   # Add alias for 127.0.0.2 to be used as a loopback address
@@ -27,7 +30,16 @@ echo -e "******************** Running tests... ********************\n"
 echo "Running tests using Java:"
 java -version
 
-echo "Maven version: $(mvn --version)"
+# Use the mvn command
+if which mvn ; then
+  mvn_cmd="mvn"
+else
+  mvn_cmd="./mvnw"
+fi
+
+ls -al
+
+echo "Maven version: $($mvn_cmd --version)"
 
 echo "Job type: ${JOB_TYPE}"
 
@@ -36,11 +48,11 @@ set +e
 
 case ${JOB_TYPE} in
 test)
-    mvn -e -B clean -ntp test -P coverage -Dcheckstyle.skip
+    $mvn_cmd -e -B clean -ntp test -P coverage -Dcheckstyle.skip
     RETURN_CODE=$?
     ;;
 integration)
-    mvn -e -B clean -ntp verify -P e2e -P coverage -Dcheckstyle.skip
+    $mvn_cmd -e -B clean -ntp verify -P e2e -P coverage -Dcheckstyle.skip
     RETURN_CODE=$?
     ;;
 esac


### PR DESCRIPTION
This better matches Github Action build configuration to Cloud build.