### PR TITLE
fix: Use the -jre variant of Google Guava library for GraalVM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>33.4.8-android</version>
+        <version>33.4.8-jre</version>
       </dependency>
       <dependency>
         <groupId>com.google.j2objc</groupId>


### PR DESCRIPTION
The Google Guava library comes in two variants: -android and -jre.  This swiches the project to use the -jre variant so that GraalVM projects will compile correctly.  GraalVM does not compile with the -android variant of Guava.

Fixes #2178