### PR TITLE
fix: Update the R2DBC connectors to work with Netty 4.2+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -236,42 +236,42 @@
       <dependency>
         <groupId>io.projectreactor.netty</groupId>
         <artifactId>reactor-netty</artifactId>
-        <version>1.2.8</version>
+        <version>1.3.1</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-handler</artifactId>
-        <version>4.1.123.Final</version>
+        <version>4.2.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-common</artifactId>
-        <version>4.1.123.Final</version>
+        <version>4.2.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport</artifactId>
-        <version>4.1.123.Final</version>
+        <version>4.2.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-unix-common</artifactId>
-        <version>4.1.123.Final</version>
+        <version>4.2.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-buffer</artifactId>
-        <version>4.1.123.Final</version>
+        <version>4.2.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec</artifactId>
-        <version>4.1.123.Final</version>
+        <version>4.2.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-resolver</artifactId>
-        <version>4.1.123.Final</version>
+        <version>4.2.7.Final</version>
       </dependency>
       <!-- Logging -->
       <dependency> 
@@ -396,11 +396,11 @@
                   </ignoreVersion>
                 </rule>
                 <rule>
-                  <!-- Always Ignore netty versions > 4.1 -->
+                  <!-- Always Ignore netty versions > 4.2 -->
                   <groupId>io.netty</groupId>
                   <ignoreVersion>
                     <type>range</type>
-                    <version>[4.2.0.Alpha,)</version>
+                    <version>[4.3.0.Alpha,)</version>
                   </ignoreVersion>
                   <ignoreVersion>
                     <type>regex</type>

--- a/r2dbc/core/src/main/java/com/google/cloud/sql/core/CloudSqlConnectionFactory.java
+++ b/r2dbc/core/src/main/java/com/google/cloud/sql/core/CloudSqlConnectionFactory.java
@@ -55,7 +55,6 @@ public class CloudSqlConnectionFactory implements ConnectionFactory {
             .getConnectionMetadata(config)
             .getPreferredIpAddress();
     builder.option(HOST, hostIp).option(PORT, SERVER_PROXY_PORT);
-
     return Mono.from(supplier.get().create(builder.build()).create())
         .map(c -> new CloudSqlConnection(config, c));
   }

--- a/r2dbc/core/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProvider.java
+++ b/r2dbc/core/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProvider.java
@@ -174,6 +174,11 @@ public abstract class GcpConnectionFactoryProvider implements ConnectionFactoryP
           sslContextBuilder.trustManager(connectionMetadata.getTrustManagerFactory());
           sslContextBuilder.protocols("TLSv1.2");
 
+          // Disable the default SSL hostname verification. Cloud SQL instances
+          // require custom hostname checking logic, which is implemented in the
+          // InstanceCheckingTrustManagerFactory.
+          sslContextBuilder.endpointIdentificationAlgorithm("");
+
           return sslContextBuilder;
         };
     return tcpSocketConnectionFactory(config, optionBuilder, sslFunction);

--- a/r2dbc/postgres/pom.xml
+++ b/r2dbc/postgres/pom.xml
@@ -58,7 +58,7 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>r2dbc-postgresql</artifactId>
-      <version>1.0.7.RELEASE</version>
+      <version>1.1.1.RELEASE</version>
       <scope>provided</scope>
       <exclusions>
         <exclusion>

--- a/r2dbc/postgres/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderPostgres.java
+++ b/r2dbc/postgres/src/main/java/com/google/cloud/sql/core/GcpConnectionFactoryProviderPostgres.java
@@ -22,6 +22,7 @@ import static io.r2dbc.spi.ConnectionFactoryOptions.DRIVER;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.r2dbc.postgresql.PostgresqlConnectionFactoryProvider;
 import io.r2dbc.postgresql.client.SSLMode;
+import io.r2dbc.postgresql.client.SSLNegotiation;
 import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.ConnectionFactoryOptions;
 import io.r2dbc.spi.ConnectionFactoryProvider;
@@ -51,7 +52,8 @@ public class GcpConnectionFactoryProviderPostgres extends GcpConnectionFactoryPr
       Function<SslContextBuilder, SslContextBuilder> customizer) {
     builder
         .option(PostgresqlConnectionFactoryProvider.SSL_CONTEXT_BUILDER_CUSTOMIZER, customizer)
-        .option(PostgresqlConnectionFactoryProvider.SSL_MODE, SSLMode.TUNNEL)
+        .option(PostgresqlConnectionFactoryProvider.SSL_MODE, SSLMode.REQUIRE)
+        .option(PostgresqlConnectionFactoryProvider.SSL_NEGOTIATION, SSLNegotiation.TUNNEL)
         .option(PostgresqlConnectionFactoryProvider.TCP_NODELAY, true)
         .option(PostgresqlConnectionFactoryProvider.TCP_KEEPALIVE, true);
 

--- a/r2dbc/postgres/src/test/java/com/google/cloud/sql/core/R2dbcPostgresIamAuthIntegrationTests.java
+++ b/r2dbc/postgres/src/test/java/com/google/cloud/sql/core/R2dbcPostgresIamAuthIntegrationTests.java
@@ -23,7 +23,6 @@ import static com.google.common.truth.Truth.assertWithMessage;
 import static io.r2dbc.spi.ConnectionFactoryOptions.DATABASE;
 import static io.r2dbc.spi.ConnectionFactoryOptions.DRIVER;
 import static io.r2dbc.spi.ConnectionFactoryOptions.HOST;
-import static io.r2dbc.spi.ConnectionFactoryOptions.PASSWORD;
 import static io.r2dbc.spi.ConnectionFactoryOptions.PROTOCOL;
 import static io.r2dbc.spi.ConnectionFactoryOptions.USER;
 
@@ -46,7 +45,6 @@ import reactor.core.publisher.Mono;
 
 @RunWith(JUnit4.class)
 public class R2dbcPostgresIamAuthIntegrationTests {
-
   // [START cloud_sql_connector_postgres_r2dbc_iam_auth]
   private static final String CONNECTION_NAME = System.getenv("POSTGRES_CONNECTION_NAME");
   private static final String DB_NAME = System.getenv("POSTGRES_DB");
@@ -71,13 +69,13 @@ public class R2dbcPostgresIamAuthIntegrationTests {
                 .isNotEmpty());
 
     // [START cloud_sql_connector_postgres_r2dbc_iam_auth]
+    System.out.println("Using IAM user: " + DB_USER);
     // Set up ConnectionFactoryOptions
     ConnectionFactoryOptions options =
         ConnectionFactoryOptions.builder()
             .option(DRIVER, "gcp")
             .option(PROTOCOL, "postgresql")
             // Password must be set to a nonempty value to bypass driver validation errors
-            .option(PASSWORD, "password")
             .option(USER, DB_USER)
             .option(DATABASE, DB_NAME)
             .option(HOST, CONNECTION_NAME)


### PR DESCRIPTION
Netty 4.2 sets the default SSL host validation mode to `HTTPS`. Netty 4.1 did not set this. The R2DBC connector 
needs to clear the SSL host validation mode so that that Netty will use the connector's custom hostname 
validation logic instead of the default.

Fixes #2227