### PR TITLE
fix: Enforce size limit on the MDX response

### DIFF
--- a/core/src/main/java/com/google/cloud/sql/core/ProtocolHandler.java
+++ b/core/src/main/java/com/google/cloud/sql/core/ProtocolHandler.java
@@ -17,6 +17,8 @@
 package com.google.cloud.sql.core;
 
 import com.google.cloud.sql.core.mdx.MetadataExchange;
+import java.io.DataInputStream;
+import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -94,6 +96,12 @@ class ProtocolHandler {
     return clientProtocolType;
   }
 
+  // Maximum allowed size for an MDX response. A MetadataExchangeResponse is a
+  // small message (two short fields), so 16 KiB is an ample cap that prevents
+  // a malicious peer from forcing an unbounded allocation (e.g. ~2 GiB) that
+  // would crash the JVM with an uncatchable OutOfMemoryError.
+  private static final int MAX_MDX_RESPONSE_SIZE = 16 * 1024;
+
   MetadataExchange.MetadataExchangeResponse readMdxResponse(InputStream in) throws IOException {
     // Mark the input stream so we can reset it if the server doesn't speak MDX.
     // 8 bytes is enough for the header (8)
@@ -108,8 +116,26 @@ class ProtocolHandler {
       return null;
     }
 
-    // Read the 4-byte big-endian size.
-    int sizeL = (in.read() << 24) | (in.read() << 16) | (in.read() << 8) | in.read();
+    // Read the 4-byte big-endian size. DataInputStream.readInt() throws
+    // EOFException on a short read instead of silently producing a negative
+    // value from -1 bytes.
+    int sizeL;
+    try {
+      sizeL = new DataInputStream(in).readInt();
+    } catch (EOFException e) {
+      throw new IOException("Failed to read MDX response size: stream ended.", e);
+    }
+
+    // Reject non-positive or oversized lengths to prevent unbounded
+    // allocation triggered by a malfunctioning peer.
+    if (sizeL <= 0 || sizeL > MAX_MDX_RESPONSE_SIZE) {
+      throw new IOException(
+          "Invalid MDX response size: "
+              + sizeL
+              + " (must be in (0, "
+              + MAX_MDX_RESPONSE_SIZE
+              + "]).");
+    }
 
     // Read the response bytes.
     byte[] responseBytes = new byte[sizeL];

--- a/core/src/test/java/com/google/cloud/sql/core/ProtocolHandlerTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/ProtocolHandlerTest.java
@@ -17,6 +17,7 @@
 package com.google.cloud.sql.core;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
 
 import com.google.cloud.sql.core.mdx.MetadataExchange;
 import java.io.ByteArrayInputStream;
@@ -98,6 +99,41 @@ public class ProtocolHandlerTest {
     int l = in.read(gotInBytes);
     assertThat(l).isEqualTo(wantInBytes.length);
     assertThat(gotInBytes).isEqualTo(wantInBytes);
+  }
+
+  @Test
+  public void testReadMdx_rejectsOversizedResponseSize_BUG_511891149() throws IOException {
+    // Regression test for b/511891149: a malicious or compromised peer (post-mTLS)
+    // could send 0x7FFFFFFF as the MDX response length, forcing the JVM to attempt
+    // a ~2 GiB byte[] allocation and crash with an uncatchable OutOfMemoryError.
+    // ProtocolHandler.readMdxResponse() must reject sizes outside (0, 16 KiB].
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    out.write("CSQLMDEX".getBytes(StandardCharsets.UTF_8));
+    // Big-endian Integer.MAX_VALUE (0x7FFFFFFF) — the attack from the bug report.
+    out.write(0x7F);
+    out.write(0xFF);
+    out.write(0xFF);
+    out.write(0xFF);
+    ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
+
+    IOException thrown =
+        assertThrows(IOException.class, () -> new ProtocolHandler("ua").readMdxResponse(in));
+    assertThat(thrown).hasMessageThat().contains("Invalid MDX response size");
+  }
+
+  @Test
+  public void testReadMdx_cutoffResponseSize() throws IOException {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    out.write("CSQLMDEX".getBytes(StandardCharsets.UTF_8));
+    // Big-endian Integer.MAX_VALUE (0x7FFFFFFF) — the attack from the bug report.
+    out.write(0x7F);
+    out.write(0xFF);
+    out.write(0xFF);
+    out.close();
+    ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
+    IOException thrown =
+        assertThrows(IOException.class, () -> new ProtocolHandler("ua").readMdxResponse(in));
+    assertThat(thrown).hasMessageThat().contains("Failed to read MDX response size: stream ended.");
   }
 
   @Test


### PR DESCRIPTION
Read the length from DataInputStream.readInt() so a short read
raises EOFException, and reject any size outside the range
(0, 16 KiB] — a MetadataExchangeResponse carries only two small
fields, so 16 KiB is an ample cap.
