### PR TITLE
deps: Explicitly pin netty to 4.1.119.Final to fix R2DBC with MariaDB

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -65,6 +65,10 @@
       "matchManagers": ["github-actions"],
       "groupName": "dependencies for github",
       "commitMessagePrefix": "chore(deps):"
+    },
+    {
+      "matchPackagePatterns": ["^io.netty:netty-"],
+      "allowedVersions": "4.1.119.Final"
     }
   ]
 }


### PR DESCRIPTION
The MariaDB R2DBC drivers are not compatible with Netty 4.2. We have tried several versions of the Netty library, but none seem to work. This causes integration tests to fail with the error below. This problem is not caught by the current unit test suite. 

We are configuring our tools to ignore updates past Netty 4.1.119.Final. 

```

23:02:08.659 [reactor-tcp-epoll-2] WARN  o.m.r.m.flow.AuthenticationFlow - Authentication failed
--
  | io.r2dbc.spi.R2dbcNonTransientResourceException: Connection error
  | at org.mariadb.r2dbc.client.SimpleClient.handleConnectionError(SimpleClient.java:282)
  | at org.mariadb.r2dbc.client.SimpleClient.sendResumeError(SimpleClient.java:291)
  | at org.mariadb.r2dbc.client.SimpleClient.receiveResumeError(SimpleClient.java:298)
  | at reactor.core.publisher.FluxOnErrorResume$ResumeSubscriber.onError(FluxOnErrorResume.java:94)
  | at reactor.core.publisher.FluxMap$MapSubscriber.onError(FluxMap.java:134)
  | at reactor.netty.channel.FluxReceive.terminateReceiver(FluxReceive.java:480)
  | at reactor.netty.channel.FluxReceive.drainReceiver(FluxReceive.java:275)
  | at reactor.netty.channel.FluxReceive.onInboundError(FluxReceive.java:468)
  | at reactor.netty.channel.ChannelOperations.onInboundError(ChannelOperations.java:514)
  | at reactor.netty.channel.ChannelOperationsHandler.exceptionCaught(ChannelOperationsHandler.java:153)
  | at io.netty.channel.AbstractChannelHandlerContext.invokeExceptionCaught(AbstractChannelHandlerContext.java:289)
  | at io.netty.channel.AbstractChannelHandlerContext.fireExceptionCaught(AbstractChannelHandlerContext.java:271)
  | at io.netty.handler.ssl.SslHandler.exceptionCaught(SslHandler.java:1238)
  | at io.netty.channel.AbstractChannelHandlerContext.invokeExceptionCaught(AbstractChannelHandlerContext.java:289)
  | at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:359)
  | at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1429)
  | at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:918)
  | at io.netty.channel.epoll.AbstractEpollStreamChannel$EpollStreamUnsafe.epollInReady(AbstractEpollStreamChannel.java:799)
  | at io.netty.channel.epoll.EpollEventLoop.processReady(EpollEventLoop.java:501)
  | at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:399)
  | at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:1073)
  | at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
  | at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
  | at java.base/java.lang.Thread.run(Thread.java:840)
  | Caused by: io.netty.handler.codec.DecoderException: javax.net.ssl.SSLHandshakeException: No subject alternative names present
  | at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:500)
  | at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:290)
  | at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:356)
  | ... 9 common frames omitted
  | Caused by: javax.net.ssl.SSLHandshakeException: No subject alternative names present
  | at java.base/sun.security.ssl.Alert.createSSLException(Alert.java:131)
  | at java.base/sun.security.ssl.TransportContext.fatal(TransportContext.java:383)
  | at java.base/sun.security.ssl.TransportContext.fatal(TransportContext.java:326)
  | at java.base/sun.security.ssl.TransportContext.fatal(TransportContext.java:321)
  | at java.base/sun.security.ssl.CertificateMessage$T12CertificateConsumer.checkServerCerts(CertificateMessage.java:654)
  | at java.base/sun.security.ssl.CertificateMessage$T12CertificateConsumer.onCertificate(CertificateMessage.java:473)
  | at java.base/sun.security.ssl.CertificateMessage$T12CertificateConsumer.consume(CertificateMessage.java:369)
  | at java.base/sun.security.ssl.SSLHandshake.consume(SSLHandshake.java:396)
  | at java.base/sun.security.ssl.HandshakeContext.dispatch(HandshakeContext.java:480)
  | at java.base/sun.security.ssl.SSLEngineImpl$DelegatedTask$DelegatedAction.run(SSLEngineImpl.java:1277)
  | at java.base/sun.security.ssl.SSLEngineImpl$DelegatedTask$DelegatedAction.run(SSLEngineImpl.java:1264)
  | at java.base/java.security.AccessController.doPrivileged(AccessController.java:712)
  | at java.base/sun.security.ssl.SSLEngineImpl$DelegatedTask.run(SSLEngineImpl.java:1209)
  | at io.netty.handler.ssl.SslHandler.runDelegatedTasks(SslHandler.java:1716)
  | at io.netty.handler.ssl.SslHandler.unwrap(SslHandler.java:1562)
  | at io.netty.handler.ssl.SslHandler.decodeJdkCompatible(SslHandler.java:1398)
  | at io.netty.handler.ssl.SslHandler.decode(SslHandler.java:1449)
  | at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:530)
  | at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:469)
  | ... 11 common frames omitted
  | Caused by: java.security.cert.CertificateException: No subject alternative names present
  | at java.base/sun.security.util.HostnameChecker.matchIP(HostnameChecker.java:142)
  | at java.base/sun.security.util.HostnameChecker.match(HostnameChecker.java:101)
  | at java.base/sun.security.ssl.X509TrustManagerImpl.checkIdentity(X509TrustManagerImpl.java:467)
  | at java.base/sun.security.ssl.X509TrustManagerImpl.checkIdentity(X509TrustManagerImpl.java:433)
  | at java.base/sun.security.ssl.X509TrustManagerImpl.checkTrusted(X509TrustManagerImpl.java:292)
  | at java.base/sun.security.ssl.X509TrustManagerImpl.checkServerTrusted(X509TrustManagerImpl.java:144)
  | at com.google.cloud.sql.core.InstanceCheckingTrustManger.checkServerTrusted(InstanceCheckingTrustManger.java:99)
  | at java.base/sun.security.ssl.CertificateMessage$T12CertificateConsumer.checkServerCerts(CertificateMessage.java:632)
  | ... 25 common frames omitted
  | [INFO]
  | [INFO] Results:
  | [INFO]
  | [ERROR] Errors:
  | [ERROR]   R2dbcMariadbIamAuthIntegrationTests.pooledConnectionTest » R2dbcNonTransientResource Fail to establish connection to [10.119.0.5:3307] : Connection error
  | [ERROR]   R2dbcMariadbIntegrationTests.pooledConnectionTest » R2dbcNonTransientResource Fail to establish connection to [34.72.43.231:3307] : Connection error
  | [INFO]
  | [ERROR] Tests run: 2, Failures: 0, Errors: 2, Skipped: 0
  | [INFO]
```