### PR TITLE
feat: Add DnsJavaResolver and related test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ target/
 **/.project
 **/.settings/
 **/.classpath
+.vscode/
 
 # direnv
 .envrc

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -127,6 +127,11 @@
       <artifactId>google-oauth-client</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>dnsjava</groupId>
+      <artifactId>dnsjava</artifactId>
+    </dependency>
+
     <!-- com.google.cloud.sql.nativeimage.CloudSqlFeature needs the GraalVM
       dependencies for compilation. The provided-scope dependencies do not add
       additional dependencies to library users. -->

--- a/core/src/main/java/com/google/cloud/sql/core/DnsJavaResolver.java
+++ b/core/src/main/java/com/google/cloud/sql/core/DnsJavaResolver.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.sql.core;
+
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.stream.Collectors;
+import javax.naming.NameNotFoundException;
+import org.xbill.DNS.Lookup;
+import org.xbill.DNS.Record;
+import org.xbill.DNS.SimpleResolver;
+import org.xbill.DNS.TXTRecord;
+import org.xbill.DNS.TextParseException;
+import org.xbill.DNS.Type;
+
+/** DnsJavaResolver is a DnsResolver that uses the dnsjava library to perform DNS lookups. */
+public class DnsJavaResolver implements DnsResolver {
+
+  private final SimpleResolver resolver;
+
+  /** Creates a resolver using the system's default DNS settings. */
+  public DnsJavaResolver() {
+    this.resolver = null; // dnsjava's Lookup uses default resolver if null.
+  }
+
+  /**
+   * Creates a DNS resolver that uses a specific DNS server.
+   *
+   * @param dnsServer the DNS server hostname
+   * @param port the DNS server port (DNS servers usually use port 53)
+   */
+  public DnsJavaResolver(String dnsServer, int port) {
+    try {
+      this.resolver = new SimpleResolver(dnsServer);
+      this.resolver.setPort(port);
+    } catch (UnknownHostException e) {
+      throw new IllegalArgumentException("Unknown DNS server host: " + dnsServer, e);
+    }
+  }
+
+  /**
+   * Returns DNS TXT records for a domain name, sorted alphabetically.
+   *
+   * @param domainName the domain name to lookup
+   * @return the list of records
+   * @throws NameNotFoundException when the domain name does not resolve.
+   */
+  @Override
+  public Collection<String> resolveTxt(String domainName) throws NameNotFoundException {
+    try {
+      // 1. Create a Lookup object for the TXT record type.
+      Lookup lookup = new Lookup(domainName, Type.TXT);
+
+      // 2. Set the custom resolver if one was provided in the constructor.
+      if (this.resolver != null) {
+        lookup.setResolver(this.resolver);
+      }
+
+      // 3. Execute the DNS query.
+      lookup.run();
+
+      // 4. Check the result of the lookup.
+      int resultCode = lookup.getResult();
+      if (resultCode == Lookup.HOST_NOT_FOUND) {
+        throw new NameNotFoundException("DNS record not found for " + domainName);
+      }
+      if (resultCode == Lookup.TYPE_NOT_FOUND) {
+        return Collections.emptyList();
+      }
+      if (resultCode != Lookup.SUCCESSFUL) {
+        throw new RuntimeException(
+            "DNS lookup failed for " + domainName + ": " + lookup.getErrorString());
+      }
+
+      // 5. Process the records, sort them, and return.
+      Record[] records = lookup.getAnswers();
+      if (records == null || records.length == 0) {
+        return Collections.emptyList();
+      }
+
+      // A single TXT record can contain multiple strings, so we use flatMap.
+      return Arrays.stream(records)
+          .map(r -> (TXTRecord) r)
+          .flatMap(txtRecord -> txtRecord.getStrings().stream())
+          .sorted() // sort multiple records alphabetically
+          .collect(Collectors.toList());
+
+    } catch (TextParseException e) {
+      // This happens if the domainName is not a valid format.
+      throw new RuntimeException("Invalid domain name format: " + domainName, e);
+    }
+  }
+}

--- a/core/src/main/java/com/google/cloud/sql/core/DnsJavaResolver.java
+++ b/core/src/main/java/com/google/cloud/sql/core/DnsJavaResolver.java
@@ -81,7 +81,7 @@ public class DnsJavaResolver implements DnsResolver {
         throw new NameNotFoundException("DNS record not found for " + domainName);
       }
       if (resultCode == Lookup.TYPE_NOT_FOUND) {
-        return Collections.emptyList();
+        throw new NameNotFoundException("DNS record type TXT not found for " + domainName);
       }
       if (resultCode != Lookup.SUCCESSFUL) {
         throw new RuntimeException(

--- a/core/src/test/java/com/google/cloud/sql/core/DnsJavaResolverTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/DnsJavaResolverTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.sql.core;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import java.util.Collection;
+import javax.naming.NameNotFoundException;
+import org.junit.Test;
+
+public class DnsJavaResolverTest {
+
+  private static final String VALID_DOMAIN_NAME = "invalid-san-test.csqlconnectortest.com";
+  private static final String VALID_DOMAIN_NAME_DATA =
+      "cloud-sql-connector-testing:us-central1:postgres-customer-cas-test";
+  private static final String INVALID_DOMAIN_NAME = "not-a-real-domain.com";
+
+  @Test
+  public void testResolveTxt_validDomainName() throws NameNotFoundException {
+    DnsJavaResolver resolver = new DnsJavaResolver();
+    Collection<String> records = resolver.resolveTxt(VALID_DOMAIN_NAME);
+    assertThat(records).isNotEmpty();
+
+    // Check that the record contains the expected IP address.
+    assertThat(records).contains(VALID_DOMAIN_NAME_DATA);
+  }
+
+  @Test
+  public void testResolveTxt_notFound() throws NameNotFoundException {
+    DnsJavaResolver resolver = new DnsJavaResolver();
+    Collection<String> records = resolver.resolveTxt(INVALID_DOMAIN_NAME);
+    assertThat(records).isEmpty();
+  }
+
+  @Test
+  public void testDnsJavaResolver_invalidDnsServer() {
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class, () -> new DnsJavaResolver("not-a-real-dns-server", 53));
+    assertThat(ex).hasMessageThat().contains("Unknown DNS server host");
+  }
+
+  @Test
+  public void testDnsJavaResolver_validDnsServer() throws NameNotFoundException {
+    // Use a public DNS server to resolve a real domain.
+    // Note: "8.8.8.8" is Google's public DNS Server
+    DnsJavaResolver resolver = new DnsJavaResolver("8.8.8.8", 53);
+    Collection<String> records = resolver.resolveTxt(VALID_DOMAIN_NAME);
+    assertThat(records).isNotEmpty();
+    assertThat(records).contains(VALID_DOMAIN_NAME_DATA);
+  }
+}

--- a/core/src/test/java/com/google/cloud/sql/core/DnsJavaResolverTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/DnsJavaResolverTest.java
@@ -51,10 +51,9 @@ public class DnsJavaResolverTest {
   }
 
   @Test
-  public void testResolveTxt_notFound() throws NameNotFoundException {
+  public void testResolveTxt_notFound() {
     DnsJavaResolver resolver = new DnsJavaResolver();
-    Collection<String> records = resolver.resolveTxt(INVALID_DOMAIN_NAME);
-    assertThat(records).isEmpty();
+    assertThrows(NameNotFoundException.class, () -> resolver.resolveTxt(INVALID_DOMAIN_NAME));
   }
 
   @Test

--- a/core/src/test/java/com/google/cloud/sql/core/DnsJavaResolverTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/DnsJavaResolverTest.java
@@ -26,6 +26,8 @@ import org.junit.Test;
 public class DnsJavaResolverTest {
 
   private static final String VALID_DOMAIN_NAME = "invalid-san-test.csqlconnectortest.com";
+  private static final String MULTI_STRING_RECORD_DOMAIN_NAME =
+      "test-multi-string-txt-record.csqlconnectortest.com";
   private static final String VALID_DOMAIN_NAME_DATA =
       "cloud-sql-connector-testing:us-central1:postgres-customer-cas-test";
   private static final String INVALID_DOMAIN_NAME = "not-a-real-domain.com";
@@ -38,6 +40,14 @@ public class DnsJavaResolverTest {
 
     // Check that the record contains the expected IP address.
     assertThat(records).contains(VALID_DOMAIN_NAME_DATA);
+  }
+
+  @Test
+  public void testResolveTxt_multiStringRecord() throws NameNotFoundException {
+    DnsJavaResolver resolver = new DnsJavaResolver();
+    Collection<String> records = resolver.resolveTxt(MULTI_STRING_RECORD_DOMAIN_NAME);
+    assertThat(records).isNotEmpty();
+    assertThat(records).containsExactly("string1", "string2");
   }
 
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -198,6 +198,11 @@
         <version>0.38.23</version>
       </dependency>
       <dependency>
+        <groupId>dnsjava</groupId>
+        <artifactId>dnsjava</artifactId>
+        <version>3.2.2</version>
+      </dependency>
+      <dependency>
         <groupId>org.graalvm.sdk</groupId>
         <artifactId>nativeimage</artifactId>
         <version>24.2.2</version>


### PR DESCRIPTION
Description:

This PR Adds the following:

1. The dnsjava dependency, and a new class `DnsJavaResolver`. Which will be use to replace `JndiDnsResolver` for DNS record lookup. 
2. DnsJavaResolverTest to make sure DnsJavaResolver are working as expected

Next:
Will replace and remove `JndiDnsResolver` with `DnsJavaResolver` in the next PR. 