### PR TITLE
deps: use latest shared config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-shared-config</artifactId>
-    <version>1.15.4</version>
+    <version>1.16.1</version>
   </parent>
 
   <name>Cloud SQL JDBC Socket Factory</name>
@@ -439,18 +439,6 @@
             </path>
           </annotationProcessorPaths>
           <failOnWarning>true</failOnWarning>
-        </configuration>
-      </plugin>
-
-      <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.7.0</version>
-        <extensions>true</extensions>
-        <configuration>
-          <serverId>ossrh</serverId>
-          <nexusUrl>https://google.oss.sonatype.org/</nexusUrl>
-          <autoReleaseAfterClose>false</autoReleaseAfterClose>
         </configuration>
       </plugin>
 


### PR DESCRIPTION
Stop declaring nexus-staging-maven-plugin because the plugin is
configured in the parent POM (shared config).
