### PR TITLE
feat: Automatically set MDX client_protocol_type=TLS for MySQL connections.

### DIFF
--- a/jdbc/mysql-j-8/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
+++ b/jdbc/mysql-j-8/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
@@ -60,7 +60,8 @@ public class SocketFactory implements com.mysql.cj.protocol.SocketFactory {
     T socket =
         (T)
             InternalConnectorRegistry.getInstance()
-                .connect(ConnectionConfig.fromConnectionProperties(props, host)
+                .connect(
+                    ConnectionConfig.fromConnectionProperties(props, host)
                         .withMdxClientProtocolType("tls"));
     return socket;
   }


### PR DESCRIPTION
When a Cloud SQL instance supports Metadata Exchange, the MySQL socket factory will 
automatically set MDX client_protocol_type=TLS. This will ensure that the password
auth protocol works correctly. 

See also https://github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory/pull/2200 and https://github.com/GoogleCloudPlatform/cloud-sql-proxy/issues/2317