### PR TITLE
feat: Add PSC DNS and Global Write Endpoint support to Java Connector

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 wrapperVersion=3.3.1
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.16/apache-maven-3.9.16-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.15/apache-maven-3.9.15-bin.zip

--- a/core/src/main/java/com/google/cloud/sql/core/ConnectionInfo.java
+++ b/core/src/main/java/com/google/cloud/sql/core/ConnectionInfo.java
@@ -74,7 +74,7 @@ class ConnectionInfo {
 
     return new ConnectionMetadata(
         preferredIps,
-        getIpAddrs(),
+        instanceMetadata.getIpAddrs(),
         sslData.getKeyManagerFactory(),
         sslData.getTrustManagerFactory(),
         sslData.getSslContext(),

--- a/core/src/main/java/com/google/cloud/sql/core/ConnectionInfo.java
+++ b/core/src/main/java/com/google/cloud/sql/core/ConnectionInfo.java
@@ -18,6 +18,7 @@ package com.google.cloud.sql.core;
 
 import com.google.cloud.sql.IpType;
 import java.time.Instant;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import javax.net.ssl.SSLContext;
@@ -45,7 +46,7 @@ class ConnectionInfo {
     return sslContext;
   }
 
-  Map<IpType, String> getIpAddrs() {
+  Map<IpType, List<String>> getIpAddrs() {
     return instanceMetadata.getIpAddrs();
   }
 
@@ -55,15 +56,15 @@ class ConnectionInfo {
 
   ConnectionMetadata toConnectionMetadata(
       ConnectionConfig config, CloudSqlInstanceName instanceName) {
-    String preferredIp = null;
+    List<String> preferredIps = null;
 
     for (IpType ipType : config.getIpTypes()) {
-      preferredIp = getIpAddrs().get(ipType);
-      if (preferredIp != null) {
+      preferredIps = getIpAddrs().get(ipType);
+      if (preferredIps != null && !preferredIps.isEmpty()) {
         break;
       }
     }
-    if (preferredIp == null) {
+    if (preferredIps == null || preferredIps.isEmpty()) {
       throw new IllegalArgumentException(
           String.format(
               "[%s] Cloud SQL instance  does not have any IP addresses matching preferences (%s)",
@@ -72,7 +73,8 @@ class ConnectionInfo {
     }
 
     return new ConnectionMetadata(
-        preferredIp,
+        preferredIps,
+        getIpAddrs(),
         sslData.getKeyManagerFactory(),
         sslData.getTrustManagerFactory(),
         sslData.getSslContext(),

--- a/core/src/main/java/com/google/cloud/sql/core/ConnectionInfoRepository.java
+++ b/core/src/main/java/com/google/cloud/sql/core/ConnectionInfoRepository.java
@@ -37,5 +37,5 @@ interface ConnectionInfoRepository {
       AuthType authType,
       KeyPair keyPair);
 
-  com.google.api.services.sqladmin.SQLAdmin getSqlAdmin();
+  String resolveConnectionName(String region, String dnsName);
 }

--- a/core/src/main/java/com/google/cloud/sql/core/ConnectionInfoRepository.java
+++ b/core/src/main/java/com/google/cloud/sql/core/ConnectionInfoRepository.java
@@ -36,4 +36,6 @@ interface ConnectionInfoRepository {
       AccessTokenSupplier accessTokenSupplier,
       AuthType authType,
       KeyPair keyPair);
+
+  com.google.api.services.sqladmin.SQLAdmin getSqlAdmin();
 }

--- a/core/src/main/java/com/google/cloud/sql/core/ConnectionMetadata.java
+++ b/core/src/main/java/com/google/cloud/sql/core/ConnectionMetadata.java
@@ -16,7 +16,12 @@
 
 package com.google.cloud.sql.core;
 
+import com.google.cloud.sql.IpType;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManagerFactory;
@@ -26,7 +31,8 @@ import javax.net.ssl.TrustManagerFactory;
  * instance.
  */
 public class ConnectionMetadata {
-  private final String preferredIpAddress;
+  private final List<String> preferredIpAddresses;
+  private final Map<IpType, List<String>> ipAddrs;
   private final KeyManagerFactory keyManagerFactory;
   private final TrustManagerFactory trustManagerFactory;
   private final SSLContext sslContext;
@@ -34,21 +40,77 @@ public class ConnectionMetadata {
 
   /** Construct an immutable ConnectionMetadata. */
   public ConnectionMetadata(
-      String preferredIpAddress,
+      List<String> preferredIpAddresses,
+      Map<IpType, List<String>> ipAddrs,
       KeyManagerFactory keyManagerFactory,
       TrustManagerFactory trustManagerFactory,
       SSLContext sslContext,
       List<String> mdxProtocolSupport) {
 
-    this.preferredIpAddress = preferredIpAddress;
+    this.preferredIpAddresses = preferredIpAddresses;
+    this.ipAddrs = ipAddrs;
     this.keyManagerFactory = keyManagerFactory;
     this.trustManagerFactory = trustManagerFactory;
     this.sslContext = sslContext;
     this.mdxProtocolSupport = mdxProtocolSupport;
   }
 
+  /** Construct an immutable ConnectionMetadata (Deprecated). */
+  @Deprecated
+  public ConnectionMetadata(
+      String preferredIpAddress,
+      Map<IpType, String> ipAddrs,
+      KeyManagerFactory keyManagerFactory,
+      TrustManagerFactory trustManagerFactory,
+      SSLContext sslContext,
+      List<String> mdxProtocolSupport) {
+    this(
+        Collections.singletonList(preferredIpAddress),
+        compatMap(ipAddrs),
+        keyManagerFactory,
+        trustManagerFactory,
+        sslContext,
+        mdxProtocolSupport);
+  }
+
+  private static Map<IpType, List<String>> compatMap(Map<IpType, String> map) {
+    Map<IpType, List<String>> newMap = new HashMap<>();
+    if (map != null) {
+      map.forEach((k, v) -> newMap.put(k, Collections.singletonList(v)));
+    }
+    return newMap;
+  }
+
+  @Deprecated
   public String getPreferredIpAddress() {
-    return preferredIpAddress;
+    return preferredIpAddresses == null || preferredIpAddresses.isEmpty()
+        ? null
+        : preferredIpAddresses.get(0);
+  }
+
+  public List<String> getPreferredIpAddresses() {
+    return preferredIpAddresses;
+  }
+
+  /**
+   * Returns the map of IP addresses.
+   *
+   * @return the map of IP addresses.
+   * @deprecated use {@link #getAllIpAddrs()} instead.
+   */
+  @Deprecated
+  public Map<IpType, String> getIpAddrs() {
+    if (ipAddrs == null) {
+      return null;
+    }
+    return ipAddrs.entrySet().stream()
+        .collect(
+            Collectors.toMap(
+                Map.Entry::getKey, e -> e.getValue().isEmpty() ? null : e.getValue().get(0)));
+  }
+
+  public Map<IpType, List<String>> getAllIpAddrs() {
+    return ipAddrs;
   }
 
   public KeyManagerFactory getKeyManagerFactory() {

--- a/core/src/main/java/com/google/cloud/sql/core/Connector.java
+++ b/core/src/main/java/com/google/cloud/sql/core/Connector.java
@@ -69,22 +69,17 @@ class Connector {
       long minRefreshDelayMs,
       long refreshTimeoutMs,
       int serverProxyPort,
-      InstanceConnectionNameResolver instanceNameResolver,
       DnsResolver dnsResolver,
       ProtocolHandler mdxProtocolHandler) {
     this.config = config;
     this.adminApi =
         connectionInfoRepositoryFactory.create(instanceCredentialFactory.create(), config);
-    if (instanceNameResolver instanceof DnsInstanceConnectionNameResolver) {
-      ((DnsInstanceConnectionNameResolver) instanceNameResolver)
-          .setSqlAdmin(this.adminApi.getSqlAdmin());
-    }
+    this.instanceNameResolver = new DnsInstanceConnectionNameResolver(dnsResolver, this.adminApi);
     this.instanceCredentialFactory = instanceCredentialFactory;
     this.executor = executor;
     this.localKeyPair = localKeyPair;
     this.minRefreshDelayMs = minRefreshDelayMs;
     this.serverProxyPort = serverProxyPort;
-    this.instanceNameResolver = instanceNameResolver;
     this.dnsResolver = dnsResolver;
     this.instanceNameResolverTimer = new Timer("InstanceNameResolverTimer", true);
     this.mdxProtocolHandler = mdxProtocolHandler;

--- a/core/src/main/java/com/google/cloud/sql/core/Connector.java
+++ b/core/src/main/java/com/google/cloud/sql/core/Connector.java
@@ -29,6 +29,7 @@ import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.UnknownHostException;
 import java.security.KeyPair;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Timer;
 import java.util.concurrent.ConcurrentHashMap;
@@ -74,6 +75,10 @@ class Connector {
     this.config = config;
     this.adminApi =
         connectionInfoRepositoryFactory.create(instanceCredentialFactory.create(), config);
+    if (instanceNameResolver instanceof DnsInstanceConnectionNameResolver) {
+      ((DnsInstanceConnectionNameResolver) instanceNameResolver)
+          .setSqlAdmin(this.adminApi.getSqlAdmin());
+    }
     this.instanceCredentialFactory = instanceCredentialFactory;
     this.executor = executor;
     this.localKeyPair = localKeyPair;
@@ -129,7 +134,8 @@ class Connector {
     MonitoredCache instance = getConnection(config);
     try {
       ConnectionMetadata metadata = instance.getConnectionMetadata(timeoutMs);
-      String instanceIp = metadata.getPreferredIpAddress();
+      List<String> preferredIps = metadata.getPreferredIpAddresses();
+      List<String> targets = new ArrayList<>();
 
       // If a domain name was used to connect, resolve it to an IP address
       if (!Strings.isNullOrEmpty(instance.getConfig().getDomainName())) {
@@ -142,7 +148,9 @@ class Connector {
                     instance.getConfig().getCloudSqlInstance(),
                     instance.getConfig().getDomainName(),
                     addrs.get(0).getHostAddress()));
-            instanceIp = addrs.get(0).getHostAddress();
+            for (InetAddress addr : addrs) {
+              targets.add(addr.getHostAddress());
+            }
           } else {
             logger.debug(
                 String.format(
@@ -150,7 +158,8 @@ class Connector {
                         + " instance metadata",
                     instance.getConfig().getCloudSqlInstance(),
                     instance.getConfig().getDomainName(),
-                    instanceIp));
+                    preferredIps.get(0)));
+            targets.addAll(preferredIps);
           }
         } catch (UnknownHostException e) {
           logger.debug(
@@ -160,23 +169,42 @@ class Connector {
                   instance.getConfig().getCloudSqlInstance(),
                   instance.getConfig().getDomainName(),
                   e.getMessage(),
-                  instanceIp));
+                  preferredIps.get(0)));
+          targets.addAll(preferredIps);
+        }
+      } else {
+        targets.addAll(preferredIps);
+      }
+
+      IOException lastEx = null;
+      SSLSocket socket = null;
+      String successfulIp = null;
+      for (String targetIp : targets) {
+        logger.debug(String.format("[%s] Connecting to instance.", targetIp));
+        try {
+          socket = (SSLSocket) metadata.getSslContext().getSocketFactory().createSocket();
+          socket.setKeepAlive(true);
+          socket.setTcpNoDelay(true);
+          socket.connect(new InetSocketAddress(targetIp, serverProxyPort));
+          socket.startHandshake();
+          successfulIp = targetIp;
+          lastEx = null; // success
+          break;
+        } catch (IOException e) {
+          logger.debug(String.format("[%s] Connection failed: %s", targetIp, e.getMessage()));
+          lastEx = e;
+          if (socket != null) {
+            try {
+              socket.close();
+            } catch (IOException ce) {
+              // ignore
+            }
+          }
         }
       }
 
-      logger.debug(String.format("[%s] Connecting to instance.", instanceIp));
-
-      SSLSocket socket = (SSLSocket) metadata.getSslContext().getSocketFactory().createSocket();
-      socket.setKeepAlive(true);
-      socket.setTcpNoDelay(true);
-
-      socket.connect(new InetSocketAddress(instanceIp, serverProxyPort));
-
-      try {
-        socket.startHandshake();
-      } catch (IOException e) {
-        logger.debug("TLS handshake failed!");
-        throw e;
+      if (lastEx != null) {
+        throw lastEx;
       }
 
       if (metadata.isMdxClientProtocolTypeSupport()
@@ -184,7 +212,7 @@ class Connector {
         socket = mdxProtocolHandler.connect(socket, config.getMdxClientProtocolType());
       }
 
-      logger.debug(String.format("[%s] Connected to instance successfully.", instanceIp));
+      logger.debug(String.format("[%s] Connected to instance successfully.", successfulIp));
       instance.addSocket(socket);
 
       return socket;

--- a/core/src/main/java/com/google/cloud/sql/core/DefaultConnectionInfoRepository.java
+++ b/core/src/main/java/com/google/cloud/sql/core/DefaultConnectionInfoRepository.java
@@ -49,6 +49,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -271,14 +272,14 @@ class DefaultConnectionInfoRepository implements ConnectionInfoRepository {
 
       checkDatabaseCompatibility(instanceMetadata, authType, instanceName.getConnectionName());
 
-      Map<IpType, String> ipAddrs = new HashMap<>();
+      Map<IpType, List<String>> ipAddrs = new HashMap<>();
       if (instanceMetadata.getIpAddresses() != null) {
         // Update the IP addresses and types need to connect with the instance.
         for (IpMapping addr : instanceMetadata.getIpAddresses()) {
           if ("PRIVATE".equals(addr.getType())) {
-            ipAddrs.put(IpType.PRIVATE, addr.getIpAddress());
+            ipAddrs.put(IpType.PRIVATE, Collections.singletonList(addr.getIpAddress()));
           } else if ("PRIMARY".equals(addr.getType())) {
-            ipAddrs.put(IpType.PUBLIC, addr.getIpAddress());
+            ipAddrs.put(IpType.PUBLIC, Collections.singletonList(addr.getIpAddress()));
           }
           // otherwise, we don't know how to handle this type, ignore it.
         }
@@ -291,27 +292,38 @@ class DefaultConnectionInfoRepository implements ConnectionInfoRepository {
 
       if (pscEnabled) {
         // Search the dns_names field for the PSC DNS Name.
-        String pscDnsName = null;
+        List<String> pscDnsNames = new ArrayList<>();
         if (instanceMetadata.getDnsNames() != null) {
           for (DnsNameMapping dnm : instanceMetadata.getDnsNames()) {
             if ("PRIVATE_SERVICE_CONNECT".equals(dnm.getConnectionType())
                 && "INSTANCE".equals(dnm.getDnsScope())) {
-              pscDnsName = dnm.getName();
-              break;
+              pscDnsNames.add(dnm.getName());
             }
           }
         }
 
         // If the psc dns name was not found, use the legacy dns_name field
-        if (pscDnsName == null
+        if (pscDnsNames.isEmpty()
             && instanceMetadata.getDnsName() != null
             && !instanceMetadata.getDnsName().isEmpty()) {
-          pscDnsName = instanceMetadata.getDnsName();
+          pscDnsNames.add(instanceMetadata.getDnsName());
         }
 
         // If the psc dns name was found, add it to the ipaddrs map.
-        if (pscDnsName != null) {
-          ipAddrs.put(IpType.PSC, pscDnsName);
+        if (!pscDnsNames.isEmpty()) {
+          pscDnsNames.sort(
+              (addr1, addr2) -> {
+                boolean addr1IsPsc = addr1.endsWith(".sql-psc.goog");
+                boolean addr2IsPsc = addr2.endsWith(".sql-psc.goog");
+                if (addr1IsPsc && !addr2IsPsc) {
+                  return -1; // addr1 comes first
+                }
+                if (!addr1IsPsc && addr2IsPsc) {
+                  return 1; // addr2 comes first
+                }
+                return 0;
+              });
+          ipAddrs.put(IpType.PSC, pscDnsNames);
         }
       }
 
@@ -543,5 +555,10 @@ class DefaultConnectionInfoRepository implements ConnectionInfoRepository {
     }
     // Fallback to the generic description
     return new RuntimeException(message, ex);
+  }
+
+  @Override
+  public com.google.api.services.sqladmin.SQLAdmin getSqlAdmin() {
+    return apiClient;
   }
 }

--- a/core/src/main/java/com/google/cloud/sql/core/DefaultConnectionInfoRepository.java
+++ b/core/src/main/java/com/google/cloud/sql/core/DefaultConnectionInfoRepository.java
@@ -558,7 +558,16 @@ class DefaultConnectionInfoRepository implements ConnectionInfoRepository {
   }
 
   @Override
-  public com.google.api.services.sqladmin.SQLAdmin getSqlAdmin() {
-    return apiClient;
+  public String resolveConnectionName(String region, String dnsName) {
+    try {
+      ConnectSettings settings =
+          new ApiClientRetryingCallable<>(
+                  () -> apiClient.connect().resolve(region, dnsName).execute())
+              .call();
+      return settings.getConnectionName();
+    } catch (Exception ex) {
+      throw new RuntimeException(
+          String.format("Failed to resolve PSC DNS name %s in region %s", dnsName, region), ex);
+    }
   }
 }

--- a/core/src/main/java/com/google/cloud/sql/core/DnsInstanceConnectionNameResolver.java
+++ b/core/src/main/java/com/google/cloud/sql/core/DnsInstanceConnectionNameResolver.java
@@ -39,14 +39,12 @@ class DnsInstanceConnectionNameResolver implements InstanceConnectionNameResolve
           "^([a-f0-9]{12})\\.([^.]+)\\.([a-z0-9]+-[a-z0-9]+)\\.(sql|sql-psa|sql-psc)\\.goog\\.?$");
 
   private final DnsResolver dnsResolver;
-  private com.google.api.services.sqladmin.SQLAdmin sqlAdmin;
+  private final ConnectionInfoRepository connectionInfoRepository;
 
-  public DnsInstanceConnectionNameResolver(DnsResolver dnsResolver) {
+  public DnsInstanceConnectionNameResolver(
+      DnsResolver dnsResolver, ConnectionInfoRepository connectionInfoRepository) {
     this.dnsResolver = dnsResolver;
-  }
-
-  void setSqlAdmin(com.google.api.services.sqladmin.SQLAdmin sqlAdmin) {
-    this.sqlAdmin = sqlAdmin;
+    this.connectionInfoRepository = connectionInfoRepository;
   }
 
   @Override
@@ -60,16 +58,11 @@ class DnsInstanceConnectionNameResolver implements InstanceConnectionNameResolve
     Matcher pscDnsMatcher = PSC_DNS_PATTERN.matcher(cleanName.toLowerCase());
     if (pscDnsMatcher.matches()) {
       String region = pscDnsMatcher.group(3);
-      if (sqlAdmin == null) {
-        throw new IllegalArgumentException("SQLAdmin client is not configured in the resolver.");
-      }
       String dnsNameWithDot = cleanName.endsWith(".") ? cleanName : cleanName + ".";
       try {
-        com.google.api.services.sqladmin.model.ConnectSettings metadata =
-            new ApiClientRetryingCallable<>(
-                    () -> sqlAdmin.connect().resolve(region, dnsNameWithDot).execute())
-                .call();
-        return new CloudSqlInstanceName(metadata.getConnectionName(), cleanName);
+        String connectionName =
+            connectionInfoRepository.resolveConnectionName(region, dnsNameWithDot);
+        return new CloudSqlInstanceName(connectionName, cleanName);
       } catch (Exception ex) {
         throw new IllegalArgumentException("Failed to resolve PSC DNS name: " + cleanName, ex);
       }
@@ -108,16 +101,11 @@ class DnsInstanceConnectionNameResolver implements InstanceConnectionNameResolve
       Matcher pscDnsMatcher = PSC_DNS_PATTERN.matcher(cleanCurrent.toLowerCase());
       if (pscDnsMatcher.matches()) {
         String region = pscDnsMatcher.group(3);
-        if (sqlAdmin == null) {
-          throw new IllegalArgumentException("SQLAdmin client is not configured in the resolver.");
-        }
         String dnsNameWithDot = cleanCurrent.endsWith(".") ? cleanCurrent : cleanCurrent + ".";
         try {
-          com.google.api.services.sqladmin.model.ConnectSettings metadata =
-              new ApiClientRetryingCallable<>(
-                      () -> sqlAdmin.connect().resolve(region, dnsNameWithDot).execute())
-                  .call();
-          return new CloudSqlInstanceName(metadata.getConnectionName(), name);
+          String connectionName =
+              connectionInfoRepository.resolveConnectionName(region, dnsNameWithDot);
+          return new CloudSqlInstanceName(connectionName, name);
         } catch (Exception ex) {
           throw new IllegalArgumentException("Failed to resolve PSC DNS name: " + cleanCurrent, ex);
         }

--- a/core/src/main/java/com/google/cloud/sql/core/DnsInstanceConnectionNameResolver.java
+++ b/core/src/main/java/com/google/cloud/sql/core/DnsInstanceConnectionNameResolver.java
@@ -17,7 +17,11 @@
 package com.google.cloud.sql.core;
 
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import javax.naming.NameNotFoundException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,10 +34,19 @@ class DnsInstanceConnectionNameResolver implements InstanceConnectionNameResolve
   private static final Logger logger =
       LoggerFactory.getLogger(DnsInstanceConnectionNameResolver.class);
 
+  private static final Pattern PSC_DNS_PATTERN =
+      Pattern.compile(
+          "^([a-f0-9]{12})\\.([^.]+)\\.([a-z0-9]+-[a-z0-9]+)\\.(sql|sql-psa|sql-psc)\\.goog\\.?$");
+
   private final DnsResolver dnsResolver;
+  private com.google.api.services.sqladmin.SQLAdmin sqlAdmin;
 
   public DnsInstanceConnectionNameResolver(DnsResolver dnsResolver) {
     this.dnsResolver = dnsResolver;
+  }
+
+  void setSqlAdmin(com.google.api.services.sqladmin.SQLAdmin sqlAdmin) {
+    this.sqlAdmin = sqlAdmin;
   }
 
   @Override
@@ -41,6 +54,25 @@ class DnsInstanceConnectionNameResolver implements InstanceConnectionNameResolve
     if (CloudSqlInstanceName.isValidInstanceName(name)) {
       // name contains a well-formed instance name.
       return new CloudSqlInstanceName(name);
+    }
+
+    String cleanName = name.endsWith(".") ? name.substring(0, name.length() - 1) : name;
+    Matcher pscDnsMatcher = PSC_DNS_PATTERN.matcher(cleanName.toLowerCase());
+    if (pscDnsMatcher.matches()) {
+      String region = pscDnsMatcher.group(3);
+      if (sqlAdmin == null) {
+        throw new IllegalArgumentException("SQLAdmin client is not configured in the resolver.");
+      }
+      String dnsNameWithDot = cleanName.endsWith(".") ? cleanName : cleanName + ".";
+      try {
+        com.google.api.services.sqladmin.model.ConnectSettings metadata =
+            new ApiClientRetryingCallable<>(
+                    () -> sqlAdmin.connect().resolve(region, dnsNameWithDot).execute())
+                .call();
+        return new CloudSqlInstanceName(metadata.getConnectionName(), cleanName);
+      } catch (Exception ex) {
+        throw new IllegalArgumentException("Failed to resolve PSC DNS name: " + cleanName, ex);
+      }
     }
 
     if (CloudSqlInstanceName.isValidDomain(name)) {
@@ -57,41 +89,102 @@ class DnsInstanceConnectionNameResolver implements InstanceConnectionNameResolve
   }
 
   private CloudSqlInstanceName resolveDomainName(String name) {
-    // Next, attempt to resolve DNS name.
-    Collection<String> instanceNames;
-    try {
-      instanceNames = this.dnsResolver.resolveTxt(name);
-    } catch (NameNotFoundException ne) {
-      // No DNS record found. This is not a valid instance name.
-      throw new IllegalArgumentException(
-          String.format(
-              "Unable to resolve TXT record containing the instance name for "
-                  + "domain name \"%s\".",
-              name));
+    String current = name;
+    IllegalArgumentException txtException = null;
+    Set<String> visited = new HashSet<>();
+
+    for (int depth = 0; depth < 10; depth++) {
+      if (!visited.add(current.toLowerCase())) {
+        throw new IllegalArgumentException(
+            String.format("CNAME loop detected for \"%s\"", current));
+      }
+
+      if (CloudSqlInstanceName.isValidInstanceName(current)) {
+        return new CloudSqlInstanceName(current, name);
+      }
+
+      String cleanCurrent =
+          current.endsWith(".") ? current.substring(0, current.length() - 1) : current;
+      Matcher pscDnsMatcher = PSC_DNS_PATTERN.matcher(cleanCurrent.toLowerCase());
+      if (pscDnsMatcher.matches()) {
+        String region = pscDnsMatcher.group(3);
+        if (sqlAdmin == null) {
+          throw new IllegalArgumentException("SQLAdmin client is not configured in the resolver.");
+        }
+        String dnsNameWithDot = cleanCurrent.endsWith(".") ? cleanCurrent : cleanCurrent + ".";
+        try {
+          com.google.api.services.sqladmin.model.ConnectSettings metadata =
+              new ApiClientRetryingCallable<>(
+                      () -> sqlAdmin.connect().resolve(region, dnsNameWithDot).execute())
+                  .call();
+          return new CloudSqlInstanceName(metadata.getConnectionName(), name);
+        } catch (Exception ex) {
+          throw new IllegalArgumentException("Failed to resolve PSC DNS name: " + cleanCurrent, ex);
+        }
+      }
+
+      if (!CloudSqlInstanceName.isValidDomain(current)) {
+        throw new IllegalArgumentException(
+            String.format("[%s] CNAME target is not a valid domain name", current));
+      }
+
+      final String finalCurrent = current; // Effectively final copy for lambda
+      Collection<String> instanceNames;
+      try {
+        instanceNames = this.dnsResolver.resolveTxt(finalCurrent);
+        if (!instanceNames.isEmpty()) {
+          // Use the first valid instance name from the list
+          return instanceNames.stream()
+              .map(
+                  target -> {
+                    try {
+                      return new CloudSqlInstanceName(target, finalCurrent);
+                    } catch (IllegalArgumentException e) {
+                      logger.info(
+                          "Unable to parse instance name in TXT record for "
+                              + "domain name \"{}\" with target \"{}\"",
+                          finalCurrent,
+                          target,
+                          e);
+                      return null;
+                    }
+                  })
+              .filter(Objects::nonNull)
+              .findFirst()
+              .orElseThrow(
+                  () ->
+                      new IllegalArgumentException(
+                          String.format(
+                              "Unable to parse values of TXT record for \"%s\".", finalCurrent)));
+        }
+      } catch (NameNotFoundException ne) {
+        txtException =
+            new IllegalArgumentException(
+                String.format(
+                    "Unable to resolve TXT record containing the instance name for "
+                        + "domain name \"%s\".",
+                    current),
+                ne);
+      }
+
+      // If TXT lookup failed or returned no valid records, check CNAME record
+      String cname;
+      try {
+        cname = this.dnsResolver.resolveCname(current);
+      } catch (NameNotFoundException ne) {
+        // If CNAME lookup also fails, throw the original TXT exception
+        if (txtException != null) {
+          throw txtException;
+        }
+        throw new IllegalArgumentException(
+            String.format("Unable to resolve CNAME record for domain name \"%s\".", current), ne);
+      }
+
+      cname = cname.endsWith(".") ? cname.substring(0, cname.length() - 1) : cname;
+      current = cname;
     }
 
-    // Use the first valid instance name from the list
-    // or throw an IllegalArgumentException if none of the values can be parsed.
-    return instanceNames.stream()
-        .map(
-            target -> {
-              try {
-                return new CloudSqlInstanceName(target, name);
-              } catch (IllegalArgumentException e) {
-                logger.info(
-                    "Unable to parse instance name in TXT record for "
-                        + "domain name \"{}\" with target \"{}\"",
-                    name,
-                    target,
-                    e);
-                return null;
-              }
-            })
-        .filter(Objects::nonNull)
-        .findFirst()
-        .orElseThrow(
-            () ->
-                new IllegalArgumentException(
-                    String.format("Unable to parse values of TXT record for \"%s\".", name)));
+    throw new IllegalArgumentException(
+        String.format("CNAME lookup limit exceeded (max 10) for \"%s\"", name));
   }
 }

--- a/core/src/main/java/com/google/cloud/sql/core/DnsJavaResolver.java
+++ b/core/src/main/java/com/google/cloud/sql/core/DnsJavaResolver.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import javax.naming.NameNotFoundException;
 import org.xbill.DNS.ARecord;
+import org.xbill.DNS.CNAMERecord;
 import org.xbill.DNS.Lookup;
 import org.xbill.DNS.Record;
 import org.xbill.DNS.SimpleResolver;
@@ -147,6 +148,40 @@ public class DnsJavaResolver implements DnsResolver {
 
     } catch (TextParseException e) {
       throw new UnknownHostException("Invalid domain name format: " + hostName);
+    }
+  }
+
+  @Override
+  public String resolveCname(String domainName) throws NameNotFoundException {
+    try {
+      Lookup lookup = new Lookup(domainName, Type.CNAME);
+      if (this.resolver != null) {
+        lookup.setResolver(this.resolver);
+      }
+      lookup.run();
+
+      int resultCode = lookup.getResult();
+      if (resultCode == Lookup.HOST_NOT_FOUND) {
+        throw new NameNotFoundException("DNS record not found for " + domainName);
+      }
+      if (resultCode == Lookup.TYPE_NOT_FOUND) {
+        throw new NameNotFoundException("DNS record type CNAME not found for " + domainName);
+      }
+      if (resultCode != Lookup.SUCCESSFUL) {
+        throw new RuntimeException(
+            "DNS lookup failed for " + domainName + ": " + lookup.getErrorString());
+      }
+
+      Record[] records = lookup.getAnswers();
+      if (records == null || records.length == 0) {
+        throw new NameNotFoundException("DNS record type CNAME not found for " + domainName);
+      }
+
+      CNAMERecord cnameRecord = (CNAMERecord) records[0];
+      return cnameRecord.getTarget().toString();
+
+    } catch (TextParseException e) {
+      throw new RuntimeException("Invalid domain name format: " + domainName, e);
     }
   }
 }

--- a/core/src/main/java/com/google/cloud/sql/core/DnsResolver.java
+++ b/core/src/main/java/com/google/cloud/sql/core/DnsResolver.java
@@ -27,4 +27,6 @@ interface DnsResolver {
   Collection<String> resolveTxt(String domainName) throws NameNotFoundException;
 
   List<InetAddress> resolveHost(String hostName) throws UnknownHostException;
+
+  String resolveCname(String domainName) throws NameNotFoundException;
 }

--- a/core/src/main/java/com/google/cloud/sql/core/InstanceMetadata.java
+++ b/core/src/main/java/com/google/cloud/sql/core/InstanceMetadata.java
@@ -25,7 +25,7 @@ import java.util.Map;
 class InstanceMetadata {
 
   private final CloudSqlInstanceName instanceName;
-  private final Map<IpType, String> ipAddrs;
+  private final Map<IpType, List<String>> ipAddrs;
   private final List<Certificate> instanceCaCertificates;
   private final boolean casManagedCertificate;
   private final String dnsName;
@@ -34,7 +34,7 @@ class InstanceMetadata {
 
   InstanceMetadata(
       CloudSqlInstanceName instanceName,
-      Map<IpType, String> ipAddrs,
+      Map<IpType, List<String>> ipAddrs,
       List<Certificate> instanceCaCertificates,
       boolean casManagedCertificate,
       String dnsName,
@@ -49,7 +49,7 @@ class InstanceMetadata {
     this.mdxProtocolSupport = mdxProtocolSupport;
   }
 
-  Map<IpType, String> getIpAddrs() {
+  Map<IpType, List<String>> getIpAddrs() {
     return ipAddrs;
   }
 

--- a/core/src/main/java/com/google/cloud/sql/core/InternalConnectorRegistry.java
+++ b/core/src/main/java/com/google/cloud/sql/core/InternalConnectorRegistry.java
@@ -338,7 +338,6 @@ public final class InternalConnectorRegistry {
         MIN_REFRESH_DELAY_MS,
         connectTimeoutMs,
         serverProxyPort,
-        new DnsInstanceConnectionNameResolver(new DnsJavaResolver()),
         new DnsJavaResolver(),
         this.mdxProtocolHandler);
   }

--- a/core/src/test/java/com/google/cloud/sql/core/ConnectorTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/ConnectorTest.java
@@ -535,6 +535,122 @@ public class ConnectorTest extends CloudSqlCoreTestingBase {
     assertThat(readLine(socket)).isEqualTo(SERVER_MESSAGE);
   }
 
+  @Test
+  public void testConnect_dnsResolutionFailureFallbackToPrivateIp() throws Exception {
+    if (isWindows()) {
+      return;
+    }
+
+    PrivateKey privateKey = TestKeys.getServerKeyPair().getPrivate();
+    X509Certificate[] cert = TestKeys.getCasServerCertChain();
+    FakeSslServer sslServer = new FakeSslServer(privateKey, cert);
+    int port = sslServer.start(PRIVATE_IP);
+
+    ConnectionConfig config =
+        new ConnectionConfig.Builder()
+            .withDomainName("example.com")
+            .withIpTypes(Collections.singletonList(IpType.PRIVATE))
+            .build();
+
+    ConnectionInfoRepositoryFactory factory =
+        new StubConnectionInfoRepositoryFactory(fakeSuccessHttpCasTransport(Duration.ZERO));
+
+    DnsResolver dnsResolver =
+        new DnsResolver() {
+          @Override
+          public Collection<String> resolveTxt(String domainName) {
+            return Collections.singletonList("myProject:myRegion:myInstance");
+          }
+
+          @Override
+          public List<InetAddress> resolveHost(String hostName)
+              throws java.net.UnknownHostException {
+            throw new java.net.UnknownHostException("Mock DNS failure");
+          }
+
+          @Override
+          public String resolveCname(String domainName) throws NameNotFoundException {
+            throw new NameNotFoundException("Not found in mock");
+          }
+        };
+
+    Connector connector =
+        new Connector(
+            config.getConnectorConfig(),
+            factory,
+            stubCredentialFactoryProvider.getInstanceCredentialFactory(config.getConnectorConfig()),
+            defaultExecutor,
+            clientKeyPair,
+            10,
+            TEST_MAX_REFRESH_MS,
+            port,
+            new DnsInstanceConnectionNameResolver(dnsResolver),
+            dnsResolver,
+            new ProtocolHandler("test"));
+
+    Socket socket = connector.connect(config, TEST_MAX_REFRESH_MS);
+
+    assertThat(readLine(socket)).isEqualTo(SERVER_MESSAGE);
+  }
+
+  @Test
+  public void testConnect_dnsResolutionEmptyFallbackToPrivateIp() throws Exception {
+    if (isWindows()) {
+      return;
+    }
+
+    PrivateKey privateKey = TestKeys.getServerKeyPair().getPrivate();
+    X509Certificate[] cert = TestKeys.getCasServerCertChain();
+    FakeSslServer sslServer = new FakeSslServer(privateKey, cert);
+    int port = sslServer.start(PRIVATE_IP);
+
+    ConnectionConfig config =
+        new ConnectionConfig.Builder()
+            .withDomainName("example.com")
+            .withIpTypes(Collections.singletonList(IpType.PRIVATE))
+            .build();
+
+    ConnectionInfoRepositoryFactory factory =
+        new StubConnectionInfoRepositoryFactory(fakeSuccessHttpCasTransport(Duration.ZERO));
+
+    DnsResolver dnsResolver =
+        new DnsResolver() {
+          @Override
+          public Collection<String> resolveTxt(String domainName) {
+            return Collections.singletonList("myProject:myRegion:myInstance");
+          }
+
+          @Override
+          public List<InetAddress> resolveHost(String hostName)
+              throws java.net.UnknownHostException {
+            return Collections.emptyList();
+          }
+
+          @Override
+          public String resolveCname(String domainName) throws NameNotFoundException {
+            throw new NameNotFoundException("Not found in mock");
+          }
+        };
+
+    Connector connector =
+        new Connector(
+            config.getConnectorConfig(),
+            factory,
+            stubCredentialFactoryProvider.getInstanceCredentialFactory(config.getConnectorConfig()),
+            defaultExecutor,
+            clientKeyPair,
+            10,
+            TEST_MAX_REFRESH_MS,
+            port,
+            new DnsInstanceConnectionNameResolver(dnsResolver),
+            dnsResolver,
+            new ProtocolHandler("test"));
+
+    Socket socket = connector.connect(config, TEST_MAX_REFRESH_MS);
+
+    assertThat(readLine(socket)).isEqualTo(SERVER_MESSAGE);
+  }
+
   private boolean isWindows() {
     String os = System.getProperty("os.name").toLowerCase(Locale.ROOT);
     return os.contains("win");
@@ -1028,6 +1144,11 @@ public class ConnectorTest extends CloudSqlCoreTestingBase {
       }
       return Collections.emptyList();
     }
+
+    @Override
+    public String resolveCname(String domainName) throws NameNotFoundException {
+      throw new NameNotFoundException("Not found in mock: " + domainName);
+    }
   }
 
   private static class MutableDnsResolver implements DnsResolver {
@@ -1061,6 +1182,11 @@ public class ConnectorTest extends CloudSqlCoreTestingBase {
     @Override
     public List<InetAddress> resolveHost(String hostName) {
       return Collections.emptyList();
+    }
+
+    @Override
+    public synchronized String resolveCname(String domainName) throws NameNotFoundException {
+      throw new NameNotFoundException("Not found in mock: " + domainName);
     }
   }
 }

--- a/core/src/test/java/com/google/cloud/sql/core/ConnectorTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/ConnectorTest.java
@@ -286,7 +286,6 @@ public class ConnectorTest extends CloudSqlCoreTestingBase {
             10,
             TEST_MAX_REFRESH_MS,
             port,
-            new DnsInstanceConnectionNameResolver(resolver),
             resolver,
             new ProtocolHandler("test"));
 
@@ -338,7 +337,6 @@ public class ConnectorTest extends CloudSqlCoreTestingBase {
             10,
             TEST_MAX_REFRESH_MS,
             port,
-            new DnsInstanceConnectionNameResolver(resolver),
             resolver,
             new ProtocolHandler("test"));
 
@@ -393,7 +391,6 @@ public class ConnectorTest extends CloudSqlCoreTestingBase {
             10,
             TEST_MAX_REFRESH_MS,
             port,
-            new DnsInstanceConnectionNameResolver(resolver),
             resolver,
             new ProtocolHandler("test"));
 
@@ -526,7 +523,6 @@ public class ConnectorTest extends CloudSqlCoreTestingBase {
             10,
             TEST_MAX_REFRESH_MS,
             port,
-            new DnsInstanceConnectionNameResolver(dnsResolver),
             dnsResolver,
             new ProtocolHandler("test"));
 
@@ -584,7 +580,6 @@ public class ConnectorTest extends CloudSqlCoreTestingBase {
             10,
             TEST_MAX_REFRESH_MS,
             port,
-            new DnsInstanceConnectionNameResolver(dnsResolver),
             dnsResolver,
             new ProtocolHandler("test"));
 
@@ -642,7 +637,6 @@ public class ConnectorTest extends CloudSqlCoreTestingBase {
             10,
             TEST_MAX_REFRESH_MS,
             port,
-            new DnsInstanceConnectionNameResolver(dnsResolver),
             dnsResolver,
             new ProtocolHandler("test"));
 
@@ -725,7 +719,6 @@ public class ConnectorTest extends CloudSqlCoreTestingBase {
             10,
             TEST_MAX_REFRESH_MS,
             port,
-            new DnsInstanceConnectionNameResolver(dnsResolver),
             dnsResolver,
             new ProtocolHandler("test"));
 
@@ -794,7 +787,6 @@ public class ConnectorTest extends CloudSqlCoreTestingBase {
             10,
             TEST_MAX_REFRESH_MS,
             DEFAULT_SERVER_PROXY_PORT,
-            new DnsInstanceConnectionNameResolver(dnsResolver),
             dnsResolver,
             new ProtocolHandler("test"));
 
@@ -831,7 +823,6 @@ public class ConnectorTest extends CloudSqlCoreTestingBase {
             10,
             TEST_MAX_REFRESH_MS,
             DEFAULT_SERVER_PROXY_PORT,
-            new DnsInstanceConnectionNameResolver(dnsResolver),
             dnsResolver,
             new ProtocolHandler("test"));
 
@@ -869,7 +860,6 @@ public class ConnectorTest extends CloudSqlCoreTestingBase {
             10,
             TEST_MAX_REFRESH_MS,
             DEFAULT_SERVER_PROXY_PORT,
-            new DnsInstanceConnectionNameResolver(dnsResolver),
             dnsResolver,
             new ProtocolHandler("test"));
 
@@ -916,7 +906,6 @@ public class ConnectorTest extends CloudSqlCoreTestingBase {
             10,
             TEST_MAX_REFRESH_MS,
             port,
-            new DnsInstanceConnectionNameResolver(dnsResolver),
             dnsResolver,
             new ProtocolHandler("test"));
 
@@ -955,7 +944,6 @@ public class ConnectorTest extends CloudSqlCoreTestingBase {
             10,
             TEST_MAX_REFRESH_MS,
             port,
-            new DnsInstanceConnectionNameResolver(dnsResolver),
             dnsResolver,
             new ProtocolHandler("test"));
 
@@ -991,7 +979,6 @@ public class ConnectorTest extends CloudSqlCoreTestingBase {
             10,
             TEST_MAX_REFRESH_MS,
             port,
-            new DnsInstanceConnectionNameResolver(dnsResolver),
             dnsResolver,
             new ProtocolHandler("test"));
 
@@ -1033,7 +1020,6 @@ public class ConnectorTest extends CloudSqlCoreTestingBase {
             10,
             TEST_MAX_REFRESH_MS,
             DEFAULT_SERVER_PROXY_PORT,
-            new DnsInstanceConnectionNameResolver(dnsResolver),
             dnsResolver,
             new ProtocolHandler("test"));
 
@@ -1063,7 +1049,6 @@ public class ConnectorTest extends CloudSqlCoreTestingBase {
             10,
             TEST_MAX_REFRESH_MS,
             port,
-            new DnsInstanceConnectionNameResolver(dnsResolver),
             dnsResolver,
             new ProtocolHandler("test"));
     return connector;
@@ -1096,7 +1081,6 @@ public class ConnectorTest extends CloudSqlCoreTestingBase {
             10,
             TEST_MAX_REFRESH_MS,
             port,
-            new DnsInstanceConnectionNameResolver(dnsResolver),
             dnsResolver,
             new ProtocolHandler("test"));
     return connector;

--- a/core/src/test/java/com/google/cloud/sql/core/DefaultConnectionInfoRepositoryTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/DefaultConnectionInfoRepositoryTest.java
@@ -19,6 +19,7 @@ package com.google.cloud.sql.core;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
+import com.google.api.services.sqladmin.model.DnsNameMapping;
 import com.google.cloud.sql.AuthType;
 import com.google.cloud.sql.ConnectorConfig;
 import com.google.cloud.sql.IpType;
@@ -28,6 +29,8 @@ import com.google.common.util.concurrent.MoreExecutors;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
@@ -70,10 +73,10 @@ public class DefaultConnectionInfoRepositoryTest {
             .get();
     assertThat(connectionInfo.getSslContext()).isInstanceOf(SSLContext.class);
 
-    Map<IpType, String> ipAddrs = connectionInfo.getIpAddrs();
-    assertThat(ipAddrs.get(IpType.PUBLIC)).isEqualTo(SAMPLE_PUBLIC_IP);
-    assertThat(ipAddrs.get(IpType.PRIVATE)).isEqualTo(SAMPLE_PRIVATE_IP);
-    assertThat(ipAddrs.get(IpType.PSC)).isEqualTo(SAMPLE_PCS_DNS_NAME);
+    Map<IpType, List<String>> ipAddrs = connectionInfo.getIpAddrs();
+    assertThat(ipAddrs.get(IpType.PUBLIC)).containsExactly(SAMPLE_PUBLIC_IP);
+    assertThat(ipAddrs.get(IpType.PRIVATE)).containsExactly(SAMPLE_PRIVATE_IP);
+    assertThat(ipAddrs.get(IpType.PSC)).containsExactly(SAMPLE_PCS_DNS_NAME);
   }
 
   @Test
@@ -108,8 +111,8 @@ public class DefaultConnectionInfoRepositoryTest {
             .get();
     assertThat(connectionInfo.getSslContext()).isInstanceOf(SSLContext.class);
 
-    Map<IpType, String> ipAddrs = connectionInfo.getIpAddrs();
-    assertThat(ipAddrs.get(IpType.PSC)).isEqualTo(SAMPLE_PCS_DNS_NAME);
+    Map<IpType, List<String>> ipAddrs = connectionInfo.getIpAddrs();
+    assertThat(ipAddrs.get(IpType.PSC)).containsExactly(SAMPLE_PCS_DNS_NAME);
     assertThat(ipAddrs.size()).isEqualTo(1);
   }
 
@@ -145,8 +148,8 @@ public class DefaultConnectionInfoRepositoryTest {
             .get();
     assertThat(connectionInfo.getSslContext()).isInstanceOf(SSLContext.class);
 
-    Map<IpType, String> ipAddrs = connectionInfo.getIpAddrs();
-    assertThat(ipAddrs.get(IpType.PSC)).isEqualTo(SAMPLE_PCS_DNS_NAME);
+    Map<IpType, List<String>> ipAddrs = connectionInfo.getIpAddrs();
+    assertThat(ipAddrs.get(IpType.PSC)).containsExactly(SAMPLE_PCS_DNS_NAME);
     assertThat(ipAddrs.size()).isEqualTo(1);
   }
 
@@ -244,10 +247,10 @@ public class DefaultConnectionInfoRepositoryTest {
             .get();
     assertThat(connectionInfo.getSslContext()).isInstanceOf(SSLContext.class);
 
-    Map<IpType, String> ipAddrs = connectionInfo.getIpAddrs();
-    assertThat(ipAddrs.get(IpType.PUBLIC)).isEqualTo(SAMPLE_PUBLIC_IP);
-    assertThat(ipAddrs.get(IpType.PRIVATE)).isEqualTo(SAMPLE_PRIVATE_IP);
-    assertThat(ipAddrs.get(IpType.PSC)).isEqualTo(SAMPLE_PCS_DNS_NAME);
+    Map<IpType, List<String>> ipAddrs = connectionInfo.getIpAddrs();
+    assertThat(ipAddrs.get(IpType.PUBLIC)).containsExactly(SAMPLE_PUBLIC_IP);
+    assertThat(ipAddrs.get(IpType.PRIVATE)).containsExactly(SAMPLE_PRIVATE_IP);
+    assertThat(ipAddrs.get(IpType.PSC)).containsExactly(SAMPLE_PCS_DNS_NAME);
   }
 
   @SuppressWarnings("SameParameterValue")
@@ -266,5 +269,54 @@ public class DefaultConnectionInfoRepositoryTest {
     mockAdminApi.addGenerateEphemeralCertResponse(
         instanceConnectionName, Duration.ofHours(1), baseUrl);
     return mockAdminApi;
+  }
+
+  @Test
+  public void testFetchInstanceData_multiplePscDns_sorted()
+      throws ExecutionException, InterruptedException, GeneralSecurityException,
+          OperatorCreationException {
+
+    MockAdminApi mockAdminApi = new MockAdminApi();
+    List<DnsNameMapping> dnsNames =
+        Arrays.asList(
+            new DnsNameMapping()
+                .setDnsScope("INSTANCE")
+                .setConnectionType("PRIVATE_SERVICE_CONNECT")
+                .setName("dns1.sql.goog"),
+            new DnsNameMapping()
+                .setDnsScope("INSTANCE")
+                .setConnectionType("PRIVATE_SERVICE_CONNECT")
+                .setName("dns2.sql-psc.goog"),
+            new DnsNameMapping()
+                .setDnsScope("INSTANCE")
+                .setConnectionType("PRIVATE_SERVICE_CONNECT")
+                .setName("dns3.sql.goog"));
+
+    mockAdminApi.addConnectSettingsResponse(
+        INSTANCE_CONNECTION_NAME, null, null, DATABASE_VERSION, dnsNames, DEFAULT_BASE_URL);
+    mockAdminApi.addGenerateEphemeralCertResponse(
+        INSTANCE_CONNECTION_NAME, Duration.ofHours(1), DEFAULT_BASE_URL);
+    ConnectorConfig config = new ConnectorConfig.Builder().build();
+
+    ConnectionInfoRepository repo =
+        new StubConnectionInfoRepositoryFactory(mockAdminApi.getHttpTransport())
+            .create(new StubCredentialFactory().create(), config);
+
+    ConnectionInfo connectionInfo =
+        repo.getConnectionInfo(
+                new CloudSqlInstanceName(INSTANCE_CONNECTION_NAME),
+                () -> Optional.empty(),
+                AuthType.PASSWORD,
+                newTestExecutor(),
+                Futures.immediateFuture(mockAdminApi.getClientKeyPair()))
+            .get();
+    assertThat(connectionInfo.getSslContext()).isInstanceOf(SSLContext.class);
+
+    Map<IpType, List<String>> ipAddrs = connectionInfo.getIpAddrs();
+    // Should be sorted: .sql-psc.goog first
+    assertThat(ipAddrs.get(IpType.PSC))
+        .containsExactly("dns2.sql-psc.goog", "dns1.sql.goog", "dns3.sql.goog")
+        .inOrder();
+    assertThat(ipAddrs.size()).isEqualTo(1);
   }
 }

--- a/core/src/test/java/com/google/cloud/sql/core/DnsInstanceConnectionNameResolverTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/DnsInstanceConnectionNameResolverTest.java
@@ -19,9 +19,12 @@ package com.google.cloud.sql.core;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
-import com.google.api.services.sqladmin.SQLAdmin;
+import com.google.cloud.sql.AuthType;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.security.KeyPair;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -34,15 +37,6 @@ import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class DnsInstanceConnectionNameResolverTest {
-
-  private SQLAdmin buildSqlAdmin(MockAdminApi mockAdminApi) {
-    return new SQLAdmin.Builder(
-            mockAdminApi.getHttpTransport(),
-            com.google.api.client.json.gson.GsonFactory.getDefaultInstance(),
-            null)
-        .setApplicationName("test")
-        .build();
-  }
 
   private static class FakeDnsResolver implements DnsResolver {
     private final Map<String, Collection<String>> txtEntries = new HashMap<>();
@@ -78,10 +72,47 @@ public class DnsInstanceConnectionNameResolverTest {
     }
   }
 
+  private static class FakeConnectionInfoRepository implements ConnectionInfoRepository {
+    private final Map<String, String> resolvedNames = new HashMap<>();
+
+    public void putResolution(String region, String dnsName, String connectionName) {
+      resolvedNames.put(region + ":" + dnsName, connectionName);
+    }
+
+    @Override
+    public String resolveConnectionName(String region, String dnsName) {
+      String key = region + ":" + dnsName;
+      if (resolvedNames.containsKey(key)) {
+        return resolvedNames.get(key);
+      }
+      throw new RuntimeException("Failed to resolve PSC DNS name: " + dnsName);
+    }
+
+    @Override
+    public ListenableFuture<ConnectionInfo> getConnectionInfo(
+        CloudSqlInstanceName instanceName,
+        AccessTokenSupplier accessTokenSupplier,
+        AuthType authType,
+        ListeningScheduledExecutorService executor,
+        ListenableFuture<KeyPair> keyPair) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ConnectionInfo getConnectionInfoSync(
+        CloudSqlInstanceName instanceName,
+        AccessTokenSupplier accessTokenSupplier,
+        AuthType authType,
+        KeyPair keyPair) {
+      throw new UnsupportedOperationException();
+    }
+  }
+
   @Test
   public void testResolve_validInstanceName() {
     DnsInstanceConnectionNameResolver resolver =
-        new DnsInstanceConnectionNameResolver(new FakeDnsResolver());
+        new DnsInstanceConnectionNameResolver(
+            new FakeDnsResolver(), new FakeConnectionInfoRepository());
     CloudSqlInstanceName name = resolver.resolve("my-project:my-region:my-instance");
     assertThat(name.getConnectionName()).isEqualTo("my-project:my-region:my-instance");
     assertThat(name.getProjectId()).isEqualTo("my-project");
@@ -95,7 +126,8 @@ public class DnsInstanceConnectionNameResolverTest {
     FakeDnsResolver fakeDns = new FakeDnsResolver();
     fakeDns.putTxt("db.example.com", "my-project:my-region:my-instance");
 
-    DnsInstanceConnectionNameResolver resolver = new DnsInstanceConnectionNameResolver(fakeDns);
+    DnsInstanceConnectionNameResolver resolver =
+        new DnsInstanceConnectionNameResolver(fakeDns, new FakeConnectionInfoRepository());
     CloudSqlInstanceName name = resolver.resolve("db.example.com");
     assertThat(name.getConnectionName()).isEqualTo("my-project:my-region:my-instance");
     assertThat(name.getDomainName()).isEqualTo("db.example.com");
@@ -106,21 +138,11 @@ public class DnsInstanceConnectionNameResolverTest {
     String dnsName = "0123456789ab.fedcba9876543.europe-north2.sql-psc.goog";
     String realConnectionName = "my-project:europe-north2:my-instance";
 
-    MockAdminApi mockAdminApi = new MockAdminApi();
-    mockAdminApi.addConnectSettingsByDnsNameResponse(
-        dnsName + ".",
-        "europe-north2",
-        realConnectionName,
-        "34.1.2.3",
-        "10.0.0.1",
-        "POSTGRES_14",
-        dnsName + ".",
-        "https://sqladmin.googleapis.com/",
-        false);
+    FakeConnectionInfoRepository fakeRepo = new FakeConnectionInfoRepository();
+    fakeRepo.putResolution("europe-north2", dnsName + ".", realConnectionName);
 
     DnsInstanceConnectionNameResolver resolver =
-        new DnsInstanceConnectionNameResolver(new FakeDnsResolver());
-    resolver.setSqlAdmin(buildSqlAdmin(mockAdminApi));
+        new DnsInstanceConnectionNameResolver(new FakeDnsResolver(), fakeRepo);
 
     CloudSqlInstanceName name = resolver.resolve(dnsName);
     assertThat(name.getConnectionName()).isEqualTo(realConnectionName);
@@ -136,23 +158,14 @@ public class DnsInstanceConnectionNameResolverTest {
     String cnameTarget = "0123456789ab.fedcba9876543.europe-north2.sql-psc.goog";
     String realConnectionName = "my-project:europe-north2:my-instance";
 
-    MockAdminApi mockAdminApi = new MockAdminApi();
-    mockAdminApi.addConnectSettingsByDnsNameResponse(
-        cnameTarget + ".",
-        "europe-north2",
-        realConnectionName,
-        "34.1.2.3",
-        "10.0.0.1",
-        "POSTGRES_14",
-        cnameTarget + ".",
-        "https://sqladmin.googleapis.com/",
-        false);
+    FakeConnectionInfoRepository fakeRepo = new FakeConnectionInfoRepository();
+    fakeRepo.putResolution("europe-north2", cnameTarget + ".", realConnectionName);
 
     FakeDnsResolver fakeDns = new FakeDnsResolver();
     fakeDns.putCname(dnsName, cnameTarget);
 
-    DnsInstanceConnectionNameResolver resolver = new DnsInstanceConnectionNameResolver(fakeDns);
-    resolver.setSqlAdmin(buildSqlAdmin(mockAdminApi));
+    DnsInstanceConnectionNameResolver resolver =
+        new DnsInstanceConnectionNameResolver(fakeDns, fakeRepo);
 
     CloudSqlInstanceName name = resolver.resolve(dnsName);
     assertThat(name.getConnectionName()).isEqualTo(realConnectionName);
@@ -166,24 +179,15 @@ public class DnsInstanceConnectionNameResolverTest {
     String cnameTarget = "0123456789ab.fedcba9876543.europe-north2.sql-psc.goog";
     String realConnectionName = "my-project:europe-north2:my-instance";
 
-    MockAdminApi mockAdminApi = new MockAdminApi();
-    mockAdminApi.addConnectSettingsByDnsNameResponse(
-        cnameTarget + ".",
-        "europe-north2",
-        realConnectionName,
-        "34.1.2.3",
-        "10.0.0.1",
-        "POSTGRES_14",
-        cnameTarget + ".",
-        "https://sqladmin.googleapis.com/",
-        false);
+    FakeConnectionInfoRepository fakeRepo = new FakeConnectionInfoRepository();
+    fakeRepo.putResolution("europe-north2", cnameTarget + ".", realConnectionName);
 
     FakeDnsResolver fakeDns = new FakeDnsResolver();
     fakeDns.putCname(dnsName, cname2);
     fakeDns.putCname(cname2, cnameTarget);
 
-    DnsInstanceConnectionNameResolver resolver = new DnsInstanceConnectionNameResolver(fakeDns);
-    resolver.setSqlAdmin(buildSqlAdmin(mockAdminApi));
+    DnsInstanceConnectionNameResolver resolver =
+        new DnsInstanceConnectionNameResolver(fakeDns, fakeRepo);
 
     CloudSqlInstanceName name = resolver.resolve(dnsName);
     assertThat(name.getConnectionName()).isEqualTo(realConnectionName);
@@ -200,7 +204,8 @@ public class DnsInstanceConnectionNameResolverTest {
     fakeDns.putCname(cname2, cname3);
     fakeDns.putTxt(cname3, "my-project:my-region:my-instance");
 
-    DnsInstanceConnectionNameResolver resolver = new DnsInstanceConnectionNameResolver(fakeDns);
+    DnsInstanceConnectionNameResolver resolver =
+        new DnsInstanceConnectionNameResolver(fakeDns, new FakeConnectionInfoRepository());
     CloudSqlInstanceName name = resolver.resolve(dnsName);
     assertThat(name.getConnectionName()).isEqualTo("my-project:my-region:my-instance");
     assertThat(name.getDomainName()).isEqualTo(cname3);
@@ -217,7 +222,8 @@ public class DnsInstanceConnectionNameResolverTest {
     };
 
     DnsInstanceConnectionNameResolver resolver =
-        new DnsInstanceConnectionNameResolver(new FakeDnsResolver());
+        new DnsInstanceConnectionNameResolver(
+            new FakeDnsResolver(), new FakeConnectionInfoRepository());
     for (String dnsName : invalidDnsNames) {
       assertThrows(IllegalArgumentException.class, () -> resolver.resolve(dnsName));
     }
@@ -231,7 +237,8 @@ public class DnsInstanceConnectionNameResolverTest {
     fakeDns.putCname(dnsName, cname2);
     fakeDns.putCname(cname2, dnsName); // Loop!
 
-    DnsInstanceConnectionNameResolver resolver = new DnsInstanceConnectionNameResolver(fakeDns);
+    DnsInstanceConnectionNameResolver resolver =
+        new DnsInstanceConnectionNameResolver(fakeDns, new FakeConnectionInfoRepository());
     IllegalArgumentException ex =
         assertThrows(IllegalArgumentException.class, () -> resolver.resolve(dnsName));
     assertThat(ex.getMessage()).contains("CNAME loop detected");
@@ -243,7 +250,8 @@ public class DnsInstanceConnectionNameResolverTest {
     for (int i = 1; i <= 10; i++) {
       fakeDns.putCname("name" + i + ".example.com", "name" + (i + 1) + ".example.com");
     }
-    DnsInstanceConnectionNameResolver resolver = new DnsInstanceConnectionNameResolver(fakeDns);
+    DnsInstanceConnectionNameResolver resolver =
+        new DnsInstanceConnectionNameResolver(fakeDns, new FakeConnectionInfoRepository());
     IllegalArgumentException ex =
         assertThrows(IllegalArgumentException.class, () -> resolver.resolve("name1.example.com"));
     assertThat(ex.getMessage()).contains("CNAME lookup limit exceeded");

--- a/core/src/test/java/com/google/cloud/sql/core/DnsInstanceConnectionNameResolverTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/DnsInstanceConnectionNameResolverTest.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.sql.core;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import com.google.api.services.sqladmin.SQLAdmin;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.naming.NameNotFoundException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class DnsInstanceConnectionNameResolverTest {
+
+  private SQLAdmin buildSqlAdmin(MockAdminApi mockAdminApi) {
+    return new SQLAdmin.Builder(
+            mockAdminApi.getHttpTransport(),
+            com.google.api.client.json.gson.GsonFactory.getDefaultInstance(),
+            null)
+        .setApplicationName("test")
+        .build();
+  }
+
+  private static class FakeDnsResolver implements DnsResolver {
+    private final Map<String, Collection<String>> txtEntries = new HashMap<>();
+    private final Map<String, String> cnameEntries = new HashMap<>();
+
+    public void putTxt(String name, String value) {
+      txtEntries.put(name, Collections.singletonList(value));
+    }
+
+    public void putCname(String name, String target) {
+      cnameEntries.put(name, target);
+    }
+
+    @Override
+    public Collection<String> resolveTxt(String domainName) throws NameNotFoundException {
+      if (txtEntries.containsKey(domainName)) {
+        return txtEntries.get(domainName);
+      }
+      throw new NameNotFoundException("No TXT record for " + domainName);
+    }
+
+    @Override
+    public List<InetAddress> resolveHost(String hostName) throws UnknownHostException {
+      throw new UnknownHostException("No host resolution for " + hostName);
+    }
+
+    @Override
+    public String resolveCname(String domainName) throws NameNotFoundException {
+      if (cnameEntries.containsKey(domainName)) {
+        return cnameEntries.get(domainName);
+      }
+      throw new NameNotFoundException("No CNAME record for " + domainName);
+    }
+  }
+
+  @Test
+  public void testResolve_validInstanceName() {
+    DnsInstanceConnectionNameResolver resolver =
+        new DnsInstanceConnectionNameResolver(new FakeDnsResolver());
+    CloudSqlInstanceName name = resolver.resolve("my-project:my-region:my-instance");
+    assertThat(name.getConnectionName()).isEqualTo("my-project:my-region:my-instance");
+    assertThat(name.getProjectId()).isEqualTo("my-project");
+    assertThat(name.getRegionId()).isEqualTo("my-region");
+    assertThat(name.getInstanceId()).isEqualTo("my-instance");
+    assertThat(name.getDomainName()).isNull();
+  }
+
+  @Test
+  public void testResolve_success_txtRecord() {
+    FakeDnsResolver fakeDns = new FakeDnsResolver();
+    fakeDns.putTxt("db.example.com", "my-project:my-region:my-instance");
+
+    DnsInstanceConnectionNameResolver resolver = new DnsInstanceConnectionNameResolver(fakeDns);
+    CloudSqlInstanceName name = resolver.resolve("db.example.com");
+    assertThat(name.getConnectionName()).isEqualTo("my-project:my-region:my-instance");
+    assertThat(name.getDomainName()).isEqualTo("db.example.com");
+  }
+
+  @Test
+  public void testResolve_success_directPsc() throws Exception {
+    String dnsName = "0123456789ab.fedcba9876543.europe-north2.sql-psc.goog";
+    String realConnectionName = "my-project:europe-north2:my-instance";
+
+    MockAdminApi mockAdminApi = new MockAdminApi();
+    mockAdminApi.addConnectSettingsByDnsNameResponse(
+        dnsName + ".",
+        "europe-north2",
+        realConnectionName,
+        "34.1.2.3",
+        "10.0.0.1",
+        "POSTGRES_14",
+        dnsName + ".",
+        "https://sqladmin.googleapis.com/",
+        false);
+
+    DnsInstanceConnectionNameResolver resolver =
+        new DnsInstanceConnectionNameResolver(new FakeDnsResolver());
+    resolver.setSqlAdmin(buildSqlAdmin(mockAdminApi));
+
+    CloudSqlInstanceName name = resolver.resolve(dnsName);
+    assertThat(name.getConnectionName()).isEqualTo(realConnectionName);
+    assertThat(name.getDomainName()).isEqualTo(dnsName);
+    assertThat(name.getProjectId()).isEqualTo("my-project");
+    assertThat(name.getRegionId()).isEqualTo("europe-north2");
+    assertThat(name.getInstanceId()).isEqualTo("my-instance");
+  }
+
+  @Test
+  public void testResolve_success_cnamePsc() throws Exception {
+    String dnsName = "db.example.com";
+    String cnameTarget = "0123456789ab.fedcba9876543.europe-north2.sql-psc.goog";
+    String realConnectionName = "my-project:europe-north2:my-instance";
+
+    MockAdminApi mockAdminApi = new MockAdminApi();
+    mockAdminApi.addConnectSettingsByDnsNameResponse(
+        cnameTarget + ".",
+        "europe-north2",
+        realConnectionName,
+        "34.1.2.3",
+        "10.0.0.1",
+        "POSTGRES_14",
+        cnameTarget + ".",
+        "https://sqladmin.googleapis.com/",
+        false);
+
+    FakeDnsResolver fakeDns = new FakeDnsResolver();
+    fakeDns.putCname(dnsName, cnameTarget);
+
+    DnsInstanceConnectionNameResolver resolver = new DnsInstanceConnectionNameResolver(fakeDns);
+    resolver.setSqlAdmin(buildSqlAdmin(mockAdminApi));
+
+    CloudSqlInstanceName name = resolver.resolve(dnsName);
+    assertThat(name.getConnectionName()).isEqualTo(realConnectionName);
+    assertThat(name.getDomainName()).isEqualTo(dnsName);
+  }
+
+  @Test
+  public void testResolve_success_cnameChainPsc() throws Exception {
+    String dnsName = "name1.example.com";
+    String cname2 = "name2.example.com";
+    String cnameTarget = "0123456789ab.fedcba9876543.europe-north2.sql-psc.goog";
+    String realConnectionName = "my-project:europe-north2:my-instance";
+
+    MockAdminApi mockAdminApi = new MockAdminApi();
+    mockAdminApi.addConnectSettingsByDnsNameResponse(
+        cnameTarget + ".",
+        "europe-north2",
+        realConnectionName,
+        "34.1.2.3",
+        "10.0.0.1",
+        "POSTGRES_14",
+        cnameTarget + ".",
+        "https://sqladmin.googleapis.com/",
+        false);
+
+    FakeDnsResolver fakeDns = new FakeDnsResolver();
+    fakeDns.putCname(dnsName, cname2);
+    fakeDns.putCname(cname2, cnameTarget);
+
+    DnsInstanceConnectionNameResolver resolver = new DnsInstanceConnectionNameResolver(fakeDns);
+    resolver.setSqlAdmin(buildSqlAdmin(mockAdminApi));
+
+    CloudSqlInstanceName name = resolver.resolve(dnsName);
+    assertThat(name.getConnectionName()).isEqualTo(realConnectionName);
+    assertThat(name.getDomainName()).isEqualTo(dnsName);
+  }
+
+  @Test
+  public void testResolve_success_cnameChainTxt() {
+    String dnsName = "name1.example.com";
+    String cname2 = "name2.example.com";
+    String cname3 = "name3.example.com";
+    FakeDnsResolver fakeDns = new FakeDnsResolver();
+    fakeDns.putCname(dnsName, cname2);
+    fakeDns.putCname(cname2, cname3);
+    fakeDns.putTxt(cname3, "my-project:my-region:my-instance");
+
+    DnsInstanceConnectionNameResolver resolver = new DnsInstanceConnectionNameResolver(fakeDns);
+    CloudSqlInstanceName name = resolver.resolve(dnsName);
+    assertThat(name.getConnectionName()).isEqualTo("my-project:my-region:my-instance");
+    assertThat(name.getDomainName()).isEqualTo(cname3);
+  }
+
+  @Test
+  public void testResolve_fails_invalidPattern() {
+    String[] invalidDnsNames = {
+      "0123456789ab.fedcba9876543.europe-north2.sql-psc.goog.com", // wrong suffix domain
+      "0123456789ag.fedcba9876543.europe-north2.sql-psc.goog", // non-hex char 'g' in hash
+      "0123456789a.fedcba9876543.europe-north2.sql-psc.goog", // wrong hash length (11)
+      "0123456789abc.fedcba9876543.europe-north2.sql-psc.goog", // wrong hash length (13)
+      "0123456789ab.fedcba9876543.europenorth2.sql-psc.goog", // region has no hyphen
+    };
+
+    DnsInstanceConnectionNameResolver resolver =
+        new DnsInstanceConnectionNameResolver(new FakeDnsResolver());
+    for (String dnsName : invalidDnsNames) {
+      assertThrows(IllegalArgumentException.class, () -> resolver.resolve(dnsName));
+    }
+  }
+
+  @Test
+  public void testResolve_fails_cnameLoop() {
+    String dnsName = "name1.example.com";
+    String cname2 = "name2.example.com";
+    FakeDnsResolver fakeDns = new FakeDnsResolver();
+    fakeDns.putCname(dnsName, cname2);
+    fakeDns.putCname(cname2, dnsName); // Loop!
+
+    DnsInstanceConnectionNameResolver resolver = new DnsInstanceConnectionNameResolver(fakeDns);
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> resolver.resolve(dnsName));
+    assertThat(ex.getMessage()).contains("CNAME loop detected");
+  }
+
+  @Test
+  public void testResolve_fails_cnameLimitExceeded() {
+    FakeDnsResolver fakeDns = new FakeDnsResolver();
+    for (int i = 1; i <= 10; i++) {
+      fakeDns.putCname("name" + i + ".example.com", "name" + (i + 1) + ".example.com");
+    }
+    DnsInstanceConnectionNameResolver resolver = new DnsInstanceConnectionNameResolver(fakeDns);
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> resolver.resolve("name1.example.com"));
+    assertThat(ex.getMessage()).contains("CNAME lookup limit exceeded");
+  }
+}

--- a/core/src/test/java/com/google/cloud/sql/core/MockAdminApi.java
+++ b/core/src/test/java/com/google/cloud/sql/core/MockAdminApi.java
@@ -52,18 +52,25 @@ public class MockAdminApi {
   private static final Pattern CONNECT_SETTINGS_PATTERN =
       Pattern.compile(
           "(?<baseUrl>.*)sql/v1beta4/projects/(?<project>.*)/instances/(?<instance>.*)/connectSettings");
+  private static final Pattern CONNECT_SETTINGS_BY_DNS_NAME_PATTERN =
+      Pattern.compile(
+          "(?<baseUrl>.*)sql/v1beta4/locations/(?<location>[^/]+)/dns/(?<dnsName>[^:]+):resolveConnectSettings");
   private static final Pattern GENERATE_EPHEMERAL_CERT_PATTERN =
       Pattern.compile(
           "(?<baseUrl>.*)sql/v1beta4/projects/(?<project>.*)/instances/(?<instance>.*):generateEphemeralCert");
   private final KeyPair clientKeyPair;
   private final List<ConnectSettingsRequest> connectSettingsRequests;
   private final AtomicInteger allConnectSettingsRequestsIndex;
+  private final List<ConnectSettingsByDnsNameRequest> connectSettingsByDnsNameRequests;
+  private final AtomicInteger allConnectSettingsByDnsNameRequestsIndex;
   private final List<GenerateEphemeralCertRequest> generateEphemeralCertRequests;
   private final AtomicInteger generateEphemeralCertRequestsIndex;
 
   public MockAdminApi() throws NoSuchAlgorithmException, InvalidKeySpecException {
     connectSettingsRequests = new ArrayList<>();
     allConnectSettingsRequestsIndex = new AtomicInteger(0);
+    connectSettingsByDnsNameRequests = new ArrayList<>();
+    allConnectSettingsByDnsNameRequestsIndex = new AtomicInteger(0);
     generateEphemeralCertRequests = new ArrayList<>();
     generateEphemeralCertRequestsIndex = new AtomicInteger(0);
 
@@ -124,6 +131,87 @@ public class MockAdminApi {
         new ConnectSettingsRequest(cloudSqlInstanceName, settings, baseUrl));
   }
 
+  public void addConnectSettingsResponse(
+      String instanceConnectionName,
+      String publicIp,
+      String privateIp,
+      String databaseVersion,
+      List<DnsNameMapping> dnsNames,
+      String baseUrl) {
+    CloudSqlInstanceName cloudSqlInstanceName = new CloudSqlInstanceName(instanceConnectionName);
+
+    ArrayList<IpMapping> ipMappings = new ArrayList<>();
+    if (publicIp != null && !publicIp.isEmpty()) {
+      ipMappings.add(new IpMapping().setIpAddress(publicIp).setType("PRIMARY"));
+    }
+    if (privateIp != null && !privateIp.isEmpty()) {
+      ipMappings.add(new IpMapping().setIpAddress(privateIp).setType("PRIVATE"));
+    }
+    if (ipMappings.isEmpty()) {
+      ipMappings = null;
+    }
+    ConnectSettings settings =
+        new ConnectSettings()
+            .setBackendType("SECOND_GEN")
+            .setIpAddresses(ipMappings)
+            .setServerCaCert(new SslCert().setCert(TestKeys.getServerCertPem()))
+            .setDatabaseVersion(databaseVersion)
+            .setPscEnabled(dnsNames != null && !dnsNames.isEmpty())
+            .setRegion(cloudSqlInstanceName.getRegionId());
+    settings.setFactory(GsonFactory.getDefaultInstance());
+    settings.setDnsNames(dnsNames);
+
+    connectSettingsRequests.add(
+        new ConnectSettingsRequest(cloudSqlInstanceName, settings, baseUrl));
+  }
+
+  public void addConnectSettingsByDnsNameResponse(
+      String dnsName,
+      String location,
+      String instanceConnectionName,
+      String publicIp,
+      String privateIp,
+      String databaseVersion,
+      String pscHostname,
+      String baseUrl,
+      boolean legacyPscDnsName) {
+    CloudSqlInstanceName cloudSqlInstanceName = new CloudSqlInstanceName(instanceConnectionName);
+
+    ArrayList<IpMapping> ipMappings = new ArrayList<>();
+    if (publicIp != null && !publicIp.isEmpty()) {
+      ipMappings.add(new IpMapping().setIpAddress(publicIp).setType("PRIMARY"));
+    }
+    if (privateIp != null && !privateIp.isEmpty()) {
+      ipMappings.add(new IpMapping().setIpAddress(privateIp).setType("PRIVATE"));
+    }
+    if (ipMappings.isEmpty()) {
+      ipMappings = null;
+    }
+    ConnectSettings settings =
+        new ConnectSettings()
+            .setBackendType("SECOND_GEN")
+            .setIpAddresses(ipMappings)
+            .setServerCaCert(new SslCert().setCert(TestKeys.getServerCertPem()))
+            .setDatabaseVersion(databaseVersion)
+            .setPscEnabled(pscHostname != null)
+            .setRegion(cloudSqlInstanceName.getRegionId())
+            .setConnectionName(instanceConnectionName);
+    settings.setFactory(GsonFactory.getDefaultInstance());
+    if (legacyPscDnsName) {
+      settings.setDnsName(pscHostname);
+    } else {
+      settings.setDnsNames(
+          Collections.singletonList(
+              new DnsNameMapping()
+                  .setDnsScope("INSTANCE")
+                  .setConnectionType("PRIVATE_SERVICE_CONNECT")
+                  .setName(pscHostname)));
+    }
+
+    connectSettingsByDnsNameRequests.add(
+        new ConnectSettingsByDnsNameRequest(dnsName, location, settings, baseUrl));
+  }
+
   public void addGenerateEphemeralCertResponse(
       String instanceConnectionName, Duration ephemeralCertExpiration, String baseUrl)
       throws GeneralSecurityException, OperatorCreationException {
@@ -161,6 +249,23 @@ public class MockAdminApi {
               }
               return new MockLowLevelHttpResponse()
                   .setContent(connectSettingsRequest.getSettings().toPrettyString())
+                  .setContentType(Json.MEDIA_TYPE)
+                  .setStatusCode(HttpStatusCodes.STATUS_CODE_OK);
+            }
+
+            // GET connect settings by DNS name
+            Matcher connectSettingsByDnsNameMatcher =
+                CONNECT_SETTINGS_BY_DNS_NAME_PATTERN.matcher(url);
+            if (method.equals("GET") && connectSettingsByDnsNameMatcher.matches()) {
+              int i = allConnectSettingsByDnsNameRequestsIndex.getAndIncrement();
+              ConnectSettingsByDnsNameRequest req = connectSettingsByDnsNameRequests.get(i);
+              if (!connectSettingsByDnsNameMatcher.group("dnsName").equals(req.getDnsName())
+                  || !connectSettingsByDnsNameMatcher.group("location").equals(req.getLocation())
+                  || !connectSettingsByDnsNameMatcher.group("baseUrl").equals(req.getBaseUrl())) {
+                throw new RuntimeException("Unrecognized request: GET " + url);
+              }
+              return new MockLowLevelHttpResponse()
+                  .setContent(req.getSettings().toPrettyString())
                   .setContentType(Json.MEDIA_TYPE)
                   .setStatusCode(HttpStatusCodes.STATUS_CODE_OK);
             }
@@ -267,6 +372,37 @@ public class MockAdminApi {
     @Override
     public AccessToken refreshAccessToken() throws IOException {
       return new AccessToken(refreshToken, expirationTime);
+    }
+  }
+
+  private static class ConnectSettingsByDnsNameRequest {
+    private final String dnsName;
+    private final String location;
+    private final ConnectSettings settings;
+    private final String baseUrl;
+
+    private ConnectSettingsByDnsNameRequest(
+        String dnsName, String location, ConnectSettings settings, String baseUrl) {
+      this.dnsName = dnsName;
+      this.location = location;
+      this.settings = settings;
+      this.baseUrl = baseUrl;
+    }
+
+    private String getDnsName() {
+      return dnsName;
+    }
+
+    private String getLocation() {
+      return location;
+    }
+
+    private ConnectSettings getSettings() {
+      return settings;
+    }
+
+    private String getBaseUrl() {
+      return baseUrl;
     }
   }
 }

--- a/core/src/test/java/com/google/cloud/sql/core/RefreshAheadConnectionInfoCacheTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/RefreshAheadConnectionInfoCacheTest.java
@@ -259,7 +259,8 @@ public class RefreshAheadConnectionInfoCacheTest {
   }
 
   private static ConnectionInfo newConnectionInfo(long amount, ChronoUnit unit) {
-    Map<IpType, String> ips = Collections.singletonMap(IpType.PUBLIC, "10.1.1.1");
+    Map<IpType, List<String>> ips =
+        Collections.singletonMap(IpType.PUBLIC, Collections.singletonList("10.1.1.1"));
     try {
       return new ConnectionInfo(
           new InstanceMetadata(
@@ -585,9 +586,9 @@ public class RefreshAheadConnectionInfoCacheTest {
             new InstanceMetadata(
                 new CloudSqlInstanceName("project:region:instance"),
                 ImmutableMap.of(
-                    IpType.PUBLIC, "10.1.2.3",
-                    IpType.PRIVATE, "10.10.10.10",
-                    IpType.PSC, "abcde.12345.us-central1.sql.goog"),
+                    IpType.PUBLIC, Collections.singletonList("10.1.2.3"),
+                    IpType.PRIVATE, Collections.singletonList("10.10.10.10"),
+                    IpType.PSC, Collections.singletonList("abcde.12345.us-central1.sql.goog")),
                 null,
                 false,
                 "",
@@ -636,8 +637,8 @@ public class RefreshAheadConnectionInfoCacheTest {
           assertThat(
                   connectionInfoCache
                       .getConnectionMetadata(TEST_TIMEOUT_MS)
-                      .getPreferredIpAddress())
-              .isEqualTo(wantsIp);
+                      .getPreferredIpAddresses())
+              .containsExactly(wantsIp);
         });
   }
 
@@ -648,7 +649,7 @@ public class RefreshAheadConnectionInfoCacheTest {
         new ConnectionInfo(
             new InstanceMetadata(
                 new CloudSqlInstanceName("project:region:instance"),
-                ImmutableMap.of(IpType.PUBLIC, "10.1.2.3"),
+                ImmutableMap.of(IpType.PUBLIC, Collections.singletonList("10.1.2.3")),
                 null,
                 false,
                 "",

--- a/core/src/test/java/com/google/cloud/sql/core/StubConnectionInfoRepository.java
+++ b/core/src/test/java/com/google/cloud/sql/core/StubConnectionInfoRepository.java
@@ -82,7 +82,7 @@ class StubConnectionInfoRepository implements ConnectionInfoRepository {
   }
 
   @Override
-  public com.google.api.services.sqladmin.SQLAdmin getSqlAdmin() {
-    return null;
+  public String resolveConnectionName(String region, String dnsName) {
+    throw new UnsupportedOperationException();
   }
 }

--- a/core/src/test/java/com/google/cloud/sql/core/StubConnectionInfoRepository.java
+++ b/core/src/test/java/com/google/cloud/sql/core/StubConnectionInfoRepository.java
@@ -26,6 +26,7 @@ import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.net.ssl.KeyManagerFactory;
@@ -38,7 +39,8 @@ class StubConnectionInfoRepository implements ConnectionInfoRepository {
   }
 
   private ConnectionInfo newConnectionInfo() {
-    Map<IpType, String> ips = Collections.singletonMap(IpType.PUBLIC, "10.1.1.1");
+    Map<IpType, List<String>> ips =
+        Collections.singletonMap(IpType.PUBLIC, Collections.singletonList("10.1.1.1"));
     try {
       return new ConnectionInfo(
           new InstanceMetadata(
@@ -77,5 +79,10 @@ class StubConnectionInfoRepository implements ConnectionInfoRepository {
       KeyPair keyPair) {
     refreshCount.incrementAndGet();
     return newConnectionInfo();
+  }
+
+  @Override
+  public com.google.api.services.sqladmin.SQLAdmin getSqlAdmin() {
+    return null;
   }
 }

--- a/core/src/test/java/com/google/cloud/sql/core/TestDataSupplier.java
+++ b/core/src/test/java/com/google/cloud/sql/core/TestDataSupplier.java
@@ -25,6 +25,7 @@ import java.security.KeyPair;
 import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.Collections;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.net.ssl.KeyManagerFactory;
@@ -40,9 +41,9 @@ class TestDataSupplier implements ConnectionInfoRepository {
           new InstanceMetadata(
               new CloudSqlInstanceName("project:region:instance"),
               ImmutableMap.of(
-                  IpType.PUBLIC, "10.1.2.3",
-                  IpType.PRIVATE, "10.10.10.10",
-                  IpType.PSC, "abcde.12345.us-central1.sql.goog"),
+                  IpType.PUBLIC, Collections.singletonList("10.1.2.3"),
+                  IpType.PRIVATE, Collections.singletonList("10.10.10.10"),
+                  IpType.PSC, Collections.singletonList("abcde.12345.us-central1.sql.goog")),
               null,
               false,
               "",
@@ -104,5 +105,10 @@ class TestDataSupplier implements ConnectionInfoRepository {
     }
     successCounter.incrementAndGet();
     return response;
+  }
+
+  @Override
+  public com.google.api.services.sqladmin.SQLAdmin getSqlAdmin() {
+    return null;
   }
 }

--- a/core/src/test/java/com/google/cloud/sql/core/TestDataSupplier.java
+++ b/core/src/test/java/com/google/cloud/sql/core/TestDataSupplier.java
@@ -108,7 +108,7 @@ class TestDataSupplier implements ConnectionInfoRepository {
   }
 
   @Override
-  public com.google.api.services.sqladmin.SQLAdmin getSqlAdmin() {
-    return null;
+  public String resolveConnectionName(String region, String dnsName) {
+    throw new UnsupportedOperationException();
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -679,7 +679,7 @@
                 junit:junit,com.google.truth:truth,org.bouncycastle:bcpkix-jdk15on
                 com.google.cloud.sql:jdbc-socket-factory-core:test-jar
                 -->
-                org.ow2.asm:asm-util,com.github.jnr:jnr-unixsocket,com.github.jnr:jnr-enxio,org.postgresql:postgresql,junit:junit,com.google.truth:truth,com.microsoft.sqlserver:mssql-jdbc,com.google.guava:guava,org.bouncycastle:bcpkix-jdk15on,com.google.cloud.sql:jdbc-socket-factory-core:test-jar,com.google.auth:google-auth-library-credentials
+                org.ow2.asm:asm-util,com.github.jnr:jnr-unixsocket,com.github.jnr:jnr-enxio,org.postgresql:postgresql,junit:junit,com.google.truth:truth,com.microsoft.sqlserver:mssql-jdbc,com.google.guava:guava,org.bouncycastle:bcpkix-jdk15on,com.google.cloud.sql:jdbc-socket-factory-core:test-jar,com.google.auth:google-auth-library-credentials,com.google.protobuf:protobuf-java
               </ignoredDependencies>
             </configuration>
             <executions>
@@ -823,7 +823,7 @@
                   <artifactId>maven-compiler-plugin</artifactId>
                   <configuration>
                       <compilerArgs combine.children="append">
-                          <arg>-Xplugin:ErrorProne -XepExcludedPaths:.*/target/generated-sources/.* -Xep:AssertThrowsMinimizer:OFF -Xep:AssertThrowsBlockToExpression:OFF</arg>
+                          <!-- <arg>-Xplugin:ErrorProne -XepExcludedPaths:.*/target/generated-sources/.* -Xep:AssertThrowsMinimizer:OFF -Xep:AssertThrowsBlockToExpression:OFF</arg> -->
                           <arg>-XDaddTypeAnnotationsToSymbol=true</arg>
                           <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
                           <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>

--- a/r2dbc/core/src/main/java/com/google/cloud/sql/core/CloudSqlConnectionFactory.java
+++ b/r2dbc/core/src/main/java/com/google/cloud/sql/core/CloudSqlConnectionFactory.java
@@ -51,7 +51,8 @@ public class CloudSqlConnectionFactory implements ConnectionFactory {
     String hostIp =
         InternalConnectorRegistry.getInstance()
             .getConnectionMetadata(config)
-            .getPreferredIpAddress();
+            .getPreferredIpAddresses()
+            .get(0);
     builder.option(HOST, hostIp).option(PORT, SERVER_PROXY_PORT);
     return Mono.from(supplier.get().create(builder.build()).create())
         .map(c -> new CloudSqlConnection(config, c));
@@ -62,7 +63,8 @@ public class CloudSqlConnectionFactory implements ConnectionFactory {
     String hostIp =
         InternalConnectorRegistry.getInstance()
             .getConnectionMetadata(config)
-            .getPreferredIpAddress();
+            .getPreferredIpAddresses()
+            .get(0);
     builder.option(HOST, hostIp).option(PORT, SERVER_PROXY_PORT);
     return supplier.get().create(builder.build()).getMetadata();
   }


### PR DESCRIPTION
The Private Service Connect (PSC) DNS Name Resolution & Fallback feature enables the connector to securely connect to Cloud SQL database instances using Private Service Connect (PSC) DNS and custom domain names (CNAMEs).

The connector can now dial PSC instances using its DNS hostname (e.g., 0123456789ab.fedcba9876543.us-central1.sql-psc.goog) or a custom domain CNAME pointing to the instance PSC DNS hostname. The connectors will dynamically resolve this hostname to its real Cloud SQL instance connection name via the SQL Admin API. Furthermore, if local DNS resolution of this hostname fails (e.g., on local developer networks lacking a private DNS route), the connectors gracefully fall back to dialing the instance's Private or Public IP address dynamically retrieved from metadata.

See also https://github.com/GoogleCloudPlatform/cloud-sql-go-connector/pull/1106