### PR TITLE
feat:Support Developer Edition connections.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -48,7 +48,7 @@ function test() {
       sudo ifconfig lo0 alias 127.0.0.3 up
     fi
   fi
-  $mvn_cmd -P coverage test
+  $mvn_cmd -P coverage test "$@"
 }
 
 ## e2e - Runs end-to-end integration tests.

--- a/build.sh
+++ b/build.sh
@@ -33,7 +33,7 @@ function clean() {
 
 ## build - Builds the project without running tests.
 function build() {
-   $mvn_cmd install -DskipTests=true
+   $mvn_cmd install -DskipTests=true "$@"
 }
 
 ## test - Runs local unit tests.

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -85,6 +85,10 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>com.google.errorprone</groupId>
@@ -215,7 +219,33 @@
       <artifactId>schemas</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
-
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-stub</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-netty</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-auth</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-testing</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-inprocess</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -239,6 +269,7 @@
           <usedDependencies>
             <!-- This dependency is not used at compile-time. -->
             <dependency>ch.qos.logback:logback-classic</dependency>
+            <dependency>io.grpc:grpc-netty</dependency>
           </usedDependencies>
         </configuration>
       </plugin>

--- a/core/src/main/java/com/google/cloud/sql/ConnectorConfig.java
+++ b/core/src/main/java/com/google/cloud/sql/ConnectorConfig.java
@@ -50,6 +50,9 @@ public class ConnectorConfig {
    */
   private final Duration failoverPeriod;
 
+  private final String sqlDataEndpoint;
+  private final Duration sqlDataStreamTimeout;
+
   private ConnectorConfig(
       String targetPrincipal,
       List<String> delegates,
@@ -62,7 +65,9 @@ public class ConnectorConfig {
       String universeDomain,
       RefreshStrategy refreshStrategy,
       Function<String, String> instanceNameResolver,
-      Duration failoverPeriod) {
+      Duration failoverPeriod,
+      String sqlDataEndpoint,
+      Duration sqlDataStreamTimeout) {
     this.targetPrincipal = targetPrincipal;
     this.delegates = delegates;
     this.adminRootUrl = adminRootUrl;
@@ -75,6 +80,8 @@ public class ConnectorConfig {
     this.refreshStrategy = refreshStrategy;
     this.instanceNameResolver = instanceNameResolver;
     this.failoverPeriod = failoverPeriod;
+    this.sqlDataEndpoint = sqlDataEndpoint;
+    this.sqlDataStreamTimeout = sqlDataStreamTimeout;
   }
 
   @Override
@@ -97,7 +104,9 @@ public class ConnectorConfig {
         && Objects.equal(universeDomain, that.universeDomain)
         && Objects.equal(refreshStrategy, that.refreshStrategy)
         && Objects.equal(instanceNameResolver, that.instanceNameResolver)
-        && Objects.equal(failoverPeriod, that.failoverPeriod);
+        && Objects.equal(failoverPeriod, that.failoverPeriod)
+        && Objects.equal(sqlDataEndpoint, that.sqlDataEndpoint)
+        && Objects.equal(sqlDataStreamTimeout, that.sqlDataStreamTimeout);
   }
 
   @Override
@@ -114,7 +123,9 @@ public class ConnectorConfig {
         universeDomain,
         refreshStrategy,
         instanceNameResolver,
-        failoverPeriod);
+        failoverPeriod,
+        sqlDataEndpoint,
+        sqlDataStreamTimeout);
   }
 
   public String getTargetPrincipal() {
@@ -165,6 +176,14 @@ public class ConnectorConfig {
     return failoverPeriod;
   }
 
+  public String getSqlDataEndpoint() {
+    return sqlDataEndpoint;
+  }
+
+  public Duration getSqlDataStreamTimeout() {
+    return sqlDataStreamTimeout;
+  }
+
   /** The builder for the ConnectionConfig. */
   public static class Builder {
 
@@ -181,6 +200,8 @@ public class ConnectorConfig {
     private Function<String, String> instanceNameResolver;
 
     private Duration failoverPeriod = DEFAULT_FAILOVER_PERIOD;
+    private String sqlDataEndpoint = "sqladmin.googleapis.com";
+    private Duration sqlDataStreamTimeout = Duration.ofHours(2);
 
     /** Chained setter for TargetPrinciple field. */
     public Builder withTargetPrincipal(String targetPrincipal) {
@@ -255,6 +276,18 @@ public class ConnectorConfig {
       return this;
     }
 
+    /** Chained setter for the SqlDataEndpoint field. */
+    public Builder withSqlDataEndpoint(String sqlDataEndpoint) {
+      this.sqlDataEndpoint = sqlDataEndpoint;
+      return this;
+    }
+
+    /** Chained setter for the SqlDataStreamTimeout field. */
+    public Builder withSqlDataStreamTimeout(Duration sqlDataStreamTimeout) {
+      this.sqlDataStreamTimeout = sqlDataStreamTimeout;
+      return this;
+    }
+
     /** Builds a new instance of {@code ConnectionConfig}. */
     public ConnectorConfig build() {
       // validate only one GoogleCredentials configuration field set
@@ -291,7 +324,9 @@ public class ConnectorConfig {
           universeDomain,
           refreshStrategy,
           instanceNameResolver,
-          failoverPeriod);
+          failoverPeriod,
+          sqlDataEndpoint,
+          sqlDataStreamTimeout);
     }
   }
 }

--- a/core/src/main/java/com/google/cloud/sql/IpType.java
+++ b/core/src/main/java/com/google/cloud/sql/IpType.java
@@ -20,5 +20,6 @@ package com.google.cloud.sql;
 public enum IpType {
   PUBLIC,
   PRIVATE,
-  PSC;
+  PSC,
+  SQL_DATA;
 }

--- a/core/src/main/java/com/google/cloud/sql/core/ConnectionConfig.java
+++ b/core/src/main/java/com/google/cloud/sql/core/ConnectionConfig.java
@@ -21,6 +21,7 @@ import com.google.cloud.sql.ConnectorConfig;
 import com.google.cloud.sql.IpType;
 import com.google.cloud.sql.RefreshStrategy;
 import com.google.common.base.Splitter;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -55,6 +56,9 @@ public class ConnectionConfig {
       Arrays.asList(IpType.PUBLIC, IpType.PRIVATE);
   public static final String CLOUD_SQL_GOOGLE_CREDENTIALS_PATH = "cloudSqlGoogleCredentialsPath";
   public static final String MDX_CLIENT_PROTOCOL_TYPE = "mdxClientProtocolType";
+  public static final String CLOUD_SQL_SQL_DATA_ENDPOINT_PROPERTY = "cloudSqlSqlDataEndpoint";
+  public static final String CLOUD_SQL_SQL_DATA_STREAM_TIMEOUT_PROPERTY =
+      "cloudSqlSqlDataStreamTimeout";
 
   private final ConnectorConfig connectorConfig;
   private final String cloudSqlInstance;
@@ -121,14 +125,16 @@ public class ConnectionConfig {
     final String mdxClientProtocolType =
         props.getProperty(ConnectionConfig.MDX_CLIENT_PROTOCOL_TYPE);
 
-    return new ConnectionConfig(
-        csqlInstanceName,
-        namedConnection,
-        unixSocketPath,
-        ipTypes,
-        authType,
-        unixSocketPathSuffix,
-        domainName,
+    final String sqlDataEndpoint =
+        props.getProperty(ConnectionConfig.CLOUD_SQL_SQL_DATA_ENDPOINT_PROPERTY);
+    final String sqlDataStreamTimeoutStr =
+        props.getProperty(ConnectionConfig.CLOUD_SQL_SQL_DATA_STREAM_TIMEOUT_PROPERTY);
+    final Duration sqlDataStreamTimeout =
+        sqlDataStreamTimeoutStr != null
+            ? Duration.ofMillis(Long.parseLong(sqlDataStreamTimeoutStr))
+            : null;
+
+    ConnectorConfig.Builder connectorConfigBuilder =
         new ConnectorConfig.Builder()
             .withTargetPrincipal(targetPrincipal)
             .withDelegates(delegates)
@@ -137,8 +143,24 @@ public class ConnectionConfig {
             .withGoogleCredentialsPath(googleCredentialsPath)
             .withAdminQuotaProject(adminQuotaProject)
             .withUniverseDomain(universeDomain)
-            .withRefreshStrategy(refreshStrategy)
-            .build(),
+            .withRefreshStrategy(refreshStrategy);
+
+    if (sqlDataEndpoint != null) {
+      connectorConfigBuilder.withSqlDataEndpoint(sqlDataEndpoint);
+    }
+    if (sqlDataStreamTimeout != null) {
+      connectorConfigBuilder.withSqlDataStreamTimeout(sqlDataStreamTimeout);
+    }
+
+    return new ConnectionConfig(
+        csqlInstanceName,
+        namedConnection,
+        unixSocketPath,
+        ipTypes,
+        authType,
+        unixSocketPathSuffix,
+        domainName,
+        connectorConfigBuilder.build(),
         mdxClientProtocolType);
   }
 
@@ -157,6 +179,9 @@ public class ConnectionConfig {
         result.add(IpType.PRIVATE);
       } else if (type.trim().equalsIgnoreCase("PSC")) {
         result.add(IpType.PSC);
+      } else if (type.trim().equalsIgnoreCase("SQL_DATA")
+          || type.trim().equalsIgnoreCase("SQLDATA")) {
+        result.add(IpType.SQL_DATA);
       } else {
         throw new IllegalArgumentException(
             "Unsupported IP type: " + type + " found in ipTypes parameter");

--- a/core/src/main/java/com/google/cloud/sql/core/ConnectionInfo.java
+++ b/core/src/main/java/com/google/cloud/sql/core/ConnectionInfo.java
@@ -58,7 +58,17 @@ class ConnectionInfo {
     String preferredIp = null;
 
     for (IpType ipType : config.getIpTypes()) {
-      preferredIp = getIpAddrs().get(ipType);
+      if (ipType == IpType.SQL_DATA) {
+        preferredIp = getIpAddrs().get(IpType.PRIVATE);
+        if (preferredIp == null) {
+          preferredIp = getIpAddrs().get(IpType.PSC);
+        }
+        if (preferredIp == null) {
+          preferredIp = getIpAddrs().get(IpType.PUBLIC);
+        }
+      } else {
+        preferredIp = getIpAddrs().get(ipType);
+      }
       if (preferredIp != null) {
         break;
       }

--- a/core/src/main/java/com/google/cloud/sql/core/Connector.java
+++ b/core/src/main/java/com/google/cloud/sql/core/Connector.java
@@ -18,6 +18,7 @@ package com.google.cloud.sql.core;
 
 import com.google.cloud.sql.ConnectorConfig;
 import com.google.cloud.sql.CredentialFactory;
+import com.google.cloud.sql.IpType;
 import com.google.cloud.sql.RefreshStrategy;
 import com.google.common.base.Strings;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -53,6 +54,8 @@ class Connector {
       new ConcurrentHashMap<>();
   private final int serverProxyPort;
   private final ConnectorConfig config;
+  private final SqlDataClient sqlDataClient;
+  private final ConcurrentHashMap<String, Boolean> sqlDataUnsupported = new ConcurrentHashMap<>();
 
   private final InstanceConnectionNameResolver instanceNameResolver;
   private final DnsResolver dnsResolver;
@@ -71,6 +74,35 @@ class Connector {
       InstanceConnectionNameResolver instanceNameResolver,
       DnsResolver dnsResolver,
       ProtocolHandler mdxProtocolHandler) {
+    this(
+        config,
+        connectionInfoRepositoryFactory,
+        instanceCredentialFactory,
+        executor,
+        localKeyPair,
+        minRefreshDelayMs,
+        refreshTimeoutMs,
+        serverProxyPort,
+        instanceNameResolver,
+        dnsResolver,
+        mdxProtocolHandler,
+        new SqlDataClient(
+            config, instanceCredentialFactory, InternalConnectorRegistry.getUserAgents()));
+  }
+
+  Connector(
+      ConnectorConfig config,
+      ConnectionInfoRepositoryFactory connectionInfoRepositoryFactory,
+      CredentialFactory instanceCredentialFactory,
+      ListeningScheduledExecutorService executor,
+      ListenableFuture<KeyPair> localKeyPair,
+      long minRefreshDelayMs,
+      long refreshTimeoutMs,
+      int serverProxyPort,
+      InstanceConnectionNameResolver instanceNameResolver,
+      DnsResolver dnsResolver,
+      ProtocolHandler mdxProtocolHandler,
+      SqlDataClient sqlDataClient) {
     this.config = config;
     this.adminApi =
         connectionInfoRepositoryFactory.create(instanceCredentialFactory.create(), config);
@@ -83,6 +115,7 @@ class Connector {
     this.dnsResolver = dnsResolver;
     this.instanceNameResolverTimer = new Timer("InstanceNameResolverTimer", true);
     this.mdxProtocolHandler = mdxProtocolHandler;
+    this.sqlDataClient = sqlDataClient;
   }
 
   public ConnectorConfig getConfig() {
@@ -124,6 +157,34 @@ class Connector {
               config.getCloudSqlInstance(), unixSocket));
       UnixSocketAddress socketAddress = new UnixSocketAddress(new File(unixSocket));
       return UnixSocketChannel.open(socketAddress).socket();
+    }
+
+    final ConnectionConfig resolvedConfig = resolveConnectionName(config);
+    CloudSqlInstanceName instanceName =
+        new CloudSqlInstanceName(resolvedConfig.getCloudSqlInstance());
+
+    if (!resolvedConfig.getIpTypes().isEmpty()
+        && resolvedConfig.getIpTypes().get(0) == IpType.SQL_DATA) {
+      if (!sqlDataUnsupported.containsKey(instanceName.getConnectionName())) {
+        try {
+          logger.debug(
+              String.format(
+                  "[%s] Attempting SQL Data Service connection.",
+                  instanceName.getConnectionName()));
+          return sqlDataClient.connect(instanceName, timeoutMs);
+        } catch (Exception e) {
+          if (isPreconditionFailed(e)) {
+            logger.warn(
+                String.format(
+                    "[%s] SQL Data Service not supported for this instance. "
+                        + "Falling back to direct IP.",
+                    instanceName.getConnectionName()));
+            sqlDataUnsupported.put(instanceName.getConnectionName(), true);
+          } else {
+            throw e;
+          }
+        }
+      }
     }
 
     MonitoredCache instance = getConnection(config);
@@ -289,5 +350,21 @@ class Connector {
     this.instanceNameResolverTimer.cancel();
     this.instances.forEach((key, c) -> c.close());
     this.instances.clear();
+    this.sqlDataClient.close();
+  }
+
+  private boolean isPreconditionFailed(Throwable t) {
+    while (t != null) {
+      if (t instanceof io.grpc.StatusRuntimeException) {
+        return ((io.grpc.StatusRuntimeException) t).getStatus().getCode()
+            == io.grpc.Status.Code.FAILED_PRECONDITION;
+      }
+      if (t instanceof io.grpc.StatusException) {
+        return ((io.grpc.StatusException) t).getStatus().getCode()
+            == io.grpc.Status.Code.FAILED_PRECONDITION;
+      }
+      t = t.getCause();
+    }
+    return false;
   }
 }

--- a/core/src/main/java/com/google/cloud/sql/core/SqlDataClient.java
+++ b/core/src/main/java/com/google/cloud/sql/core/SqlDataClient.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.sql.core;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.sql.ConnectorConfig;
+import com.google.cloud.sql.CredentialFactory;
+import com.google.cloud.sql.v1beta4.SqlDataServiceGrpc;
+import com.google.cloud.sql.v1beta4.StartSession;
+import com.google.cloud.sql.v1beta4.StreamSqlDataRequest;
+import com.google.cloud.sql.v1beta4.StreamSqlDataResponse;
+import io.grpc.CallCredentials;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
+import io.grpc.StatusRuntimeException;
+import io.grpc.auth.MoreCallCredentials;
+import io.grpc.stub.MetadataUtils;
+import io.grpc.stub.StreamObserver;
+import java.io.IOException;
+import java.net.Socket;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class SqlDataClient {
+  private static final Logger logger = LoggerFactory.getLogger(SqlDataClient.class);
+
+  private final String endpoint;
+  private final CredentialFactory credentialFactory;
+  private final String quotaProject;
+  private final String userAgent;
+  private final Duration timeout;
+  private final Object channelLock = new Object();
+  private final ManagedChannel externalChannel;
+  private ManagedChannel channel;
+
+  SqlDataClient(ConnectorConfig config, CredentialFactory credentialFactory, String userAgent) {
+    this(config, credentialFactory, userAgent, null);
+  }
+
+  SqlDataClient(
+      ConnectorConfig config,
+      CredentialFactory credentialFactory,
+      String userAgent,
+      ManagedChannel externalChannel) {
+    this.endpoint = config.getSqlDataEndpoint();
+    this.credentialFactory = credentialFactory;
+    this.quotaProject = config.getAdminQuotaProject();
+    this.userAgent = userAgent;
+    this.timeout = config.getSqlDataStreamTimeout();
+    this.externalChannel = externalChannel;
+  }
+
+  private ManagedChannel getChannel() {
+    synchronized (channelLock) {
+      if (channel == null) {
+        if (externalChannel != null) {
+          channel = externalChannel;
+        } else {
+          logger.debug("Initializing gRPC channel to {}", endpoint);
+          // Split host and port if present
+          String host = endpoint;
+          int port = 443;
+          int colonIndex = endpoint.indexOf(':');
+          if (colonIndex > 0) {
+            host = endpoint.substring(0, colonIndex);
+            port = Integer.parseInt(endpoint.substring(colonIndex + 1));
+          }
+
+          ManagedChannelBuilder<?> builder =
+              ManagedChannelBuilder.forAddress(host, port).userAgent(userAgent);
+
+          // For development/testing we might want to support insecure, but default is secure.
+          // Go has useInsecure flag. In Java we can check if host is localhost or similar,
+          // or just default to transport security.
+          if (host.equals("localhost") || host.equals("127.0.0.1")) {
+            builder.usePlaintext();
+          } else {
+            builder.useTransportSecurity();
+          }
+
+          channel = builder.build();
+        }
+      }
+      return channel;
+    }
+  }
+
+  Socket connect(CloudSqlInstanceName instanceName, long connectTimeoutMs) throws IOException {
+    ManagedChannel currentChannel = getChannel();
+
+    GoogleCredentials credentials = credentialFactory.getCredentials();
+    if (quotaProject != null && !quotaProject.isEmpty()) {
+      credentials = credentials.createWithQuotaProject(quotaProject);
+    }
+
+    CallCredentials creds = MoreCallCredentials.from(credentials);
+
+    Metadata metadata = new Metadata();
+    String instanceId =
+        String.format(
+            "projects/%s/instances/%s", instanceName.getProjectId(), instanceName.getInstanceId());
+    String locationId = String.format("locations/%s", instanceName.getRegionId());
+
+    metadata.put(
+        Metadata.Key.of("x-goog-request-params", Metadata.ASCII_STRING_MARSHALLER),
+        String.format("instance_id=%s&location_id=%s", instanceId, locationId));
+
+    SqlDataServiceGrpc.SqlDataServiceStub stub =
+        SqlDataServiceGrpc.newStub(currentChannel)
+            .withCallCredentials(creds)
+            .withInterceptors(MetadataUtils.newAttachHeadersInterceptor(metadata));
+
+    if (timeout != null && timeout.toMillis() > 0) {
+      stub = stub.withDeadlineAfter(timeout.toMillis(), TimeUnit.MILLISECONDS);
+    }
+
+    class ResponseObserver implements StreamObserver<StreamSqlDataResponse> {
+      private final CompletableFuture<Void> handshakeFuture;
+      private SqlDataSocket socket;
+
+      ResponseObserver(CompletableFuture<Void> handshakeFuture) {
+        this.handshakeFuture = handshakeFuture;
+      }
+
+      void setSocket(SqlDataSocket socket) {
+        this.socket = socket;
+      }
+
+      @Override
+      public void onNext(StreamSqlDataResponse response) {
+        if (response.hasSessionMetadata()) {
+          logger.debug("Received SessionMetadata, connection established");
+          handshakeFuture.complete(null);
+        } else if (socket != null) {
+          socket.onNextResponse(response);
+        }
+      }
+
+      @Override
+      public void onError(Throwable t) {
+        if (!handshakeFuture.isDone()) {
+          handshakeFuture.completeExceptionally(t);
+        }
+        if (socket != null) {
+          socket.onErrorResponse(t);
+        }
+      }
+
+      @Override
+      public void onCompleted() {
+        if (!handshakeFuture.isDone()) {
+          handshakeFuture.completeExceptionally(
+              new IOException("Stream completed before handshake"));
+        }
+        if (socket != null) {
+          socket.onCompletedResponse();
+        }
+      }
+    }
+
+    CompletableFuture<Void> handshakeFuture = new CompletableFuture<>();
+    ResponseObserver responseObserver = new ResponseObserver(handshakeFuture);
+    StreamObserver<StreamSqlDataRequest> requestObserver = stub.streamSqlData(responseObserver);
+
+    SqlDataSocket socket = new SqlDataSocket(requestObserver);
+    responseObserver.setSocket(socket);
+
+    // Send StartSession
+    StreamSqlDataRequest startRequest =
+        StreamSqlDataRequest.newBuilder()
+            .setStartSession(
+                StartSession.newBuilder()
+                    .setInstanceId(instanceId)
+                    .setLocationId(locationId)
+                    .build())
+            .build();
+
+    try {
+      requestObserver.onNext(startRequest);
+    } catch (Exception e) {
+      throw new IOException("Failed to send StartSession request", e);
+    }
+
+    try {
+      if (connectTimeoutMs > 0) {
+        handshakeFuture.get(connectTimeoutMs, TimeUnit.MILLISECONDS);
+      } else {
+        handshakeFuture.get();
+      }
+    } catch (ExecutionException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof StatusRuntimeException) {
+        throw new IOException("Failed to connect via SQL Data Service", cause);
+      }
+      throw new IOException("Failed to connect via SQL Data Service", e);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IOException("Connection interrupted", e);
+    } catch (TimeoutException e) {
+      throw new IOException("Connection timed out waiting for SQL Data Service response", e);
+    }
+
+    return socket;
+  }
+
+  void close() {
+    synchronized (channelLock) {
+      if (channel != null) {
+        logger.debug("Closing gRPC channel");
+        channel.shutdown();
+        try {
+          if (!channel.awaitTermination(5, TimeUnit.SECONDS)) {
+            channel.shutdownNow();
+          }
+        } catch (InterruptedException e) {
+          channel.shutdownNow();
+          Thread.currentThread().interrupt();
+        }
+        channel = null;
+      }
+    }
+  }
+}

--- a/core/src/main/java/com/google/cloud/sql/core/SqlDataSocket.java
+++ b/core/src/main/java/com/google/cloud/sql/core/SqlDataSocket.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.sql.core;
+
+import com.google.cloud.sql.v1beta4.DataPacket;
+import com.google.cloud.sql.v1beta4.StreamSqlDataRequest;
+import com.google.cloud.sql.v1beta4.StreamSqlDataResponse;
+import io.grpc.stub.StreamObserver;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class SqlDataSocket extends Socket {
+  private static final Logger logger = LoggerFactory.getLogger(SqlDataSocket.class);
+
+  private final StreamObserver<StreamSqlDataRequest> requestObserver;
+  private final BlockingQueue<byte[]> readQueue = new LinkedBlockingQueue<>();
+  private final InputStream inputStream;
+  private final OutputStream outputStream;
+  private volatile boolean closed = false;
+  private Throwable error = null;
+
+  SqlDataSocket(StreamObserver<StreamSqlDataRequest> requestObserver) {
+    this.requestObserver = requestObserver;
+    this.inputStream = new SqlDataInputStream();
+    this.outputStream = new SqlDataOutputStream();
+  }
+
+  // Called by the client's response observer when new data arrives
+  void onNextResponse(StreamSqlDataResponse response) {
+    if (response.hasData()) {
+      byte[] data = response.getData().getData().toByteArray();
+      if (data.length > 0) {
+        readQueue.add(data);
+      }
+    } else if (response.hasTerminateSession()) {
+      logger.debug("Received TerminateSession from server");
+      closeQuietly();
+    }
+  }
+
+  void onErrorResponse(Throwable t) {
+    logger.debug("Received error from server stream", t);
+    this.error = t;
+    readQueue.add(new byte[0]); // Sentinel to unblock read
+    closeQuietly();
+  }
+
+  void onCompletedResponse() {
+    logger.debug("Server stream completed");
+    readQueue.add(new byte[0]); // Sentinel to unblock read
+    closeQuietly();
+  }
+
+  private void closeQuietly() {
+    try {
+      close();
+    } catch (IOException e) {
+      // ignore
+    }
+  }
+
+  @Override
+  public InputStream getInputStream() throws IOException {
+    if (closed) {
+      throw new IOException("Socket is closed");
+    }
+    return inputStream;
+  }
+
+  @Override
+  public OutputStream getOutputStream() throws IOException {
+    if (closed) {
+      throw new IOException("Socket is closed");
+    }
+    return outputStream;
+  }
+
+  @Override
+  public synchronized void close() throws IOException {
+    if (closed) {
+      return;
+    }
+    closed = true;
+    try {
+      requestObserver.onCompleted();
+    } catch (Exception e) {
+      // ignore if already closed or failed
+    }
+    // Sentinel to unblock any waiting reader
+    readQueue.add(new byte[0]);
+  }
+
+  @Override
+  public boolean isClosed() {
+    return closed;
+  }
+
+  @Override
+  public boolean isConnected() {
+    return !closed;
+  }
+
+  @Override
+  public void connect(java.net.SocketAddress endpoint) throws IOException {
+    // Already connected
+  }
+
+  @Override
+  public void connect(java.net.SocketAddress endpoint, int timeout) throws IOException {
+    // Already connected
+  }
+
+  private class SqlDataInputStream extends InputStream {
+    private byte[] currentBlock = null;
+    private int currentOffset = 0;
+
+    @Override
+    public int read() throws IOException {
+      byte[] b = new byte[1];
+      int n = read(b, 0, 1);
+      if (n == -1) {
+        return -1;
+      }
+      return b[0] & 0xFF;
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+      if (closed) {
+        throw new IOException("Stream is closed");
+      }
+      if (error != null) {
+        throw new IOException("Stream failed", error);
+      }
+
+      if (currentBlock == null || currentOffset >= currentBlock.length) {
+        try {
+          currentBlock = readQueue.take();
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw new IOException("Read interrupted", e);
+        }
+
+        if (closed) {
+          throw new IOException("Socket closed during read");
+        }
+        if (error != null) {
+          throw new IOException("Stream failed", error);
+        }
+        if (currentBlock == null || currentBlock.length == 0) {
+          // EOF sentinel (empty byte array)
+          return -1;
+        }
+        currentOffset = 0;
+      }
+
+      int remaining = currentBlock.length - currentOffset;
+      int toCopy = Math.min(len, remaining);
+      System.arraycopy(currentBlock, currentOffset, b, off, toCopy);
+      currentOffset += toCopy;
+      return toCopy;
+    }
+  }
+
+  private class SqlDataOutputStream extends OutputStream {
+    @Override
+    public void write(int b) throws IOException {
+      write(new byte[] {(byte) b}, 0, 1);
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+      if (closed) {
+        throw new IOException("Socket is closed");
+      }
+      if (error != null) {
+        throw new IOException("Stream failed", error);
+      }
+
+      StreamSqlDataRequest request =
+          StreamSqlDataRequest.newBuilder()
+              .setData(
+                  DataPacket.newBuilder()
+                      .setData(com.google.protobuf.ByteString.copyFrom(b, off, len))
+                      .build())
+              .build();
+
+      try {
+        synchronized (requestObserver) {
+          requestObserver.onNext(request);
+        }
+      } catch (Exception e) {
+        throw new IOException("Failed to write to stream", e);
+      }
+    }
+  }
+}

--- a/core/src/test/java/com/google/cloud/sql/ConnectorConfigTest.java
+++ b/core/src/test/java/com/google/cloud/sql/ConnectorConfigTest.java
@@ -456,6 +456,8 @@ public class ConnectorConfigTest {
                 null, // universeDomain
                 wantRefreshStrategy, // refreshStrategy
                 null, // instanceNameResolver
-                ConnectorConfig.DEFAULT_FAILOVER_PERIOD));
+                ConnectorConfig.DEFAULT_FAILOVER_PERIOD,
+                "sqladmin.googleapis.com",
+                Duration.ofHours(2)));
   }
 }

--- a/core/src/test/java/com/google/cloud/sql/core/ConnectorTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/ConnectorTest.java
@@ -27,7 +27,15 @@ import com.google.cloud.sql.AuthType;
 import com.google.cloud.sql.ConnectorConfig;
 import com.google.cloud.sql.CredentialFactory;
 import com.google.cloud.sql.IpType;
+import com.google.cloud.sql.v1beta4.StreamSqlDataRequest;
+import com.google.cloud.sql.v1beta4.StreamSqlDataResponse;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.stub.StreamObserver;
+import io.grpc.testing.GrpcCleanupRule;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -45,16 +53,19 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import javax.naming.NameNotFoundException;
 import javax.net.ssl.SSLHandshakeException;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class ConnectorTest extends CloudSqlCoreTestingBase {
+  @Rule public final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
   ListeningScheduledExecutorService defaultExecutor;
   private final long TEST_MAX_REFRESH_MS = 5000L;
 
@@ -160,6 +171,115 @@ public class ConnectorTest extends CloudSqlCoreTestingBase {
     Socket socket = connector.connect(config, TEST_MAX_REFRESH_MS);
 
     assertThat(readLine(socket)).isEqualTo(SERVER_MESSAGE);
+  }
+
+  @Test
+  public void connect_SqlDataSuccess() throws IOException, InterruptedException {
+    FakeSqlDataService sqlDataService = new FakeSqlDataService();
+    ConnectionConfig config =
+        new ConnectionConfig.Builder()
+            .withCloudSqlInstance("myProject:myRegion:myInstance")
+            .withIpTypes("SQL_DATA")
+            .build();
+
+    Connector connector =
+        newConnectorWithSqlData(config.getConnectorConfig(), 0, null, null, false, sqlDataService);
+
+    try (Socket socket = connector.connect(config, TEST_MAX_REFRESH_MS)) {
+      assertThat(socket).isNotNull();
+      assertThat(socket.isClosed()).isFalse();
+
+      // Verify StartSession was received
+      StreamSqlDataRequest receivedRequest = sqlDataService.requests.poll(5, TimeUnit.SECONDS);
+      assertThat(receivedRequest).isNotNull();
+      assertThat(receivedRequest.hasStartSession()).isTrue();
+    }
+  }
+
+  @Test
+  public void connect_SqlDataFallback() throws IOException, InterruptedException {
+    FakeSqlDataService sqlDataService = new FakeSqlDataService();
+    sqlDataService.failHandshake = true; // Force fallback
+
+    FakeSslServer sslServer = new FakeSslServer();
+    int fallbackPort = sslServer.start(PRIVATE_IP);
+
+    ConnectionConfig config =
+        new ConnectionConfig.Builder()
+            .withCloudSqlInstance("myProject:myRegion:myInstance")
+            .withIpTypes("SQL_DATA")
+            .build();
+
+    Connector connector =
+        newConnectorWithSqlData(
+            config.getConnectorConfig(), fallbackPort, null, null, false, sqlDataService);
+
+    try (Socket socket = connector.connect(config, TEST_MAX_REFRESH_MS)) {
+      // Should connect to the FakeSslServer (fallback)
+      assertThat(readLine(socket)).isEqualTo(SERVER_MESSAGE);
+
+      // Verify that subsequent connection to the same instance skips SQL Data Service
+      assertThat(sqlDataService.requests.size()).isEqualTo(1);
+
+      // Clear requests to make sure we don't see new ones
+      sqlDataService.requests.clear();
+
+      // Connect again
+      try (Socket socket2 = connector.connect(config, TEST_MAX_REFRESH_MS)) {
+        assertThat(readLine(socket2)).isEqualTo(SERVER_MESSAGE);
+
+        // Verify no new requests were sent to SQL Data Service
+        assertThat(sqlDataService.requests).isEmpty();
+      }
+    }
+  }
+
+  @Test
+  public void connect_SqlDataNoFallbackOnOtherErrors() throws IOException, InterruptedException {
+    FakeSqlDataService sqlDataService =
+        new FakeSqlDataService() {
+          @Override
+          public StreamObserver<StreamSqlDataRequest> streamSqlData(
+              StreamObserver<StreamSqlDataResponse> responseObserver) {
+            return new StreamObserver<StreamSqlDataRequest>() {
+              @Override
+              public void onNext(StreamSqlDataRequest request) {
+                if (request.hasStartSession()) {
+                  // Fail with INTERNAL instead of FAILED_PRECONDITION
+                  responseObserver.onError(
+                      Status.INTERNAL.withDescription("Internal error").asRuntimeException());
+                }
+              }
+
+              @Override
+              public void onError(Throwable t) {}
+
+              @Override
+              public void onCompleted() {}
+            };
+          }
+        };
+
+    FakeSslServer sslServer = new FakeSslServer();
+    int fallbackPort = sslServer.start(PUBLIC_IP);
+
+    ConnectionConfig config =
+        new ConnectionConfig.Builder()
+            .withCloudSqlInstance("myProject:myRegion:myInstance")
+            .withIpTypes("SQL_DATA")
+            .build();
+
+    Connector connector =
+        newConnectorWithSqlData(
+            config.getConnectorConfig(), fallbackPort, null, null, false, sqlDataService);
+
+    // Should NOT fall back, should throw IOException caused by StatusRuntimeException (INTERNAL)
+    IOException ex =
+        assertThrows(IOException.class, () -> connector.connect(config, TEST_MAX_REFRESH_MS));
+    assertThat(ex).hasMessageThat().contains("Failed to connect via SQL Data Service");
+    assertThat(ex.getCause()).isInstanceOf(StatusRuntimeException.class);
+    assertThat(((StatusRuntimeException) ex.getCause()).getStatus().getCode())
+        .isEqualTo(Status.Code.INTERNAL);
   }
 
   @Test
@@ -1062,5 +1182,61 @@ public class ConnectorTest extends CloudSqlCoreTestingBase {
     public List<InetAddress> resolveHost(String hostName) {
       return Collections.emptyList();
     }
+  }
+
+  private Connector newConnectorWithSqlData(
+      ConnectorConfig config,
+      int port,
+      String domainName,
+      String instanceName,
+      boolean cas,
+      FakeSqlDataService sqlDataService)
+      throws IOException {
+
+    String serverName = InProcessServerBuilder.generateName();
+    grpcCleanup.register(
+        InProcessServerBuilder.forName(serverName)
+            .directExecutor()
+            .addService(sqlDataService)
+            .build()
+            .start());
+
+    io.grpc.ManagedChannel channel =
+        grpcCleanup.register(InProcessChannelBuilder.forName(serverName).directExecutor().build());
+
+    CredentialFactory credentialFactory =
+        stubCredentialFactoryProvider.getInstanceCredentialFactory(config);
+    SqlDataClient sqlDataClient =
+        new SqlDataClient(config, credentialFactory, "test-agent", channel);
+
+    ConnectionInfoRepositoryFactory factory =
+        new StubConnectionInfoRepositoryFactory(
+            fakeSuccessHttpTransport(
+                TestKeys.getServerCertPem(),
+                Duration.ofSeconds(0),
+                null,
+                cas,
+                false,
+                null,
+                Collections.singletonList(
+                    new DnsNameMapping()
+                        .setName(domainName)
+                        .setConnectionType("PRIVATE_SERVICE_CONNECT")
+                        .setDnsScope("INSTANCE"))));
+    DnsResolver dnsResolver = new MockDnsResolver(domainName, instanceName);
+
+    return new Connector(
+        config,
+        factory,
+        credentialFactory,
+        defaultExecutor,
+        clientKeyPair,
+        10,
+        TEST_MAX_REFRESH_MS,
+        port,
+        new DnsInstanceConnectionNameResolver(dnsResolver),
+        dnsResolver,
+        new ProtocolHandler("test"),
+        sqlDataClient);
   }
 }

--- a/core/src/test/java/com/google/cloud/sql/core/FakeSqlDataService.java
+++ b/core/src/test/java/com/google/cloud/sql/core/FakeSqlDataService.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.sql.core;
+
+import com.google.cloud.sql.v1beta4.SessionMetadata;
+import com.google.cloud.sql.v1beta4.SqlDataServiceGrpc;
+import com.google.cloud.sql.v1beta4.StreamSqlDataRequest;
+import com.google.cloud.sql.v1beta4.StreamSqlDataResponse;
+import io.grpc.Status;
+import io.grpc.stub.StreamObserver;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+
+class FakeSqlDataService extends SqlDataServiceGrpc.SqlDataServiceImplBase {
+  final BlockingQueue<StreamSqlDataRequest> requests = new ArrayBlockingQueue<>(10);
+  final java.util.concurrent.CountDownLatch completed = new java.util.concurrent.CountDownLatch(1);
+  volatile StreamObserver<StreamSqlDataResponse> responseObserver;
+  boolean failHandshake = false;
+  boolean delayHandshake = false;
+
+  @Override
+  public StreamObserver<StreamSqlDataRequest> streamSqlData(
+      StreamObserver<StreamSqlDataResponse> responseObserver) {
+    this.responseObserver = responseObserver;
+
+    return new StreamObserver<StreamSqlDataRequest>() {
+      @Override
+      public void onNext(StreamSqlDataRequest request) {
+        requests.add(request);
+        if (request.hasStartSession()) {
+          if (failHandshake) {
+            responseObserver.onError(
+                Status.FAILED_PRECONDITION
+                    .withDescription("AI Developer Edition not enabled")
+                    .asRuntimeException());
+          } else if (delayHandshake) {
+            // Do nothing, let it timeout
+          } else {
+            // Send SessionMetadata back to establish connection
+            responseObserver.onNext(
+                StreamSqlDataResponse.newBuilder()
+                    .setSessionMetadata(SessionMetadata.getDefaultInstance())
+                    .build());
+          }
+        }
+      }
+
+      @Override
+      public void onError(Throwable t) {
+        // ignore
+      }
+
+      @Override
+      public void onCompleted() {
+        completed.countDown();
+        responseObserver.onCompleted();
+      }
+    };
+  }
+}

--- a/core/src/test/java/com/google/cloud/sql/core/SqlDataClientTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/SqlDataClientTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.sql.core;
+
+import static com.google.common.truth.Truth.assertThat;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertThrows;
+
+import com.google.cloud.sql.ConnectorConfig;
+import com.google.cloud.sql.CredentialFactory;
+import com.google.cloud.sql.v1beta4.DataPacket;
+import com.google.cloud.sql.v1beta4.StartSession;
+import com.google.cloud.sql.v1beta4.StreamSqlDataRequest;
+import com.google.cloud.sql.v1beta4.StreamSqlDataResponse;
+import com.google.protobuf.ByteString;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.testing.GrpcCleanupRule;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class SqlDataClientTest {
+
+  @Rule public final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
+
+  private final FakeSqlDataService serviceImpl = new FakeSqlDataService();
+  private SqlDataClient client;
+  private CredentialFactory credentialFactory;
+
+  @Before
+  public void setUp() throws Exception {
+    String serverName = InProcessServerBuilder.generateName();
+    grpcCleanup.register(
+        InProcessServerBuilder.forName(serverName)
+            .directExecutor()
+            .addService(serviceImpl)
+            .build()
+            .start());
+
+    io.grpc.ManagedChannel channel =
+        grpcCleanup.register(InProcessChannelBuilder.forName(serverName).directExecutor().build());
+
+    ConnectorConfig config =
+        new ConnectorConfig.Builder()
+            .withSqlDataEndpoint("unused-endpoint")
+            .withSqlDataStreamTimeout(Duration.ofSeconds(10))
+            .build();
+
+    credentialFactory = new StubCredentialFactory();
+    client = new SqlDataClient(config, credentialFactory, "test-agent", channel);
+  }
+
+  @After
+  public void tearDown() {
+    client.close();
+  }
+
+  @Test
+  public void testConnect_Success() throws Exception {
+    CloudSqlInstanceName instanceName = new CloudSqlInstanceName("proj:reg:inst");
+
+    Socket socket = client.connect(instanceName, 5000);
+    assertThat(socket).isNotNull();
+    assertThat(socket.isClosed()).isFalse();
+
+    // Verify StartSession was received by server
+    StreamSqlDataRequest receivedRequest = serviceImpl.requests.poll(5, TimeUnit.SECONDS);
+    assertThat(receivedRequest).isNotNull();
+    assertThat(receivedRequest.hasStartSession()).isTrue();
+    StartSession startSession = receivedRequest.getStartSession();
+    assertThat(startSession.getInstanceId()).isEqualTo("projects/proj/instances/inst");
+    assertThat(startSession.getLocationId()).isEqualTo("locations/reg");
+
+    // Test Data Transfer
+    OutputStream out = socket.getOutputStream();
+    InputStream in = socket.getInputStream();
+
+    // Client -> Server
+    byte[] clientData = "Hello Server".getBytes(UTF_8);
+    out.write(clientData);
+    out.flush();
+
+    StreamSqlDataRequest dataRequest = serviceImpl.requests.poll(5, TimeUnit.SECONDS);
+    assertThat(dataRequest).isNotNull();
+    assertThat(dataRequest.hasData()).isTrue();
+    assertThat(dataRequest.getData().getData().toByteArray()).isEqualTo(clientData);
+
+    // Server -> Client
+    byte[] serverData = "Hello Client".getBytes(UTF_8);
+    serviceImpl.responseObserver.onNext(
+        StreamSqlDataResponse.newBuilder()
+            .setData(DataPacket.newBuilder().setData(ByteString.copyFrom(serverData)).build())
+            .build());
+
+    byte[] readBuffer = new byte[serverData.length];
+    int bytesRead = in.read(readBuffer);
+    assertThat(bytesRead).isEqualTo(serverData.length);
+    assertThat(readBuffer).isEqualTo(serverData);
+
+    socket.close();
+
+    // Verify client close sends onCompleted to server
+    assertThat(serviceImpl.completed.await(5, TimeUnit.SECONDS)).isTrue();
+  }
+
+  @Test
+  public void testConnect_HandshakeFailure() throws Exception {
+    serviceImpl.failHandshake = true;
+    CloudSqlInstanceName instanceName = new CloudSqlInstanceName("proj:reg:inst");
+
+    IOException ex = assertThrows(IOException.class, () -> client.connect(instanceName, 5000));
+    assertThat(ex).hasMessageThat().contains("Failed to connect via SQL Data Service");
+    assertThat(ex.getCause()).isInstanceOf(StatusRuntimeException.class);
+    StatusRuntimeException statusEx = (StatusRuntimeException) ex.getCause();
+    assertThat(statusEx.getStatus().getCode()).isEqualTo(Status.Code.FAILED_PRECONDITION);
+  }
+
+  @Test
+  public void testConnect_Timeout() throws Exception {
+    serviceImpl.delayHandshake = true;
+    CloudSqlInstanceName instanceName = new CloudSqlInstanceName("proj:reg:inst");
+
+    IOException ex = assertThrows(IOException.class, () -> client.connect(instanceName, 500));
+    assertThat(ex)
+        .hasMessageThat()
+        .contains("Connection timed out waiting for SQL Data Service response");
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -195,6 +195,11 @@
         <scope>compile</scope>
       </dependency>
       <dependency>
+        <groupId>com.google.api.grpc</groupId>
+        <artifactId>proto-google-common-protos</artifactId>
+        <version>2.64.1</version>
+      </dependency>
+      <dependency>
         <groupId>com.github.jnr</groupId>
         <artifactId>jnr-unixsocket</artifactId>
         <version>0.38.25</version>
@@ -228,6 +233,37 @@
         <groupId>io.grpc</groupId>
         <artifactId>grpc-context</artifactId>
         <version>1.81.0</version>
+      </dependency>
+      <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-protobuf</artifactId>
+        <version>1.81.0</version>
+      </dependency>
+      <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-stub</artifactId>
+        <version>1.81.0</version>
+      </dependency>
+      <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-netty</artifactId>
+        <version>1.81.0</version>
+      </dependency>
+      <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-auth</artifactId>
+        <version>1.81.0</version>
+      </dependency>
+      <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-testing</artifactId>
+        <version>1.81.0</version>
+      </dependency>
+      <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-inprocess</artifactId>
+        <version>1.81.0</version>
+        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.reactivestreams</groupId>

--- a/schemas/pom.xml
+++ b/schemas/pom.xml
@@ -42,6 +42,22 @@
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-protobuf</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-stub</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api.grpc</groupId>
+      <artifactId>proto-google-common-protos</artifactId>
+    </dependency>
   </dependencies>
 
 
@@ -80,7 +96,19 @@
               <optimizeCodegen>false</optimizeCodegen>
               <protocVersion>3.23.0</protocVersion>
               <includeStdTypes>true</includeStdTypes>
-              <outputOptions></outputOptions>
+              <includeDirectories>
+                <includeDirectory>src/main/protobuf</includeDirectory>
+                <includeDirectory>src/main/proto_imports</includeDirectory>
+              </includeDirectories>
+              <outputTargets>
+                <outputTarget>
+                  <type>java</type>
+                </outputTarget>
+                <outputTarget>
+                  <type>grpc-java</type>
+                  <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.81.0:exe:${os.detected.classifier}</pluginArtifact>
+                </outputTarget>
+              </outputTargets>
             </configuration>
           </execution>
         </executions>

--- a/schemas/src/main/proto_imports/google/rpc/code.proto
+++ b/schemas/src/main/proto_imports/google/rpc/code.proto
@@ -1,0 +1,186 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.rpc;
+
+option go_package = "google.golang.org/genproto/googleapis/rpc/code;code";
+option java_multiple_files = true;
+option java_outer_classname = "CodeProto";
+option java_package = "com.google.rpc";
+option objc_class_prefix = "RPC";
+
+
+// The canonical error codes for Google APIs.
+//
+//
+// Sometimes multiple error codes may apply.  Services should return
+// the most specific error code that applies.  For example, prefer
+// `OUT_OF_RANGE` over `FAILED_PRECONDITION` if both codes apply.
+// Similarly prefer `NOT_FOUND` or `ALREADY_EXISTS` over `FAILED_PRECONDITION`.
+enum Code {
+  // Not an error; returned on success
+  //
+  // HTTP Mapping: 200 OK
+  OK = 0;
+
+  // The operation was cancelled, typically by the caller.
+  //
+  // HTTP Mapping: 499 Client Closed Request
+  CANCELLED = 1;
+
+  // Unknown error.  For example, this error may be returned when
+  // a `Status` value received from another address space belongs to
+  // an error space that is not known in this address space.  Also
+  // errors raised by APIs that do not return enough error information
+  // may be converted to this error.
+  //
+  // HTTP Mapping: 500 Internal Server Error
+  UNKNOWN = 2;
+
+  // The client specified an invalid argument.  Note that this differs
+  // from `FAILED_PRECONDITION`.  `INVALID_ARGUMENT` indicates arguments
+  // that are problematic regardless of the state of the system
+  // (e.g., a malformed file name).
+  //
+  // HTTP Mapping: 400 Bad Request
+  INVALID_ARGUMENT = 3;
+
+  // The deadline expired before the operation could complete. For operations
+  // that change the state of the system, this error may be returned
+  // even if the operation has completed successfully.  For example, a
+  // successful response from a server could have been delayed long
+  // enough for the deadline to expire.
+  //
+  // HTTP Mapping: 504 Gateway Timeout
+  DEADLINE_EXCEEDED = 4;
+
+  // Some requested entity (e.g., file or directory) was not found.
+  //
+  // Note to server developers: if a request is denied for an entire class
+  // of users, such as gradual feature rollout or undocumented whitelist,
+  // `NOT_FOUND` may be used. If a request is denied for some users within
+  // a class of users, such as user-based access control, `PERMISSION_DENIED`
+  // must be used.
+  //
+  // HTTP Mapping: 404 Not Found
+  NOT_FOUND = 5;
+
+  // The entity that a client attempted to create (e.g., file or directory)
+  // already exists.
+  //
+  // HTTP Mapping: 409 Conflict
+  ALREADY_EXISTS = 6;
+
+  // The caller does not have permission to execute the specified
+  // operation. `PERMISSION_DENIED` must not be used for rejections
+  // caused by exhausting some resource (use `RESOURCE_EXHAUSTED`
+  // instead for those errors). `PERMISSION_DENIED` must not be
+  // used if the caller can not be identified (use `UNAUTHENTICATED`
+  // instead for those errors). This error code does not imply the
+  // request is valid or the requested entity exists or satisfies
+  // other pre-conditions.
+  //
+  // HTTP Mapping: 403 Forbidden
+  PERMISSION_DENIED = 7;
+
+  // The request does not have valid authentication credentials for the
+  // operation.
+  //
+  // HTTP Mapping: 401 Unauthorized
+  UNAUTHENTICATED = 16;
+
+  // Some resource has been exhausted, perhaps a per-user quota, or
+  // perhaps the entire file system is out of space.
+  //
+  // HTTP Mapping: 429 Too Many Requests
+  RESOURCE_EXHAUSTED = 8;
+
+  // The operation was rejected because the system is not in a state
+  // required for the operation's execution.  For example, the directory
+  // to be deleted is non-empty, an rmdir operation is applied to
+  // a non-directory, etc.
+  //
+  // Service implementors can use the following guidelines to decide
+  // between `FAILED_PRECONDITION`, `ABORTED`, and `UNAVAILABLE`:
+  //  (a) Use `UNAVAILABLE` if the client can retry just the failing call.
+  //  (b) Use `ABORTED` if the client should retry at a higher level
+  //      (e.g., when a client-specified test-and-set fails, indicating the
+  //      client should restart a read-modify-write sequence).
+  //  (c) Use `FAILED_PRECONDITION` if the client should not retry until
+  //      the system state has been explicitly fixed.  E.g., if an "rmdir"
+  //      fails because the directory is non-empty, `FAILED_PRECONDITION`
+  //      should be returned since the client should not retry unless
+  //      the files are deleted from the directory.
+  //
+  // HTTP Mapping: 400 Bad Request
+  FAILED_PRECONDITION = 9;
+
+  // The operation was aborted, typically due to a concurrency issue such as
+  // a sequencer check failure or transaction abort.
+  //
+  // See the guidelines above for deciding between `FAILED_PRECONDITION`,
+  // `ABORTED`, and `UNAVAILABLE`.
+  //
+  // HTTP Mapping: 409 Conflict
+  ABORTED = 10;
+
+  // The operation was attempted past the valid range.  E.g., seeking or
+  // reading past end-of-file.
+  //
+  // Unlike `INVALID_ARGUMENT`, this error indicates a problem that may
+  // be fixed if the system state changes. For example, a 32-bit file
+  // system will generate `INVALID_ARGUMENT` if asked to read at an
+  // offset that is not in the range [0,2^32-1], but it will generate
+  // `OUT_OF_RANGE` if asked to read from an offset past the current
+  // file size.
+  //
+  // There is a fair bit of overlap between `FAILED_PRECONDITION` and
+  // `OUT_OF_RANGE`.  We recommend using `OUT_OF_RANGE` (the more specific
+  // error) when it applies so that callers who are iterating through
+  // a space can easily look for an `OUT_OF_RANGE` error to detect when
+  // they are done.
+  //
+  // HTTP Mapping: 400 Bad Request
+  OUT_OF_RANGE = 11;
+
+  // The operation is not implemented or is not supported/enabled in this
+  // service.
+  //
+  // HTTP Mapping: 501 Not Implemented
+  UNIMPLEMENTED = 12;
+
+  // Internal errors.  This means that some invariants expected by the
+  // underlying system have been broken.  This error code is reserved
+  // for serious errors.
+  //
+  // HTTP Mapping: 500 Internal Server Error
+  INTERNAL = 13;
+
+  // The service is currently unavailable.  This is most likely a
+  // transient condition, which can be corrected by retrying with
+  // a backoff.
+  //
+  // See the guidelines above for deciding between `FAILED_PRECONDITION`,
+  // `ABORTED`, and `UNAVAILABLE`.
+  //
+  // HTTP Mapping: 503 Service Unavailable
+  UNAVAILABLE = 14;
+
+  // Unrecoverable data loss or corruption.
+  //
+  // HTTP Mapping: 500 Internal Server Error
+  DATA_LOSS = 15;
+}

--- a/schemas/src/main/proto_imports/google/rpc/error_details.proto
+++ b/schemas/src/main/proto_imports/google/rpc/error_details.proto
@@ -1,0 +1,200 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.rpc;
+
+import "google/protobuf/duration.proto";
+
+option go_package = "google.golang.org/genproto/googleapis/rpc/errdetails;errdetails";
+option java_multiple_files = true;
+option java_outer_classname = "ErrorDetailsProto";
+option java_package = "com.google.rpc";
+option objc_class_prefix = "RPC";
+
+
+// Describes when the clients can retry a failed request. Clients could ignore
+// the recommendation here or retry when this information is missing from error
+// responses.
+//
+// It's always recommended that clients should use exponential backoff when
+// retrying.
+//
+// Clients should wait until `retry_delay` amount of time has passed since
+// receiving the error response before retrying.  If retrying requests also
+// fail, clients should use an exponential backoff scheme to gradually increase
+// the delay between retries based on `retry_delay`, until either a maximum
+// number of retires have been reached or a maximum retry delay cap has been
+// reached.
+message RetryInfo {
+  // Clients should wait at least this long between retrying the same request.
+  google.protobuf.Duration retry_delay = 1;
+}
+
+// Describes additional debugging info.
+message DebugInfo {
+  // The stack trace entries indicating where the error occurred.
+  repeated string stack_entries = 1;
+
+  // Additional debugging information provided by the server.
+  string detail = 2;
+}
+
+// Describes how a quota check failed.
+//
+// For example if a daily limit was exceeded for the calling project,
+// a service could respond with a QuotaFailure detail containing the project
+// id and the description of the quota limit that was exceeded.  If the
+// calling project hasn't enabled the service in the developer console, then
+// a service could respond with the project id and set `service_disabled`
+// to true.
+//
+// Also see RetryDetail and Help types for other details about handling a
+// quota failure.
+message QuotaFailure {
+  // A message type used to describe a single quota violation.  For example, a
+  // daily quota or a custom quota that was exceeded.
+  message Violation {
+    // The subject on which the quota check failed.
+    // For example, "clientip:<ip address of client>" or "project:<Google
+    // developer project id>".
+    string subject = 1;
+
+    // A description of how the quota check failed. Clients can use this
+    // description to find more about the quota configuration in the service's
+    // public documentation, or find the relevant quota limit to adjust through
+    // developer console.
+    //
+    // For example: "Service disabled" or "Daily Limit for read operations
+    // exceeded".
+    string description = 2;
+  }
+
+  // Describes all quota violations.
+  repeated Violation violations = 1;
+}
+
+// Describes what preconditions have failed.
+//
+// For example, if an RPC failed because it required the Terms of Service to be
+// acknowledged, it could list the terms of service violation in the
+// PreconditionFailure message.
+message PreconditionFailure {
+  // A message type used to describe a single precondition failure.
+  message Violation {
+    // The type of PreconditionFailure. We recommend using a service-specific
+    // enum type to define the supported precondition violation types. For
+    // example, "TOS" for "Terms of Service violation".
+    string type = 1;
+
+    // The subject, relative to the type, that failed.
+    // For example, "google.com/cloud" relative to the "TOS" type would
+    // indicate which terms of service is being referenced.
+    string subject = 2;
+
+    // A description of how the precondition failed. Developers can use this
+    // description to understand how to fix the failure.
+    //
+    // For example: "Terms of service not accepted".
+    string description = 3;
+  }
+
+  // Describes all precondition violations.
+  repeated Violation violations = 1;
+}
+
+// Describes violations in a client request. This error type focuses on the
+// syntactic aspects of the request.
+message BadRequest {
+  // A message type used to describe a single bad request field.
+  message FieldViolation {
+    // A path leading to a field in the request body. The value will be a
+    // sequence of dot-separated identifiers that identify a protocol buffer
+    // field. E.g., "field_violations.field" would identify this field.
+    string field = 1;
+
+    // A description of why the request element is bad.
+    string description = 2;
+  }
+
+  // Describes all violations in a client request.
+  repeated FieldViolation field_violations = 1;
+}
+
+// Contains metadata about the request that clients can attach when filing a bug
+// or providing other forms of feedback.
+message RequestInfo {
+  // An opaque string that should only be interpreted by the service generating
+  // it. For example, it can be used to identify requests in the service's logs.
+  string request_id = 1;
+
+  // Any data that was used to serve this request. For example, an encrypted
+  // stack trace that can be sent back to the service provider for debugging.
+  string serving_data = 2;
+}
+
+// Describes the resource that is being accessed.
+message ResourceInfo {
+  // A name for the type of resource being accessed, e.g. "sql table",
+  // "cloud storage bucket", "file", "Google calendar"; or the type URL
+  // of the resource: e.g. "type.googleapis.com/google.pubsub.v1.Topic".
+  string resource_type = 1;
+
+  // The name of the resource being accessed.  For example, a shared calendar
+  // name: "example.com_4fghdhgsrgh@group.calendar.google.com", if the current
+  // error is [google.rpc.Code.PERMISSION_DENIED][google.rpc.Code.PERMISSION_DENIED].
+  string resource_name = 2;
+
+  // The owner of the resource (optional).
+  // For example, "user:<owner email>" or "project:<Google developer project
+  // id>".
+  string owner = 3;
+
+  // Describes what error is encountered when accessing this resource.
+  // For example, updating a cloud project may require the `writer` permission
+  // on the developer console project.
+  string description = 4;
+}
+
+// Provides links to documentation or for performing an out of band action.
+//
+// For example, if a quota check failed with an error indicating the calling
+// project hasn't enabled the accessed service, this can contain a URL pointing
+// directly to the right place in the developer console to flip the bit.
+message Help {
+  // Describes a URL link.
+  message Link {
+    // Describes what the link offers.
+    string description = 1;
+
+    // The URL of the link.
+    string url = 2;
+  }
+
+  // URL(s) pointing to additional information on handling the current error.
+  repeated Link links = 1;
+}
+
+// Provides a localized error message that is safe to return to the user
+// which can be attached to an RPC error.
+message LocalizedMessage {
+  // The locale used following the specification defined at
+  // http://www.rfc-editor.org/rfc/bcp/bcp47.txt.
+  // Examples are: "en-US", "fr-CH", "es-MX"
+  string locale = 1;
+
+  // The localized error message in the above locale.
+  string message = 2;
+}

--- a/schemas/src/main/proto_imports/google/rpc/status.proto
+++ b/schemas/src/main/proto_imports/google/rpc/status.proto
@@ -1,0 +1,92 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.rpc;
+
+import "google/protobuf/any.proto";
+
+option go_package = "google.golang.org/genproto/googleapis/rpc/status;status";
+option java_multiple_files = true;
+option java_outer_classname = "StatusProto";
+option java_package = "com.google.rpc";
+option objc_class_prefix = "RPC";
+
+
+// The `Status` type defines a logical error model that is suitable for different
+// programming environments, including REST APIs and RPC APIs. It is used by
+// [gRPC](https://github.com/grpc). The error model is designed to be:
+//
+// - Simple to use and understand for most users
+// - Flexible enough to meet unexpected needs
+//
+// # Overview
+//
+// The `Status` message contains three pieces of data: error code, error message,
+// and error details. The error code should be an enum value of
+// [google.rpc.Code][google.rpc.Code], but it may accept additional error codes if needed.  The
+// error message should be a developer-facing English message that helps
+// developers *understand* and *resolve* the error. If a localized user-facing
+// error message is needed, put the localized message in the error details or
+// localize it in the client. The optional error details may contain arbitrary
+// information about the error. There is a predefined set of error detail types
+// in the package `google.rpc` that can be used for common error conditions.
+//
+// # Language mapping
+//
+// The `Status` message is the logical representation of the error model, but it
+// is not necessarily the actual wire format. When the `Status` message is
+// exposed in different client libraries and different wire protocols, it can be
+// mapped differently. For example, it will likely be mapped to some exceptions
+// in Java, but more likely mapped to some error codes in C.
+//
+// # Other uses
+//
+// The error model and the `Status` message can be used in a variety of
+// environments, either with or without APIs, to provide a
+// consistent developer experience across different environments.
+//
+// Example uses of this error model include:
+//
+// - Partial errors. If a service needs to return partial errors to the client,
+//     it may embed the `Status` in the normal response to indicate the partial
+//     errors.
+//
+// - Workflow errors. A typical workflow has multiple steps. Each step may
+//     have a `Status` message for error reporting.
+//
+// - Batch operations. If a client uses batch request and batch response, the
+//     `Status` message should be used directly inside batch response, one for
+//     each error sub-response.
+//
+// - Asynchronous operations. If an API call embeds asynchronous operation
+//     results in its response, the status of those operations should be
+//     represented directly using the `Status` message.
+//
+// - Logging. If some API errors are stored in logs, the message `Status` could
+//     be used directly after any stripping needed for security/privacy reasons.
+message Status {
+  // The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
+  int32 code = 1;
+
+  // A developer-facing error message, which should be in English. Any
+  // user-facing error message should be localized and sent in the
+  // [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+  string message = 2;
+
+  // A list of messages that carry the error details.  There is a common set of
+  // message types for APIs to use.
+  repeated google.protobuf.Any details = 3;
+}

--- a/schemas/src/main/protobuf/sql_data_service.proto
+++ b/schemas/src/main/protobuf/sql_data_service.proto
@@ -1,0 +1,285 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+
+package google.cloud.sql.v1beta4;
+option go_package = "internal/sqldata";
+
+option java_package = "com.google.cloud.sql.v1beta4";
+option java_outer_classname = "CloudSqlDataProto";
+option java_multiple_files = true;
+
+import "google/rpc/status.proto";
+
+// Service for streaming data to and from Cloud SQL instances.
+service SqlDataService {
+  // `StreamSqlData` establishes a bidirectional stream to a Cloud SQL instance,
+  // and then streams data to and from the instance.
+  //
+  // The first message from the client MUST be a `StreamSqlDataRequest` request
+  // with configuration settings, including required values for the
+  // `connection_settings` field. Subsequent messages from the client may
+  // contain the `payload` field.
+  //
+  // Messages from the server may contain the `payload` field.
+  //
+  // The `payload` fields of the request and response streams contain the raw
+  // data of the database's native wire protocol (e.g., PostgreSQL wire
+  // protocol). The database client is responsible for generating and parsing
+  // this data.
+  //
+  // Any errors on initial connection (e.g., connection failure, authorization
+  // issues, network problems) will result in the stream being terminated with
+  // an appropriate RPC status exception.
+  //
+  // After a successful connection is made, if an error occurs, then the server
+  // terminates connection and returns the appropriate RPC status exception.
+  rpc StreamSqlData(stream StreamSqlDataRequest)
+    returns (stream StreamSqlDataResponse) {}
+}
+
+// Message sent from the client to `SqlDataService`.
+message StreamSqlDataRequest {
+
+
+  // Deprecated: Use `StartSession.location_id` or `ContinueSession.location_id`
+  // instead. `location_id` is used to route the request to a specific region.
+  // Use the same region which was used to create the instance. Use the format
+  // `locations/{location}`, for example: `locations/us-central1`.
+  string location_id = 1;
+
+  // Deprecated: Use the `message` oneof instead. The type of message sent
+  // within the stream.
+  oneof message_type {
+    // Deprecated: Use `start_session` or `continue_session` instead.
+    // Parameters for establishing the connection. MUST be sent as the first
+    // message on the stream.
+    ConnectionSettings connection_settings = 2;
+
+    // Deprecated: Use `DataPacket` instead.
+    // Data to be forwarded to the database.
+    ClientPayload payload = 3;
+  }
+
+  // Acknowledges data received by the client.
+  Ack ack = 4;
+
+  // The message to the server.
+  oneof message {
+    // Starts a new session. When starting a new session, this is the first
+    // message the client sends.
+    StartSession start_session = 5;
+    // Continues an existing session. When starting a new session, this is the
+    // first message the client sends.
+    ContinueSession continue_session = 6;
+    // Database data.
+    DataPacket data = 7;
+    // Terminates the session. This closes the connection to the database.
+    TerminateSession terminate_session = 8;
+  }
+}
+
+// Deprecated:  New schema structure. Initial connection parameters.
+message ConnectionSettings {
+  option deprecated = true;
+
+
+  // The target of the connection.
+  oneof target {
+    // The identifier of the Cloud SQL instance.
+    InstanceId instance_id = 1;
+  }
+}
+
+// Start a new session. The client must send this as the first message to the
+// server to start a new session. The client may immediately send Data messages
+// without waiting for a reply from the server.
+message StartSession {
+
+
+  //`location_id` is used to route the
+  // request to a specific region. Use the same region which was used to create
+  // the instance. Use the format `locations/{location}`, for example:
+  // `locations/us-central1`.
+  string location_id = 1;
+  // The Cloud SQL instance resource name, for example:
+  // projects/example-project/instances/example-instance
+  string instance_id = 2;
+  // The session id, chosen by the client. This should be an unguessable string.
+  // If the client does not intend to reconnect to this session, the client may
+  // leave session_id unset.
+  string session_id = 3;
+}
+
+// Reconnects to an existing session. The client must send this as the first
+// message to the server to reconnect to an existing session. The client may
+// immediately send Data messages without waiting for a reply from the server.
+message ContinueSession {
+
+
+  //`location_id` is used to route the
+  // request to a specific region. Use the same region which was used to create
+  // the instance. Use the format `locations/{location}`, for example:
+  // `locations/us-central1`.
+  string location_id = 1;
+
+  // The Cloud SQL instance resource name, for example:
+  // projects/example-project/instances/example-instance
+  string instance_id = 2;
+
+  // The id of the session to reconnect.
+  string session_id = 3;
+}
+
+// Deprecated:  New schema structure. The identifier of the Cloud SQL instance.
+message InstanceId {
+  option deprecated = true;
+
+
+  // Full resource name of the Cloud SQL instance, in the form:
+  // `projects/{project}/instances/{instance}`, for example:
+  // `projects/foo-project/instances/bar-instance`.
+  string instance = 1;
+}
+
+// Deprecated:  New schema structure. Wrapper for data being sent to the
+// database.
+message ClientPayload {
+  option deprecated = true;
+
+
+  // Raw data to be sent to the database. See the documentation for
+  // `StreamSqlData` for details on the expected wire format.
+  bytes data = 1;
+}
+
+// Message sent from SqlDataService back to the client.
+message StreamSqlDataResponse {
+
+
+  // Deprecated:  New schema structure. The type of the message received from
+  // `SqlDataService`.
+  oneof type {
+    // Raw data received from the database.
+    ServerPayload payload = 1;
+  }
+
+  // Acknowledges data received by the server.
+  Ack ack = 2;
+  // A message from the server to the client.
+  oneof message {
+    // The first message from the server to the client, containing metadata
+    // about this session.
+    SessionMetadata session_metadata = 3;
+    // Data from the database.
+    DataPacket data = 4;
+    // Terminates the session. This indicates that the database connection
+    // is closed. When the client receives this message, it should not
+    // attempt to reconnect.
+    TerminateSession terminate_session = 5;
+  }
+}
+
+// Deprecated:  New schema structure. Wrapper for data being received from the
+// database.
+message ServerPayload {
+  option deprecated = true;
+
+
+  // Raw data received from the database. See the documentation for
+  // `StreamSqlData` for details on the expected wire format.
+  bytes data = 1;
+}
+// Metadata from the server to the client about the session. The server will
+// always send this as the first message
+message SessionMetadata {
+
+
+  // The features supported by the server for this session. This field is used
+  // by the client to determine which features are available on the server.
+  // The features supported by the server for this session.
+  repeated SqlDataFeature supported_features = 1;
+}
+
+// Contains data being sent or received by the database.
+message DataPacket {
+
+
+  // The absolute byte offset of the first byte in this payload.
+  // 0 for new connections or resumed connections that hasn't acked any bytes
+  // from server. Non-zero for resumed connections
+  int64 first_byte_offset = 1;
+  // Raw data being sent or received by the database.
+  bytes data = 2;
+}
+// Acknowledges data received by the client or server.
+message Ack {
+
+
+  // The absolute number of bytes processed in the session.
+  int64 received_offset = 1;
+}
+// Indicates that the session is permanently ended.
+message TerminateSession {
+
+
+  // The session termination status.
+  google.rpc.Status status = 1;
+}
+
+// Error reasons for `StreamSqlData`.
+// Typically used with standard error codes, with the error info/reason field
+// set to the string representation of the enum value.
+enum StreamSqlDataErrorReason {
+  // Indicates that the error reason is unknown.
+  STREAM_SQL_DATA_ERROR_REASON_UNKNOWN = 0;
+
+  // Indicates that the operation is not supported for given instance type.
+  // Used with status code `google.rpc.Code.FAILED_PRECONDITION`.
+  STREAM_SQL_DATA_ERROR_REASON_UNSUPPORTED_INSTANCE_TYPE = 1;
+
+  // Indicates that reconnect failed and should not be retried.
+  // Used with status code `google.rpc.Code.INTERNAL`.
+  STREAM_SQL_DATA_ERROR_REASON_RECONNECT_FAILED = 3;
+
+  // Indicates that the database client closed its connection normally.
+  // Used with status code `google.rpc.Code.CANCELED`.
+  STREAM_SQL_DATA_ERROR_REASON_DB_CLIENT_CLOSED = 4;
+
+  // Indicates that the database server closed its connection normally.
+  // Used with status code `google.rpc.Code.CANCELED`.
+  STREAM_SQL_DATA_ERROR_REASON_DB_SERVER_CLOSED = 5;
+
+  // Indicates that the peer sent an ACK message that was not within an
+  // acceptable range. Used with the status code
+  // `google.rpc.Code.FAILED_PRECONDITION`.
+  STREAM_SQL_DATA_ERROR_REASON_INVALID_ACK = 6;
+
+  // Indicates that the SqlDataService lost its connection to the
+  // database instance. This is a retryable error.
+  // Used with status code `google.rpc.Code.ABORTED`.
+  STREAM_SQL_DATA_ERROR_REASON_DISCONNECTED = 7;
+}
+
+// The session features. The server must send the supported features in its
+// first message to the client.
+enum SqlDataFeature {
+  // The feature is not specified. This value should not be used.
+  SQL_DATA_FEATURE_UNSPECIFIED = 0;
+  // The server supports reconnecting to the session. If this feature is not
+  // present, the client should not attempt to reconnect to the session.
+  SQL_DATA_FEATURE_RECONNECT = 1;
+}


### PR DESCRIPTION
This PR adds support for Developer Edition connections via the SqlDataService. It includes a fallback mechanism to standard IP connections if the SqlDataService is not supported by the instance edition.

See https://github.com/GoogleCloudPlatform/cloud-sql-go-connector/pull/1108