### PR TITLE
build: attach javadoc jar for schemas module

### DIFF
--- a/schemas/pom.xml
+++ b/schemas/pom.xml
@@ -47,7 +47,6 @@
 
   <build>
     <plugins>
-      <!--
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
@@ -55,6 +54,7 @@
         <configuration>
           <source>8</source>
           <sourcepath>${project.build.directory}/generated-sources</sourcepath>
+          <doclint>none</doclint>
         </configuration>
         <executions>
           <execution>
@@ -65,7 +65,6 @@
           </execution>
         </executions>
       </plugin>
-      -->
       <plugin>
         <groupId>com.github.os72</groupId>
         <artifactId>protoc-jar-maven-plugin</artifactId>


### PR DESCRIPTION
Uncomment and configure the maven-javadoc-plugin in the schemas module to package a Javadoc jar. Sonatype Central Portal validation requires Javadocs to be present for all published artifacts.